### PR TITLE
Type-indexed Typeable

### DIFF
--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -279,7 +279,7 @@ Defining ``TypeRep``
 ~~~~~~~~~~~~~~~~~~~~
 
 The heart of ``Type.Reflection`` is the ``TypeRep`` type. It can be defined as a
-standard GADT (omitting the ``Fingerprint``s used for O(1) comparison), ::
+standard GADT (omitting the ``Fingerprint``\ s used for O(1) comparison), ::
 
     data TypeRep (a :: k) where
         TrTyCon :: TyCon -> TypeRep k -> TypeRep (a :: k)

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -151,15 +151,15 @@ We can also test for type equality,
 
 .. code-block:: haskell
 
-    -- | Kind-homogenous type equality
+    -- | Kind-homogeneous type equality
     eqTypeRep  :: forall k (a :: k) (b :: k).
                   TypeRep a -> TypeRep b -> Maybe (a :~: b)
 
-    -- | Kind-heterogenous type equality
+    -- | Kind-heterogeneous type equality
     eqTypeRep' :: forall k1 k2 (a :: k1) (b :: k2).
                   TypeRep a -> TypeRep b -> Maybe (a :~~: b)
 
-    -- | Kind-heterogenous type equality
+    -- | Kind-heterogeneous type equality
     data (a :: k1) :~~: (b :: k2) where
         HRefl :: a :~~: a
 

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -29,7 +29,8 @@ Motivation
 
 Consider the case of ``Data.Dynamic`` which provides a type for working with
 dynamically-typed values. Its definition is straightforward Haskell 98,
-::
+
+.. code-block:: haskell
 
     data Dynamic = Dynamic TypeRep Any
 
@@ -65,7 +66,9 @@ Proposed Change
 
 The core of the proposal is the introduction of a new type reflection interface,
 exposed in the ``Type.Reflection`` module. This interface provides a mechanism
-similar to ``Typeable`` but with an indexed representation type, ::
+similar to ``Typeable`` but with an indexed representation type,
+
+.. code-block:: haskell
 
     module Type.Reflection where
 
@@ -82,7 +85,9 @@ similar to ``Typeable`` but with an indexed representation type, ::
     typeRepKind :: TypeRep (a :: k) -> TypeRep k
 
 With a ``Typeable`` constraint we can get a ``TypeRep`` for a (non-kind
-polymorphic) type ``a`` with ``typeRep``, ::
+polymorphic) type ``a`` with ``typeRep``,
+
+.. code-block:: haskell
 
     class Typeable (a :: k)
 
@@ -93,7 +98,9 @@ to ``typeRep``; the desired type propagates through ``TypeRep``\'s index.
 
 
 We can pattern match on the structure of a ``TypeRep``. For instance, on type
-constructors, ::
+constructors,
+
+.. code-block:: haskell
 
     -- | A type constructor type. This is a bidirectional pattern.
     pattern TRCon :: forall k (a :: k). TyCon -> TypeRep a
@@ -106,7 +113,9 @@ constructors, ::
     tyConModule :: TyCon -> String
     tyConName :: TyCon -> String
 
-Type application can also be decomposed, ::
+Type application can also be decomposed,
+
+.. code-block:: haskell
 
     -- | A representation of a type application, @a b@. This is a bidirectional pattern.
     pattern TRApp :: forall k2 (fun :: k2). ()
@@ -116,7 +125,9 @@ Type application can also be decomposed, ::
 We can also decompose function types (e.g. ``Int -> String``) in their argument
 (e.g. ``Int``) and result types (``String``). Strictly speaking this can be
 expressed in terms of ``TRFun`` but it seems like a common enough pattern that
-it's worth providing a pattern for it, ::
+it's worth providing a pattern for it,
+
+.. code-block:: haskell
 
     pattern TRFun :: forall fun. ()
                   => forall arg res. (fun ~ (arg -> res))
@@ -124,7 +135,9 @@ it's worth providing a pattern for it, ::
                   -> TypeRep res
                   -> TypeRep fun
 
