### PR TITLE
The Eval class proposal

### DIFF
--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -23,12 +23,12 @@ The main benefit, in the medium term, would be to make Haskell fully parametric 
 to make η-conversion and foldr-build optimization safe, to reopen the possibility of unlifted products (*i.e.*,
 ``newtype`` with multiple fields), and possibly to satisfy Bob Harper. Here is some background reading material that
 explains the existing problems:
-  - `η-equivalence in Haskell <http://cstheory.stackexchange.com/questions/19165/is-eta-equivalence-for-functions-compatiable-with-haskells-seq-operation>`
-  - `Haskell has no state monad <http://www.cse.chalmers.se/~nicsma/no-state-monad.html>`
-  - `Hask is not a category <http://math.andrej.com/2016/08/06/hask-is-not-a-category/>`
-  - `Correctness of short cut fusion <https://wiki.haskell.org/Correctness_of_short_cut_fusion#In_the_absence_of_seq>`
+  - `η-equivalence in Haskell <http://cstheory.stackexchange.com/questions/19165/is-eta-equivalence-for-functions-compatiable-with-haskells-seq-operation>`_
+  - `Haskell has no state monad <http://www.cse.chalmers.se/~nicsma/no-state-monad.html>`_
+  - `Hask is not a category <http://math.andrej.com/2016/08/06/hask-is-not-a-category/>`_
+  - `Correctness of short cut fusion <https://wiki.haskell.org/Correctness_of_short_cut_fusion#In_the_absence_of_seq>`_
   - `Haskell is exceptionally unsafe
-    <https://existentialtype.wordpress.com/2012/08/14/haskell-is-exceptionally-unsafe/>`
+    <https://existentialtype.wordpress.com/2012/08/14/haskell-is-exceptionally-unsafe/>`_
 
 Proposed Change
 ---------------
@@ -122,7 +122,7 @@ Backward compatibility issues
 
 Most of the existing code would continue to work unless the ``-XNoUniversalEval`` option was used. There are some
 exceptions that this mechanism would not solve. In particular `(as suggested by Simon
-PJ)<https://github.com/ghc-proposals/ghc-proposals/pull/27#issuecomment-259913953>`, higher-rank types like
+PJ)<https://github.com/ghc-proposals/ghc-proposals/pull/27#issuecomment-259913953>`_, higher-rank types like
 ::
    data Rank2 (m :: (* -> *)) = MkRank2 (m Int)
    f :: forall (m :: * -> *). Rank2 m -> Int
@@ -140,7 +140,7 @@ and GADTs as in
 
 cause GHC to report a missing ``Eval`` instances on ``(m Int)`` and ``(m Bool)``, but with no accompanying suggestion on
 which type signatures to modify. I take this to mean that the
-`INCOMPLETE_CONTEXTS<https://github.com/ghc-proposals/ghc-proposals/pull/34>` implementation strategy could not provide
+`INCOMPLETE_CONTEXTS<https://github.com/ghc-proposals/ghc-proposals/pull/34>`_ implementation strategy could not provide
 an automatic recovery.
    
 Overall, the biggest problem would probably be presented by class instances like

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -122,7 +122,7 @@ Backward compatibility issues
 
 Most of the existing code would continue to work unless the ``-XNoUniversalEval`` option was used. There are some
 exceptions that this mechanism would not solve. In particular `(as suggested by Simon
-PJ)<https://github.com/ghc-proposals/ghc-proposals/pull/27#issuecomment-259913953>`_, higher-rank types like
+PJ) <https://github.com/ghc-proposals/ghc-proposals/pull/27#issuecomment-259913953>`_, higher-rank types like
 ::
    data Rank2 (m :: (* -> *)) = MkRank2 (m Int)
    f :: forall (m :: * -> *). Rank2 m -> Int
@@ -139,9 +139,9 @@ and GADTs as in
    f (T2 y) = y `seq` 5
 
 cause GHC to report a missing ``Eval`` instances on ``(m Int)`` and ``(m Bool)``, but with no accompanying suggestion on
