### PR TITLE
Treatment of proposals that happen to be implemented

### DIFF
--- a/steering-committee.rst
+++ b/steering-committee.rst
@@ -38,6 +38,9 @@ Debate steps
    commentary) with the reasons for rejection. The proposer is welcome
    to revise and try again, but the document should retain this original
    rejection information.
+   
+   In the case that the the proposed change has already been implemented in
+   GHC, it will be reverted.
 
 -  If during the Debate, the need for substantial changes does arise, we
    reject the proposal in its current state and it can go back to
@@ -103,14 +106,6 @@ and any other relevant considerations appropriately.
    with other new features. In the common case the original implementor of
    a feature moves on to other things after a few years, and this
    maintenance burden falls on others.
-
-
-Matter-of-fact acceptance of proposals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The proposal process is one way of getting changes implemented, but not the only one.
-In particular, GHC developers can just go ahead an implement a change on their own, the same way they did before the proposal process was created.
-If that happens to a change that is the topic of a proposal, then the proposal is closed without further deliberation by the committee, and marked with the label “``Already implemented``”.
 
 Membership
 ----------

--- a/steering-committee.rst
+++ b/steering-committee.rst
@@ -39,7 +39,7 @@ Debate steps
    to revise and try again, but the document should retain this original
    rejection information.
    
-   In the case that the the proposed change has already been implemented in
+   In the case that the proposed change has already been implemented in
    GHC, it will be reverted.
 
 -  If during the Debate, the need for substantial changes does arise, we

--- a/steering-committee.rst
+++ b/steering-committee.rst
@@ -104,6 +104,14 @@ and any other relevant considerations appropriately.
    a feature moves on to other things after a few years, and this
    maintenance burden falls on others.
 
+
+Matter-of-fact acceptance of proposals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The proposal process is one way of getting changes implemented, but not the only one.
+In particular, GHC developers can just go ahead an implement a change on their own, the same way they did before the proposal process was created.
+If that happens to a change that is the topic of a proposal, then the proposal is closed without further deliberation by the committee, and marked with the label “``Already implemented``”.
+
 Membership
 ----------
 


### PR DESCRIPTION
This is motivated by #29, which is already implemented in https://github.com/ghc/ghc/commit/e7985ed23ddc68b6a2e4af753578dc1d9e8ab4c9. I don’t see the need for a formal decision after the fact.