-We can also test for type equality, ::
+We can also test for type equality,
+
+.. code-block:: haskell
 
     -- | Kind-homogenous type equality
     eqTypeRep  :: forall k (a :: k) (b :: k).
@@ -135,7 +148,9 @@ We can also test for type equality, ::
                   TypeRep a -> TypeRep b -> Maybe (a :~~: b)
 
 Since ``TypeRep`` is a singleton, we can provide a means of satisfying a
-``Typeable`` constraint with a ``TypeRep`` without loss of coherence, ::
+``Typeable`` constraint with a ``TypeRep`` without loss of coherence,
+
+.. code-block:: haskell
 
     withTypeable :: TypeRep a -> (Typeable a => b) -> b
     
@@ -143,7 +158,9 @@ Implementing ``Data.Dynamic``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With this reflection machinery we can implement the ``Data.Dynamic`` type
-described in the Motivation section in a perfectly type-safe manner, ::
+described in the Motivation section in a perfectly type-safe manner,
+
+.. code-block:: haskell
 
     data Dynamic where
         Dynamic :: TypeRep a -> a -> Dynamic
@@ -169,7 +186,9 @@ Preserving ``Data.Typeable``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The existing ``Data.Typeable`` machinery can be expressed in terms of the
-primitives provided by ``Type.Reflection``, ::
+primitives provided by ``Type.Reflection``,
+
+.. code-block:: haskell
 
     module Data.Typeable where
 

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -116,7 +116,9 @@ constructors,
 
 .. code-block:: haskell
 
-    -- | A type constructor type. This is a bidirectional pattern.
+    -- | A type constructor type. This must be a unidirectional pattern since
+    -- we have no way of preventing the user from instantiating a TyCon in an
+    -- ill-kinded manner.
     pattern TRCon :: forall k (a :: k). TyCon -> TypeRep a
 
     -- | Information about a type constructor. No means of constructing 'TyCon's

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -81,7 +81,7 @@ proposal is the introduction of a new type reflection interface, exposed in the
     -- provide these
     instance Eq (TypeRep a)  where (==) _ _    = True
     instance Ord (TypeRep a) where compare _ _ = EQ
-    instance TestEquality TypeRepX
+    instance TestEquality TypeRep
 
 .. [PeytonJones2016]
     Peyton Jones, Weirich, Eisenberg, Vytiniotis. "`A Reflection on Types
@@ -91,6 +91,8 @@ proposal is the introduction of a new type reflection interface, exposed in the
 Like today, the new ``Typeable`` mechanism will only support kind-monomorphic
 types. Unlike today's mechanism, we provide a means of extracting the *kind* of
 a type representation,
+
+.. code-block:: haskell
 
     -- | The kind of a type.
     typeRepKind :: TypeRep (a :: k) -> TypeRep k
@@ -182,8 +184,6 @@ this we introduce,
     instance Eq SomeTypeRep
     instance Ord SomeTypeRep
     instance Show SomeTypeRep
-
-    someTypeRep :: Typeable a => Proxy a -> SomeTypeRep
 
 Implementing ``Data.Dynamic``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -292,6 +292,10 @@ Here a type constructor type consists of a (possibly kind-polymorphic)
 type constructor and a ``TypeRep`` of its kind. The kind is necessary to ensure
 that we represent only kind-monomorphic types. Type application types are
 represented by the representations of the two types of the application.
+
+Since we cannot guarantee that the ``TrTyCon`` couldn't be used to construct
+ill-kinded ``TypeRep``\ s we must hide it and instead expose a unidirectional
+pattern synonym. In contrast, ``TrApp`` can be exposed bidirectionally.
 
 
 Serializing type representations

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -57,6 +57,11 @@ to help us avoid,
 
 * we need to use ``unsafeCoerce`` in a number of places
 
+In general the current ``Typeable`` mechanism gives us no way to tell the
+type-checker about the relationship between the (potentially unknown) type of a
+value (say, the ``Any`` in the ``Dynamic`` example above) and the type
+represented by a ``TypeRep``.
+
 Proposed Change
 ---------------
 

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -366,7 +366,8 @@ Therefore we have four distinct loops:
   * ``RuntimeRep :: Type``
   * ``'PtrRepLifted :: RuntimeRep``
 