-which type signatures to modify. I take this to mean that the
-`INCOMPLETE_CONTEXTS<https://github.com/ghc-proposals/ghc-proposals/pull/34>`_ implementation strategy could not provide
-an automatic recovery.
+which type signatures to modify. I take this to mean that the `INCOMPLETE_CONTEXTS
+<https://github.com/ghc-proposals/ghc-proposals/pull/34>`_ implementation strategy could not provide an automatic
+recovery.
    
 Overall, the biggest problem would probably be presented by class instances like
 ::

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -23,12 +23,12 @@ The main benefit, in the medium term, would be to make Haskell fully parametric 
 to make η-conversion and foldr-build optimization safe, to reopen the possibility of unlifted products (*i.e.*,
 ``newtype`` with multiple fields), and possibly to satisfy Bob Harper. Here is some background reading material that
 explains the existing problems:
-  - `η-equivalence in Haskell <http://cstheory.stackexchange.com/questions/19165/is-eta-equivalence-for-functions-compatiable-with-haskells-seq-operation>`_
-  - `Haskell has no state monad <http://www.cse.chalmers.se/~nicsma/no-state-monad.html>`_
-  - `Hask is not a category <http://math.andrej.com/2016/08/06/hask-is-not-a-category/>`_
-  - `Correctness of short cut fusion <https://wiki.haskell.org/Correctness_of_short_cut_fusion#In_the_absence_of_seq>`_
-  - `Haskell is exceptionally unsafe
-    <https://existentialtype.wordpress.com/2012/08/14/haskell-is-exceptionally-unsafe/>`_
+
+- `η-equivalence in Haskell <http://cstheory.stackexchange.com/questions/19165/is-eta-equivalence-for-functions-compatiable-with-haskells-seq-operation>`_
+- `Haskell has no state monad <http://www.cse.chalmers.se/~nicsma/no-state-monad.html>`_
+- `Hask is not a category <http://math.andrej.com/2016/08/06/hask-is-not-a-category/>`_
+- `Correctness of short cut fusion <https://wiki.haskell.org/Correctness_of_short_cut_fusion#In_the_absence_of_seq>`_
+- `Haskell is exceptionally unsafe <https://existentialtype.wordpress.com/2012/08/14/haskell-is-exceptionally-unsafe/>`_
 
 Proposed Change
 ---------------
@@ -164,9 +164,10 @@ the instance.
 This particular instance is breaking the ``Functor`` laws, but that is beside the point. There are other user-defined
 classes and data types with those classes' instances that may use ``seq`` in this way. For each of those cases, there
 would be three ways to make the instance compile again:
