### PR TITLE
Proposal: use %rsp for the stack pointer on x86_64

### DIFF
--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -13,7 +13,8 @@ We currently use ``%rbp`` for the stack pointer on x86_64.  It might be a good i
 
 Why we might want this:
 
-* We could potentially use the ``ret`` instruction for returning.  This is one byte shorter than ``jmp *(%rbp)``, and might benefit from better CPU optimisations.  Using `call` is not possible, because the return address has an info table preceding it.
+* We could potentially use the ``ret`` instruction for returning.  This is one byte shorter than ``jmp *(%rbp)``, and might benefit from better CPU optimisations.
+* We could potentially use the ``call`` instruction for calling, which should result in smaller code than the current calling sequence which involves explicitly writing the return address to the stack.  Note however that we would need a ``call foo; jmp ret`` sequence to jump over the info table, and return addresses would no longer point directly to the info table, so this involves more invasive changes to the RTS and code genreator.
 * Some tools (e.g. perf) look at ``%rsp`` to collect information about the stack.  This might enable smoother integration with external tooling, especially in conjunction with DWARF.  (TODO: flesh this out).
 
 Proposed Change
@@ -26,7 +27,13 @@ Drawbacks
 
 * Unfortunately the instruction encoding for instructions using ``%rsp`` is often longer than for ``%rbp``.  e.g. ``mov  %rax,-0x8(%rsp)`` is 5 bytes compared with 4 bytes for the corresponding instruction using ``%rbp``.  So despite the 1-byte saving for a ``ret`` instruction, code would likely get larger if we used ``%rsp`` for the stack.
 
-* We have to worry about signals messing up the stack, but we have a 128-byte red zone on x86_64.  (what fallback mechanisms would be required if we needed more than this?)
+* To gain the most performance benefits from ``call`` and ``ret``, they should be paired correctly according to the Intel optimisation docs, which means that we may not benefit much from using ``ret`` alone.
+
+* We have to worry about signals messing up the stack, but we have a 128-byte red zone on x86_64.  (what fallback mechanisms would be required if we needed more than this?).  There is `sigaltstack` to avoid signals messing up the stack, but that's not feasible in general because user code and other libraries might enable signals without setting `sigaltstack`.  
+
+* On Windows it is simply not possible to use memory below `%rsp`; there is no red zone and no `sigaltstack`.
+
+* We 
 
 Alternatives
 ------------

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -3,28 +3,28 @@
 .. implemented:: 
 .. highlight:: haskell
 
-Use `%rsp` for the SP on x86_64
+Use ``%rsp`` for the SP on x86_64
 ===============================
 
 Motivation
 ----------
 
-We currently use `%rbp` for the stack pointer on x86_64.  It might be a good idea to switch to using `%rsp`; this proposal is to collect the evidence and rationale and come to a conclusion.
+We currently use ``%rbp`` for the stack pointer on x86_64.  It might be a good idea to switch to using ``%rsp``; this proposal is to collect the evidence and rationale and come to a conclusion.
 
 Why we might want this:
 
-* We could potentially use the `ret` instruction for returning.  This is one byte shorter than `jmp *(%rbp)`, and might benefit from better CPU optimisations.  Using `call` is not possible, because the return address has an info table preceding it.
-* Some tools (e.g. perf) look at `%rsp` to collect information about the stack.  This might enable smoother integration with external tooling, especially in conjunction with DWARF.  (TODO: flesh this out).
+* We could potentially use the ``ret`` instruction for returning.  This is one byte shorter than ``jmp *(%rbp)``, and might benefit from better CPU optimisations.  Using `call` is not possible, because the return address has an info table preceding it.
+* Some tools (e.g. perf) look at ``%rsp`` to collect information about the stack.  This might enable smoother integration with external tooling, especially in conjunction with DWARF.  (TODO: flesh this out).
 
 Proposed Change
 ---------------
 
-Swap the purposes of `%rbp` and `%rsp`; make `%rbp` point to the spill area on the C stack, and make `%rsp` point to the Haskell stack.
+Swap the purposes of ``%rbp`` and ``%rsp``; make ``%rbp`` point to the spill area on the C stack, and make `%rsp` point to the Haskell stack.
 
 Drawbacks
 ---------
 
-* Unfortunately the instruction encoding for instructions using `%rsp` is often longer than for `%rbp`.  e.g. `mov  %rax,-0x8(%rsp)` is 5 bytes compared with 4 bytes for the corresponding instruction using `%rbp`.  So despite the 1-byte saving for a `ret` instruction, code would likely get larger if we used `%rsp` for the stack.
+* Unfortunately the instruction encoding for instructions using ``%rsp`` is often longer than for ``%rbp``.  e.g. ``mov  %rax,-0x8(%rsp)`` is 5 bytes compared with 4 bytes for the corresponding instruction using ``%rbp``.  So despite the 1-byte saving for a ``ret`` instruction, code would likely get larger if we used ``%rsp`` for the stack.
 
 * We have to worry about signals messing up the stack, but we have a 128-byte red zone on x86_64.  (what fallback mechanisms would be required if we needed more than this?)
 

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -33,8 +33,6 @@ Drawbacks
 
 * On Windows it is simply not possible to use memory below `%rsp`; there is no red zone and no `sigaltstack`.
 
-* We 
-
 Alternatives
 ------------
 


### PR DESCRIPTION
This came up a couple of times recently, and I did a bit of digging to see whether it might be a good idea.  Summary: I suspect it's not going to buy us very much and might even be a loss performance-wise due to the increase in code size, but at least this proposal will serve as a place to collect the information.

[Rendered](https://github.com/simonmar/ghc-proposals/blob/patch-1/proposals/0000-template.rst)