-This poses a rather unfortunate safety issue for authors of serializers. One
+This poses a rather unfortunate safety issue for authors of serializers,
+pretty-printers, and other consumers which deeply inspect ``TypeRep`` s. One
 option for approaching this would be to restructure the ``TypeRep`` type to draw
 particular attention to these cases,
 
@@ -379,9 +380,14 @@ particular attention to these cases,
         TRArrow :: TypeRep a -> TypeRep b -> TypeRep (a -> b)
         TRPtrRepLifted :: TypeRep 'PtrRepLifted
 
-This also may have the advantage of simplifying production of compiler evidence
-and making the runtime representations of common types more concise.
-Another option would be to retain the simpler two-constructor ``TypeRep``
+This would ensure that consumers who match totally on ``TypeRep``\ s won't face
+unexpected loops. This also may have the advantage of in some ways simplifying
+production of evidence by the compiler and making the runtime representations of
+common types more concise. Unfortunately, in other ways it complicates the
+implementation of ``TypeRep`` since it needs to maintain some normalization
+invariants.
+
+Another option would be to retain the more simple two-constructor ``TypeRep``
 described above but expose pattern synonyms for the special cases seen here,
 along with clear documentation instructing library authors to handle them.
 
@@ -457,3 +463,8 @@ Do we want to allow the user to construct ill-kinded type representations? Given
 that the the user could never cast with such a representation, it seems like
 there is likely no potential for unsafety by doing so.
 
+Current Status
+--------------
+
+A variant of this proposal has been implemented and is available in the
+`wip/ttypeable <https://github.com/bgamari/ghc/tree/wip/ttypeable>`_ branch.

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -279,7 +279,9 @@ Defining ``TypeRep``
 ~~~~~~~~~~~~~~~~~~~~
 
 The heart of ``Type.Reflection`` is the ``TypeRep`` type. It can be defined as a
-standard GADT (omitting the ``Fingerprint``\ s used for O(1) comparison), ::
+standard GADT (omitting the ``Fingerprint``\ s used for O(1) comparison),
+
+.. code-block:: haskell
 
     data TypeRep (a :: k) where
         TrTyCon :: TyCon -> TypeRep k -> TypeRep (a :: k)

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -20,7 +20,7 @@ the represented type.
 
 Here we propose a reimagining of the ``Typeable`` mechanism, adding
 indexing the ``TypeRep`` type with the represented type. This additional type
-information enables the type system to provde the soundness of many uses of
+information enables the type system to provide the soundness of many uses of
 ``Typeable``, allowing many currently unsafe programs to be written in a
 completely type-safe manner.
 

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -60,9 +60,10 @@ to help us avoid,
 Proposed Change
 ---------------
 
-The core of the proposal is the introduction of a new type reflection interface,
-exposed in the ``Type.Reflection`` module. This interface provides a mechanism
-similar to ``Typeable`` but with an indexed representation type,
+This proposal follows the idea proposed in [PeytonJones2016]_. The core of the
+proposal is the introduction of a new type reflection interface, exposed in the
+``Type.Reflection`` module. This interface provides a mechanism similar to
+``Typeable`` but with an indexed representation type,
 
 .. code-block:: haskell
 
@@ -76,6 +77,11 @@ similar to ``Typeable`` but with an indexed representation type,
     instance Eq (TypeRep a)  where (==) _ _    = True
     instance Ord (TypeRep a) where compare _ _ = EQ
     instance TestEquality TypeRepX
+
+.. [PeytonJones2016]
+    Peyton Jones, Weirich, Eisenberg, Vytiniotis. "`A Reflection on Types
+    <http://research.microsoft.com/en-us/um/people/simonpj/papers/haskell-dynamic/index.htm>`__."
+    *Proc. Philip Wadler's 60th birthday Festschrift*. Edinburgh, April 2016.
 
 Like today, the new ``Typeable`` mechanism will only support kind-monomorphic
 types. Unlike today's mechanism, we provide a means of extracting the *kind* of

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -203,10 +203,9 @@ described in the Motivation section in a perfectly type-safe manner,
        where
 
     dynApply :: Dynamic -> Dynamic -> Maybe Dynamic