-  - remove the use of ``seq``, potentially losing the performance,
-  - add ``(Eval a)`` to the context of the type class method, or
-  - add ``(Eval a)`` to the context of the data type constructor.
+
+- remove the use of ``seq``, potentially losing the performance,
+- add ``(Eval a)`` to the context of the type class method, or
+- add ``(Eval a)`` to the context of the data type constructor.
 
 Potential solution
 ------------------

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -1,0 +1,121 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+Bring back ``class Eval``
+=========================
+
+This proposal is to add a language extension that, when specified, rolls back the ``seq`` semantics to their Haskell 1.3
+state.
+
+Motivation
+----------
+
+The main benefits would be to make Haskell fully parametric again, to make η-conversion and foldr-build optimization
+safe, and possibly to satisfy Bob Harper. Here is some background reading material that explains the existing problems:
+  - `η-equivalence in Haskell <http://cstheory.stackexchange.com/questions/19165/is-eta-equivalence-for-functions-compatiable-with-haskells-seq-operation>`
+  - `Haskell has no state monad <http://www.cse.chalmers.se/~nicsma/no-state-monad.html>`
+  - `Hask is not a category <http://math.andrej.com/2016/08/06/hask-is-not-a-category/>`
+  - `Correctness of short cut fusion <https://wiki.haskell.org/Correctness_of_short_cut_fusion#In_the_absence_of_seq>`
+  - `Haskell is exceptionally unsafe
+    <https://existentialtype.wordpress.com/2012/08/14/haskell-is-exceptionally-unsafe/>`
+
+Proposed Change
+---------------
+
+**First**, Restore class ``Eval`` and its methods much as they were in Haskell 1.3 specification, only renaming the
+method ``strict`` to its modern equivalent ``$!``
+::
+    class Eval a where
+      ($!)    :: (a -> b) -> a -> b
+      seq     :: a -> b -> b
+      f $! x  =  x `seq` f x
+
+Like ``Typeable``, the ``Eval`` class is implicitly derived for every data type and its instances cannot be explicitly
+defined.
+
+As a consequence of this change, the ``Eval`` class would start appearing in the inferred type context of expressions
+using ``seq``. For example, the inferred type of function ``f x = seq x x`` would become ``f :: forall a. Eval a => a ->
+a``.
+
+**Second**, add a new language option, namely ``-XNoUniversalEval`` together with its evil twin ``-XUniversalEval``. The
+latter option would be the default one.
+
+In any module compiled with ``-XUniversalEval``, the class ``Eval`` would be satisfied by every type of kind
+``*``. Furthermore, every explicit type signature would be considered equivalent to the same signature with the context
+``Eval a =>`` added for every type variable ``a :: *``. The example function ``f`` above would thus still compile even
+if accompanied by an explicit type signature ``f :: forall a. a -> a``.
+
+In a module compiled with ``-XNoUniversalEval`` the class ``Eval`` would become a normal class, subject to the usual
+type equivalence rules. Any polymorphic use of ``seq`` would trigger a compilation error, including the above
+example. The same constraint would apply to bang patterns and the strict data bang, but monomorphic applications of
+``seq`` and bang would not be affected. GHC should be able to apply more aggressive optimizations in a
+``-XNoUniversalEval`` module.
+
+**Third**, add the ``Eval =>`` context to the type signatures of ``Data.List.foldl'`` and all other strict functions in
+the ``base`` library. That includes ``Data.Foldable.foldl'`` and other class methods whose instances are expected to be
+strict.
+
+**Fourth**, add the ``-WetaUnsafe`` option that warns about any polymorphic occurrence of ``seq``. In other words, the
+warning would be issued for any use of ``seq`` in every module compiled with ``-XUniversalEval`` that would trigger an
+error if ``-XNoUniversalEval`` was active instead. The warning would be off by default, but included in ``-Wall``.
+
+This proposal is orthogonal to all existing language extensions. This includes even ``StrictHaskell``, though the
+combination of this one with ``-XNoUniversalEval`` in the same module might prove impractical.
+
+Drawbacks
+---------
+
+The main reason given for dropping the ``Eval`` class from Haskell 98 given in *A History of Haskell: Being Lazy With
+Class* (§10.3) was ease of debugging. Specifically, if one wants for debugging purposes to temporarily invoke ``seq`` in
+a polymorphic function, that forces adding the ``Eval a =>`` context to the explicit type signatures of that function
+and all its polymorphic callers.
+
+Personally, that justification strikes me as strange. Haskell is not otherwise known for weakening the language
+properties in order to accommodate development procedures or tooling.
+
+To make another point, I have often wished I could avoid adding the ``Show a =>`` context for debugging
+purposes. Indeed, if the function ``show``, or at least ``traceShow`` should become polymorphic, that would greatly
+simplify printf-style debugging. I'm not aware of anybody asking for this.
+
+The main drawback to clamping down on ``seq`` today is the quantity of code that's using it unconstrained. Still, we
+have to start somewhere. My hope is that one day ``-XNoUniversalEval`` will become the default and the
+``-XUniversalEval`` pragma will be necessary to apply ``seq`` willy-nilly.
+
+If this change were to happen today, there would certainly be plenty of broken code. The breakage would probably *not*
+be in the low-level libraries that heavily depend on strictness annotations for optimization. That code is typically
+monomorphic and thus wouldn't be affected.
+
+Alternatives
+------------
+
+A previous version of this proposal started by adding a new module named ``Data.Eval``, exporting the class ``Eval`` and
+its methods. There would thus be two variants of ``seq``, the polymorphic one in ``Prelude`` and the safe one in
+``Data.Eval``, and users would opt into using the latter by importing ``Data.Eval``.
+
+This cunning plan would require virtually no change to GHC, but unfortunately it fell apart on the ``foldl'`` and
+``foldr'`` methods of the ``Foldable`` class. We can't simply export an alternative ``Foldable`` class from
+``Data.Eval.Foldable`` because the two classes would be incompatible.
+
+The ``-WetaUnsafe`` part of the proposal is meant as a gentle nudge away from the polymorphic ``seq`` and toward the
+bright future. The current habits would probably continue without it. Stronger alternatives like turning the warning on
+by default can be imagined, but they would likely bring too many complaints.
+
+I had also considered extending the *SafeHaskell* inference mechanism. It could infer a module *EtaSafe* if it's *Safe*
+or *Trustworthy*, all its imports are *EtaSafe*, and no ``seq`` use in the module is polymorphic. I dropped this idea
+mostly because it seemed wrong to conflate ``unsafePerformIO`` and polymorphic ``seq``; they are not unsafe in the same
+sense. Besides, I'm not convinced the *EtaSafe* certificate would attract much attention.
+
+Unresolved Questions
+--------------------
+
+It would be nice to get some estimate of the proportion of existing packages that cannot be compiled with
+``-XNoUniversalEval``.

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -174,20 +174,21 @@ Potential solution
   
 There is a relatively principled way to make GHC accept even these instances. First, let's think about how we could
 apply GHC's suggestion manually to the ``Functor`` class. We don't want to modify the ``fmap`` method signature and
