### PR TITLE
Allow bundling patterns with type synonyms

### DIFF
--- a/proposals/0000-bundle-with-type-synonym.rst
+++ b/proposals/0000-bundle-with-type-synonym.rst
@@ -48,6 +48,7 @@ with a pattern synonym for the latter. ::
 
     type State s a = StateT s Identity a
 
+    pattern State :: (s -> (s, a)) -> State s a
     pattern State { runState } <- ((runIdentity .) . runStateT -> runState)
         where State runState_ = StateT (Identity . runState_)
 

--- a/proposals/0000-bundle-with-type-synonym.rst
+++ b/proposals/0000-bundle-with-type-synonym.rst
@@ -104,6 +104,16 @@ An import of the form ``T(d1,...,dm)``, where ``T`` is a type synonym exported i
 
 An import of the form ``T(..)``, where ``T`` is a type synonym exported in the form ``T(c1,...,cn)`` will import ``T`` and ``c1`` to ``cn``.
 
+
+Is there a better way of checking whether ``c1`` to ``cn`` are actually
+associated with the type synonym ``T``?
+
+None have been proposed.
+
+The specification covers the simple case where the type synonym unfolds
+directly into a data type or newtype, based on
+`AssociatingSynonyms#Typing <https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms#Typing>`_.
+
 Discussion
 ^^^^^^^^^^
 
@@ -116,6 +126,11 @@ the export list of the `State` module could be changed to ::
  ) where
 
 Then, importing ``State(..)`` from the ``State`` module would import the pattern and selector into another module.
+
+Should this be tied to some language extension?
+^^^^^^^^^^
+
+Bundling pattern synonyms isn't guarded by a language extension so it seems sensible that this isn't either.
 
 Drawbacks
 ---------
@@ -131,11 +146,8 @@ None so far.
 Unresolved Questions
 --------------------
 
-* Should this be tied to some language extension?
-* Is there a better way of checking whether ``c1`` to ``cn`` are actually associated with the type synonym ``T``?
-  (the specification covers the simple case where the type synonym unfolds directly into a data type or newtype,
-  based on `AssociatingSynonyms#Typing <https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms#Typing>`_.)
-  
+None at the moment.
+
 Remarks
 -------
 

--- a/proposals/0000-bundle-with-type-synonym.rst
+++ b/proposals/0000-bundle-with-type-synonym.rst
@@ -82,8 +82,17 @@ is replaced by ::
     or in the form T(c1,...,cn), where c1...cn name pattern synonyms, data constructors,
     or record field selectors.
 
+In addition, the associated pattern synonyms should not be *visibly incompatible* (using terminology from `AssociatingSynonyms#Typing <https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms#Typing>`_): ::
+
+    If unfolding type synonyms in a saturated application of T results in the shape
+        T t1 ... tn = S t1' ... tn'
+    where S is a data/newtype constructor, then c1,...,cn should be constructors of S, functions with
+    type of shape S t1' ... tn' -> t, or pattern synonyms P that are not visibly incompatible with S,
+    that is, if the type of P after unfolding type synonyms has shape ... -> S' t1' ... tn' for a
+    data/newtype constructor S', then S = S'.
+
 Note that `HR:5.3 <https://www.haskell.org/onlinereport/haskell2010/haskellch5.html#x11-1010005.3>`_
-does not spell out any corresponding restriction.
+does not spell out any restriction on the imported entities.
 
 Semantics
 ^^^^^^^^^
@@ -123,11 +132,9 @@ Unresolved Questions
 --------------------
 
 * Should this be tied to some language extension?
-* Is there a sane way of checking whether ``c1`` to ``cn`` are actually associated with the type synonym ``T``?
-  It should be possible to adapt the approach taken for bundling with data types,
-  see `AssociatingSynonyms#Typing <https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms#Typing>`_.
-  To make it work, the type synonym needs to be unfolded and given similar treatment.
-  (**TODO**: incorporate this into the specification)
+* Is there a better way of checking whether ``c1`` to ``cn`` are actually associated with the type synonym ``T``?
+  (the specification covers the simple case where the type synonym unfolds directly into a data type or newtype,
+  based on `AssociatingSynonyms#Typing <https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms#Typing>`_.)
   
 Remarks
 -------

--- a/proposals/0000-bundle-with-type-synonym.rst
+++ b/proposals/0000-bundle-with-type-synonym.rst
@@ -105,8 +105,8 @@ An import of the form ``T(d1,...,dm)``, where ``T`` is a type synonym exported i
 An import of the form ``T(..)``, where ``T`` is a type synonym exported in the form ``T(c1,...,cn)`` will import ``T`` and ``c1`` to ``cn``.
 
 
-Is there a better way of checking whether ``c1`` to ``cn`` are actually
-associated with the type synonym ``T``?
+*Is there a better way of checking whether ``c1`` to ``cn`` are actually
+associated with the type synonym ``T``?*
 
 None have been proposed.
 

--- a/proposals/0000-bundle-with-type-synonym.rst
+++ b/proposals/0000-bundle-with-type-synonym.rst
@@ -130,7 +130,8 @@ Then, importing ``State(..)`` from the ``State`` module would import the pattern
 Should this be tied to some language extension?
 ^^^^^^^^^^
 
-Bundling pattern synonyms isn't guarded by a language extension so it seems sensible that this isn't either.
+Bundling pattern synonyms with type constructors isn't guarded by a language
+extension so it seems sensible that this isn't either.
 
 Drawbacks
 ---------


### PR DESCRIPTION
This is a proposal to allows associating pattern synonyms (and related record selectors) with type synonyms.
There is a corresponding feature request on ghc's Trac, cf. https://ghc.haskell.org/trac/ghc/ticket/12857

The proposal can be viewed at https://github.com/int-e/ghc-proposals/blob/bundle-with-type-synonym/proposals/0000-bundle-with-type-synonym.rst