-    dynApply (Dynamic t1 f) (Dynamic t2 x) =
-      case funResultTy t1 t2 of
-        Just t3 -> Just (Dynamic t3 ((unsafeCoerce f) x))
-        Nothing -> Nothing
+    dynApply (Dynamic (TRFun ta tr) f) (Dynamic ta' x)
+      | Just HRefl <- ta `eqTypeRep` ta' = Just (Dynamic tr (f x))
+    dynApply _ _                         = Nothing
 
 
 Preserving ``Data.Typeable``

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -443,8 +443,11 @@ need to have ``Typeable`` evidence for the type that the caller *expects*.
 Drawbacks
 ---------
 
-What are the reasons for *not* adopting the proposed change. These might include
-complicating the language grammar, poor interactions with other features, 
+The only obvious drawback is the complexity burden which this places on those
+who must deeply inspect ``TypeRep``\ s. Otherwise the proposal has a good
+backwards compatibility story, nicely subsumes the existing ``Typeable``
+mechanism, and has introduces only a small amount of additional compiler
+complexity which providing additional expressive power.
 
 Alternatives
 ------------
@@ -463,7 +466,8 @@ The design described above does not propagate any type information beyond
         TRTyCon :: TyCon a -> TypeRep k -> TypeRep a
 
 However, the benefits to this approach are unclear and it would complicate
-evidence generation.
+evidence generation, and potentially have adverse effects on runtime and
+compile-time.
 
 Unresolved Questions
 --------------------

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -1,0 +1,213 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+Type-indexed ``Typeable``
+=========================
+
+GHC's ``Typeable`` mechanism provides a means of working with dynamically-typed
+values. While it serves this purpose well, using it safely requires care on the
+part of the user as type representations carry no type infomation identifying
+the represented type.
+
+Here we propose a reimagining of the ``Typeable`` mechanism, adding
+indexing the ``TypeRep`` type with the represented type. This additional type
+information enables the type system to provde the soundness of many uses of
+``Typeable``, allowing many currently unsafe programs to be written in a
+completely type-safe manner.
+
+Motivation
+----------
+
+Consider the case of ``Data.Dynamic`` which provides a type for working with
+dynamically-typed values. Its definition is straightforward Haskell 98,
+::
+
+    data Dynamic = Dynamic TypeRep Any
+
+    toDyn :: Typeable a => a -> Dynamic
+    toDyn v = Dynamic (typeOf v) (unsafeCoerce v)
+
+    fromDynamic :: Typeable a => Dynamic -> Maybe a
+    fromDynamic (Dynamic t v) =
+      case unsafeCoerce v of 
+        r | t == typeOf r -> Just r
+          | otherwise     -> Nothing
+
+    dynApply :: Dynamic -> Dynamic -> Maybe Dynamic
+    dynApply (Dynamic t1 f) (Dynamic t2 x) =
+      case funResultTy t1 t2 of
+        Just t3 -> Just (Dynamic t3 ((unsafeCoerce f) x))
+        Nothing -> Nothing
+
+Note how there are several potential bugs here which the type system is unable
+to help us avoid,
+
+* there is nothing to ensure that the ``TypeRep`` and the ``Any`` of a
+  ``Dynamic`` value are consistent.
+
+* we need to use ``unsafeCoerce`` in a number of places
+
+Here you should describe in greater detail the motivation for the change. This
+should include concrete examples of the shortcomings of the current
+state of things.
+
+Proposed Change
+---------------
+
+The core of the proposal is the introduction of a new type reflection interface,
+exposed in the ``Type.Reflection`` module. This interface provides a mechanism
+similar to ``Typeable`` but with an indexed representation type, ::
+
+    module Type.Reflection where
+
+    data TypeRep (a :: k)
+    instance Show (TypeRep a)
+
+    -- Since TypeRep is indexed by its type and must be a singleton we can trivially
+    -- provide these
+    instance Eq (TypeRep a)  where (==) _ _    = True
+    instance Ord (TypeRep a) where compare _ _ = EQ
+    instance TestEquality TypeRepX
+
+    -- | The kind of a type.
+    typeRepKind :: TypeRep (a :: k) -> TypeRep k
+
+With a ``Typeable`` constraint we can get a ``TypeRep`` for a (non-kind
+polymorphic) type ``a`` with ``typeRep``, ::
+
+    class Typeable (a :: k)
+
+    typeRep :: forall (a :: k). Typeable a => TypeRep a
+
+Note how in contrast to ``Data.Typeable.typeRep`` we needn't provide a ``Proxy``
+to ``typeRep``; the desired type propagates through ``TypeRep``\'s index.
+
+
+We can pattern match on the structure of a ``TypeRep``. For instance, on type
+constructors, ::
+
+    -- | A type constructor type. This is a bidirectional pattern.
+    pattern TRCon :: forall k (a :: k). TyCon -> TypeRep a
+
+    -- | Information about a type constructor. No means of constructing 'TyCon's
+    -- is provided; the only values of this type available are those from
+    -- 'TypeRep's.
+    data TyCon
+    tyConPackage :: TyCon -> String
+    tyConModule :: TyCon -> String
+    tyConName :: TyCon -> String
+
+Type application can also be decomposed, ::
+
+    -- | A representation of a type application, @a b@. This is a bidirectional pattern.
+    pattern TRApp :: forall k2 (fun :: k2). ()
+                  => forall k1 (a :: k1 -> k2) (b :: k1). (fun ~ a b)
+                  => TypeRep a -> TypeRep b -> TypeRep fun
+
+We can also decompose function types (e.g. ``Int -> String``) in their argument
+(e.g. ``Int``) and result types (``String``). Strictly speaking this can be
+expressed in terms of ``TRFun`` but it seems like a common enough pattern that
+it's worth providing a pattern for it, ::
+
+    pattern TRFun :: forall fun. ()
+                  => forall arg res. (fun ~ (arg -> res))
+                  => TypeRep arg
+                  -> TypeRep res
+                  -> TypeRep fun
+
+We can also test for type equality, ::
+
+    -- | Kind-homogenous type equality
+    eqTypeRep  :: forall k (a :: k) (b :: k).
+                  TypeRep a -> TypeRep b -> Maybe (a :~: b)
+
+    -- | Kind-heterogenous type equality
+    eqTypeRep' :: forall k1 k2 (a :: k1) (b :: k2).
+                  TypeRep a -> TypeRep b -> Maybe (a :~~: b)
+
+Since ``TypeRep`` is a singleton, we can provide a means of satisfying a
+``Typeable`` constraint with a ``TypeRep`` without loss of coherence, ::
+
+    withTypeable :: TypeRep a -> (Typeable a => b) -> b
+    
+Implementing ``Data.Dynamic``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With this reflection machinery we can implement the ``Data.Dynamic`` type
+described in the Motivation section in a perfectly type-safe manner, ::
+
+    data Dynamic where
+        Dynamic :: TypeRep a -> a -> Dynamic
+
+    toDyn :: Typeable a => a -> Dynamic
+    toDyn v = Dynamic (typeOf v) v
+
+    fromDynamic :: Typeable a => Dynamic -> Maybe a
+    fromDynamic (Dynamic t v) =
+      case v of 
+        r | t `eqTypeRep` typeOf r -> Just r
+          | otherwise     -> Nothing
+       where
+
+    dynApply :: Dynamic -> Dynamic -> Maybe Dynamic
+    dynApply (Dynamic t1 f) (Dynamic t2 x) =
+      case funResultTy t1 t2 of
+        Just t3 -> Just (Dynamic t3 ((unsafeCoerce f) x))
+        Nothing -> Nothing
+
+
+Preserving ``Data.Typeable``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The existing ``Data.Typeable`` machinery can be expressed in terms of the
+primitives provided by ``Type.Reflection``, ::
+
+    module Data.Typeable where
+
+    import qualified Type.Reflection as R
+
+    data TypeRep where
+        TypeRep :: R.TypeRep a -> TypeRep
+
+    instance Eq TypeRepX
+    instance Ord TypeRepX
+    instance Show TypeRepX
+
+Here you should describe in precise terms what the proposal seeks to change.
+This should cover several things,
+
+* define the grammar and semantics of any new syntactic constructs
+* define the interfaces for any new library interfaces
+* discuss how the change addresses the points raised in the Motivation section
+* discuss how the proposed approach might interact with existing features  
+
+Note, however, that this section need not describe details of the
+implementation of the feature. The proposal is merely supposed to give a
+conceptual specification of the new feature and its behavior.
+
+Drawbacks
+---------
+
+What are the reasons for *not* adopting the proposed change. These might include
+complicating the language grammar, poor interactions with other features, 
+
+Alternatives
+------------
+
+Here is where you can describe possible variants to the approach described in
+the Proposed Change section.
+
+Unresolved Questions
+--------------------
+
+Are there any parts of the design that are still unclear? Hopefully this section
+will be empty by the time the proposal is brought up for a final decision.

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -136,7 +136,7 @@ Type application can also be decomposed,
 
 We can also decompose function types (e.g. ``Int -> String``) in their argument
 (e.g. ``Int``) and result types (``String``). Strictly speaking this can be
-expressed in terms of ``TRFun`` but it seems like a common enough pattern that
+expressed in terms of ``TRApp`` but it seems like a common enough pattern that
 it's worth providing a pattern for it,
 
 .. code-block:: haskell
@@ -229,7 +229,7 @@ primitives provided by ``Type.Reflection``,
     typeOf _ = R.SomeTypeRep (R.typeRep :: TypeRep a)
 
     typeRep :: forall proxy a. Typeable a => proxy a -> TypeRep
-    typeRep = $.SomeTypeRep (R.typeRep :: TypeRep a)
+    typeRep = R.SomeTypeRep (R.typeRep :: TypeRep a)
 
     cast :: forall a b. (Typeable a, Typeable b) => a -> Maybe b
     cast x
@@ -463,8 +463,11 @@ Do we want to allow the user to construct ill-kinded type representations? Given
 that the the user could never cast with such a representation, it seems like
 there is likely no potential for unsafety by doing so.
 
-Current Status
---------------
+Implementation Status
+---------------------
 
 A variant of this proposal has been implemented and is available in the
 `wip/ttypeable <https://github.com/bgamari/ghc/tree/wip/ttypeable>`_ branch.
+However, there are a number of limitations elsewhere in the compiler that must
+be lifted before this is can be merged. See the `GHC Wiki
+<https://ghc.haskell.org/trac/ghc/wiki/Typeable/BenGamari>`_ for details.

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -159,6 +159,10 @@ We can also test for type equality,
     eqTypeRep' :: forall k1 k2 (a :: k1) (b :: k2).
                   TypeRep a -> TypeRep b -> Maybe (a :~~: b)
 
+    -- | Kind-heterogenous type equality
+    data (a :: k1) :~~: (b :: k2) where
+        HRefl :: a :~~: a
+
 Since ``TypeRep`` is a singleton, we can provide a means of satisfying a
 ``Typeable`` constraint with a ``TypeRep`` without loss of coherence,
 

--- a/proposals/0000-type-indexed-typeable.rst
+++ b/proposals/0000-type-indexed-typeable.rst
@@ -266,7 +266,7 @@ The remaining existing exports of ``Data.Typeable`` follow easily.
 
     rnfTypeRep :: TypeRep -> ()
 
-We can also continue to provide the deprecated non-kind polymorphic ``Typeable``
+We can also continue to provide the deprecated non-kind-polymorphic ``Typeable``
 exports,
 
 .. code-block:: haskell


### PR DESCRIPTION
Here is a proposal for augmenting our existing `Typeable` mechanism with a variant, `Type.Reflection`, which provides a more strongly typed variant as originally described in [A Reflection on Types](http://research.microsoft.com/en-us/um/people/simonpj/papers/haskell-dynamic/index.htm) (Peyton Jones, _et al._ 2016).

[Rendered](https://github.com/bgamari/ghc-proposals/blob/typeable/proposals/0000-type-indexed-typeable.rst)