-affect all well-behaved instances. We can instead add an evil-twin method ``fmap'`` with the required ``Eval`` context,
-with a default implementation:
+affect all well-behaved instances. We can instead add an evil-twin method ``fmap'`` with the required ``Eval`` context:
 ::
+   {-# LANGUAGE UniversalEval #-}
    class Functor f where
       fmap  ::                     (a -> b) -> f a -> f b
       fmap' :: (Eval a, Eval b) => (a -> b) -> f a -> f b
       fmap' = fmap
+      fmap  = fmap'
 
 Of course the ``Functor`` class is out of our reach by the time we encounter the bad instance, so we can't do this in
 retrospect. And we certainly don't want to do it manually. Rather, we want GHC to perform this magic for all class
-definitions in any module compiled with ``-XNoUniversalEval``. Somewhat more exactly, GHC would automatically shadow
-every method with free type variables with another method whose type signature adds an ``Eval`` constraint to each type
+definitions in any module compiled with ``-XUniversalEval``. Somewhat more exactly, GHC would automatically shadow every
+method with free type variables with another method whose type signature adds an ``Eval`` constraint to each type
 variable. The generated methods would be accessible only for the error-recovery purposes in class instances, and only in
-modules compiled with ``-XNoUniversalEval``.
+modules compiled with ``-XUniversalEval``.
 
 Note that this is an optional extension to the proposal. It's not clear if the instance backward compatibility problems
 will be severe enough to justify the complexity of the fix.

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -104,7 +104,8 @@ This cunning plan would require virtually no change to GHC, but unfortunately it
 I considered adding yet another pair of language options, ``LiftedFunctions`` and ``UnliftedFunctions``. The former
 would be on by default. The latter option, where specified, would prevent the ``Eval`` class from being implicitly
 derived for function types. However, different designs are possible (should a function type ``Bool -> Int`` still be an
-instance of ``Eval``?) and I felt this was better left for a future proposal, if this one should take.
+instance of ``Eval``? how about a ``DataEval`` subclass of ``Eval``?) and I felt this was better left for a future
+proposal, if this one should take.
 
 I had also considered extending the *SafeHaskell* inference mechanism. It could infer a module *EtaSafe* if it's *Safe*
 or *Trustworthy*, all its imports are *EtaSafe*, and no ``seq`` use in the module is polymorphic nor applied to a

--- a/proposals/0000-eval-class.rst
+++ b/proposals/0000-eval-class.rst
@@ -78,7 +78,6 @@ All data types declared with ``data`` would have an automatically derived ``Eval
 constructor declared with strict fields would have ``Eval`` context for such fields, but that would not affect the
 type's ``Eval`` instance. The derived instance of a ``newtype``-declared type on the other hand would inherit the
 context of the ``Eval`` instance of its sole constructor field. Taking the following type declarations for example:
-
 ::
    data Foo a b  = Strict !a !b
                  | HalfStrict !a b
@@ -86,7 +85,6 @@ context of the ``Eval`` instance of its sole constructor field. Taking the follo
    newtype Bar a = Bar a
 
 the compiler would derive
-
 ::
    Strict     :: (Eval a, Eval b) => a -> b -> Foo a b
    HalfStrict :: Eval a => a -> b -> Foo a b
@@ -105,7 +103,6 @@ the compiler would derive
       
 The only effect of strict fields is on the type constructors, the corresponding patterns are not affected in any
 way. The patterns ``Strict a b``, ``NonStrict a`` or ``Bar a`` would behave the same way they do today.
-
 ::
    f :: Foo a b -> a
    f (Strict x _) = x
@@ -113,7 +110,6 @@ way. The patterns ``Strict a b``, ``NonStrict a`` or ``Bar a`` would behave the 
 If in the future we should introduce unlifted products in the form of multi-field ``newtype``, such as in ``newtype Pair
 a b = MkPair a b``, they would likely have no ``Eval`` instance. The reason is that the properties of the instance would
 require that
-
 ::
    MkPair ⊥ b `seq` x = b `seq` x
    MkPair a ⊥ `seq` x = a `seq` x
@@ -127,14 +123,12 @@ Backward compatibility issues
 Most of the existing code would continue to work unless the ``-XNoUniversalEval`` option was used. There are some
 exceptions that this mechanism would not solve. In particular `(as suggested by Simon
 PJ)<https://github.com/ghc-proposals/ghc-proposals/pull/27#issuecomment-259913953>`, higher-rank types like
-
 ::
    data Rank2 (m :: (* -> *)) = MkRank2 (m Int)
    f :: forall (m :: * -> *). Rank2 m -> Int
    f (MkRank2 x) = x `seq` 42
 
 and GADTs as in
-
 ::
    data T m where
      T1 :: m Int -> T m
@@ -150,7 +144,6 @@ which type signatures to modify. I take this to mean that the
 an automatic recovery.
    
 Overall, the biggest problem would probably be presented by class instances like
-
 ::
    data Foo a = MkFoo a
    instance Functor Foo where
@@ -158,7 +151,6 @@ Overall, the biggest problem would probably be presented by class instances like
 
 In this case, GHC 8.0.2 does helpfully suggest adding ``(Eval a)`` to the context of the type signature as a possible
 fix. In this case, unfortunately, the suggested context is wrong:
-
 ::
    Possible fix:
      add (Eval a) to the context of
@@ -183,7 +175,6 @@ There is a relatively principled way to make GHC accept even these instances. Fi
 apply GHC's suggestion manually to the ``Functor`` class. We don't want to modify the ``fmap`` method signature and
 affect all well-behaved instances. We can instead add an evil-twin method ``fmap'`` with the required ``Eval`` context,
 with a default implementation:
-
 ::
    class Functor f where
       fmap  ::                     (a -> b) -> f a -> f b

--- a/proposals/0000-incomplete-contexts-pragma.rst
+++ b/proposals/0000-incomplete-contexts-pragma.rst
@@ -1,0 +1,116 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+The INCOMPLETE_CONTEXTS pragma
+==============================
+
+The proposal is to add a pragma that allows a specified class to be left out of any explicit type declaration context.
+
+Motivation
+----------
+
+The original inspiration came from the proposed implementation mechanism for preserving the backward compatibility with
+the ``Eval`` class proposal. In the form presented here, though, the proposal would be more immediately useful during
+development and debugging. So I'll start with this motivating example:
+::
+   
+   low-level-function :: a -> b -> DataStructure a b -> DataStructure a b
+   low-level-function a b = trace ("Working with " ++ show (a, b)) $ ...
+
+You see, this ``low-level-function`` appears to contain a bug that's triggered by certain input values, and we added the
+``trace`` call in order to discover the problematic inputs. Even though the function is polymorphic, we happen to use
+it with a data type that is an instance of ``Show``.
+
+The above example triggers the following GHC error report:
+::
+   
+      No instance for (Show a) arising from a use of ‘show’
+      Possible fix:
+        add (Show a) to the context of
+          the type signature for:
+            low-level-function :: a -> b -> DataStructure a b -> DataStructure a b
+
+If we listen to compiler's advice and try compiling again, we'll be rewarded by another error advising us to add ``(Show
+b)`` to the function's context as well. Also, to add the same context to every single ``high-level-function`` that
+depends on ``low-level-function``, and then to their callers *et cetera*. Sometimes it's enough to make one give up and
+write a QuickCheck test suite instead. Or to live with the bug.
+
+Proposed Change
+---------------
+
+Introduce pragma ``INCOMPLETE_CONTEXTS`` with a single parameter that has to be a single-argument class name. In this
+example, the full pragma would be
+::
+   
+   {-# INCOMPLETE_CONTEXTS Show #-}
+
+It's obvious from the error message that GHC knows exactly how to fix the type signature. The pragma tells the compiler
+to go ahead and apply its own recommendation throughout the module, transitively expanding all necessary contexts until
+the module compiles.
+
+It's not difficult to come up with examples of type classes other than ``Show`` that could be temporarily used for
+debugging with this pragma: ``Monad``, ``MonadIO``, ``Typeable``, and ``Arbitrary`` immediately jump to mind. Apart from
+debugging, the pragma could be used for rapid prototyping until we decide which class constraints are necessary: must we
+demand a ``Monad`` or would an ``Applicative`` instance be enough?
+
+Still, the pragma is meant to be strictly a debugging and development aid. It would only replace compiler errors by
+compiler warnings that cannot be silenced. Once the bugs and the design issues are taken care of, the developer should
+either remove the offending code or explicitly add the missing contexts. Hackage should refuse to accept any package
+upload that still triggers the warnings.
+
+As implied above, the effect of the ``INCOMPLETE_CONTEXTS`` pragma is per module. It should be placed before the
+``module`` keyword, together with the ``LANGUAGE`` pragmas. The type signatures of exported bindings are affected the
+same as everything else, but their users in importing modules are not: one may need to add the pragma to each importing
+module.
+
+Drawbacks
+---------
+
+We must be careful to prevent the use of ``INCOMPLETE_CONTEXTS`` from seeping into released packages. It would be a
+grievous loss if incomplete signatures started appearing on Hackage.
+
+Alternatives
+------------
+
+Instead of a whole new pragma, ``INCOMPLETE_CONTEXTS`` could become just another language extension. This would leave no
+place to specify the class name, so presumably all context constraints would then become optional. I'd prefer some more
+discipline, and I'm guessing the proposal would be easier to implement as presented.
+
+If the need to add pragma to multiple modules turns out to be too inconvenient, we can add a command-line option in
+addition to the pragma.
+
+The specified proposal is made as simple as possible, so it provides no mechanism to cover any non-standard contexts
+such as multiple-parameter type class constraints, type equality constraints, or type functions. Adding those would
+require syntactic and semantic changes and presumably complicate the implementation.
+
+Unresolved Questions
+--------------------
+
+Context ``HasCallStack`` is funny in that it it's not a class name and it already comes with an ad-hoc mechanism that
+makes the transient context adjustments unnecessary. Per documentation:
+
+    GHC solves HasCallStack constraints in three steps:
+
+    1. If there is a ``CallStack`` in scope -- i.e. the enclosing function has a ``HasCallStack`` constraint -- GHC will
+    append the new call-site to the existing ``CallStack``.
+
+    2. If there is no ``CallStack`` in scope -- e.g. in the GHCi session above -- and the enclosing definition does not
+    have an explicit type signature, GHC will infer a ``HasCallStack`` constraint for the enclosing definition (subject
+    to the monomorphism restriction).
+
+    3. If there is no ``CallStack`` in scope and the enclosing definition has an explicit type signature, GHC will solve
+    the ``HasCallStack`` constraint for the singleton ``CallStack`` containing just the current call-site.
+
+The present proposal does not cover it, but there is some appeal in allowing ``{-# INCOMPLETE_CONTEXTS HasCallStack
+#-}`` with obvious semantics: the first point above would be additionally qualified with *or the ``INCOMPLETE_CONTEXTS
+HasCallStack`` pragma is specified in the module*. This would provide an easy way to obtain deep call stacks while
+debugging.


### PR DESCRIPTION
This is a short proposal for a new language extension (or perhaps retraction) that tames `seq` by putting it back in the `Eval` class from Haskell versions 1.3 and 1.4.

[Rendered proposal](https://github.com/blamario/ghc-proposals/blob/master/proposals/0000-eval-class.rst)
