### PR TITLE
Add support for class-based reflection

### DIFF
--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -1,0 +1,247 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/69>`_.
+
+.. contents::
+
+Add built-in support for class-based reflection
+===============================================
+
+The ``reflection`` package allows users to inject runtime values of arbitrary
+types into the constraint system. Other packages allow similar injection for
+singleton types. Unfortunately, these packages need to use ``unsafeCoerce`` to
+do their work, and as a result miss out on certain optimizations (such as
+inlining and unboxing). Furthermore, these packages rely on single-method
+classes being represented as newtypes. Furthermore, there is talk among GHC
+developers of changing that representation, which would break all the packages.
+For both these reasons, I believe built-in support is justified. The ideas in
+this proposal were previously discussed on the GHC Wiki, in
+`MagicalReflectionSupport
+<https://ghc.haskell.org/trac/ghc/wiki/MagicalReflectionSupport>`_.
+
+
+Motivation
+------------
+
+Motivation for the core idea behind the ``reflection`` package can be found in
+"`Functional Pearl: Implicit Configurations — or, Type Classes Reflect the Values of Types <http://okmij.org/ftp/Haskell/tr-15-04.pdf>`_",
+by Oleg Kiselyov and Chung-chieh Shan.
+
+The specific fragments of the package covered by this proposal are ``Reifies``,
+``reify``, ``reifyNat``, ``reifySymbol``, ``Given``, and ``give``. The package
+also offers ``reifyTypeable``, which works using a completely different
+mechanism.
+
+The actual ``reflection`` package currently uses proxy-based type passing,
+but to make it easier to think about the generated Core, I will use a
+``Tagged``-based version. Translating between the two is straightforward.
+
+.. code-block:: haskell
+
+  newtype Tagged s a = Tagged { unTagged :: a }
+
+  class Reifies s a | s -> a where
+    reflect :: Tagged s a
+
+  reify :: forall a r. (forall s. Reifies s a => Tagged s r) -> a -> r
+  reifyNat :: forall r. (forall n. KnownNat n => Tagged n r) -> Integer -> r
+  reifySymbol :: forall r. (forall n. KnownSymbol n => Tagged n r) -> String -> r
+
+  class Given a where
+    given :: a
+  give :: (Given a => r) -> a -> r
+
+I will discuss ``Reifies`` and ``reify``; the other reification functions
+work similarly. ``Given`` and ``give`` are immediately implementable.
+
+From the singleton side, if we have
+
+.. code-block:: haskell
+
+  data Nat = Z | S Nat
+  data SNat n where
+    Zy :: SNat 'Z
+    Sy :: SNat n -> SNat ('S n)
+  class KnownUnaryNat n where
+    known :: SNat n
+
+then we would like to be able to write functions like
+
+.. code-block:: haskell
+
+  reifyUnaryNat :: forall n r. SNat n -> (KnownUnaryNat n => r) -> r
+
+Note the difference in quantification: whereas ``reifyNat`` takes a function
+polymorphic in the natural number, the inherent coherence of the
+``KnownUnaryNat`` class allows ``reifyUnary`` to accept a monomorphic value.
+Haskell programmers currently use both these styles, and therefore both should
+be supported.
+
+Proposed Change Specification
+-----------------------------
+
+Offer a new derivable class
+
+.. code-block:: haskell
+
+  class Reflectable (c :: Constraint) where
+    type DictRep c :: *
+    reify# :: (c => r) -> DictRep c -> r
+
+derivable for single-method classes without superclass constraints.
+
+Given
+
+.. code-block:: haskell
+
+  class TheClass a where
+    method :: T
+
+  deriving instance Reflectable (TheClass a)
+
+we would produce an instance
+
+.. code-block:: haskell
+
+  instance Reflectable (TheClass a) where
+    type DictRep (TheClass a) = T
+    reify# = ...
+
+
+Operationally, ``reify# f x`` will package up ``x`` in a dictionary
+and pass that dictionary to ``f``. Currently, that means ``reify#``
+will actually just be a coercion. Later, it may mean something else.
+
+Effect and Interactions
+-----------------------
+
+We can implement what we want
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The above-described mechanism can implement singleton reflection
+directly. We could simply write, for example,
+
+.. code-block:: haskell
+
+  deriving instance Reflectable (KnownUnaryNat n)
+
+  reifyUnaryNat :: forall n r. (KnownUnaryNat n => r) -> SNat n -> r
+  reifyUnaryNat = reify# @(KnownUnaryNat n)
+
+Implementing ``reflection``'s ``reify`` function is a bit hairier, but it
+only needs to be done once.
+
+.. code-block:: haskell
+
+  class Reifies s a | s -> a where
+    reflect :: Tagged s a
+
+  deriving instance Reflectable (Reifies s a)
+
+  reify :: forall a r. (forall s. Reifies s a => Tagged s r) -> a -> r
+  reify f a = unTagged (reify# @(Reifies s a) (f :: Tagged s r) a
+                          :: forall s. Tagged s r)
+
+The optimizer has to be careful
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+My main concern with regard to implementation has to do with
+specialization in the ``reflection`` case. ``reify`` desugars to a term
+that uses ``$fReflectableReifies @ Any @ a``. It's critical
+that the specializer never specializes this; ``Any`` must not equal ``Any``
+in this context! If I write ``reify (... (reify ... (3 :: Int))) (4 :: Int)``,
+it's impermissible to change 3 into 4 or vice versa.
+
+
+Costs and Drawbacks
+-------------------
+
+The proposed mechanism allows users to subvert class coherence by
+implementing fundamentally illegitimate functions like ``give``.
+Coherence is only guaranteed when reflection is carefully protected
+by polymorphism (as in ``reify``) or when the reified type is truly
+a singleton. Others have told me that library authors, rather than
+GHC, should be responsible for using this mechanism responsibly.
+I think they are probably right.
+
+
+Alternatives
+------------
+
+Use a data family
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: haskell
+
+  class Reflectable (s :: Symbol) (c :: Constraint) where
+    data DictRep s c :: *
+    reify# :: (c => r) -> DictRep s c -> r
+
+In this version, the dictionary is represented by a data family
+instead of a type family. By using a data family, the newtype
+constructor on the argument to ``reify#`` determines the class we are
+reifying, avoiding the need to use explicit type application to
+specify the class. The ``Symbol`` allows the user to name the
+newtype constructor for the ``DictRep``. This all seems reasonably
+convenient, but I think it's probably actually overkill. Using
+a bit of explicit type application to fix the constraint doesn't
+seem like a huge price to pay for simplicity.
+
+.. code-block:: haskell
+
+Build the constraint from the representation type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A very different approach suggested earlier by Simon Peyton Jones uses a class
+of reifiable types rather than reflectable classes.
+
+.. code-block:: haskell
+
+  class Reifiable (a :: *) where
+    type RC a :: Constraint
+    reify# :: (RC a => r) -> a -> r
+
+As Iceland_Jack noted, it should be possible to make it levity-polymorphic:
+
+.. code-block:: haskell
+
+  class Reifiable (a :: TYPE rep) where
+    type RC a :: Constraint
+    reify# :: (RC a => r) -> a -> r
+
+I doubt that polymorphism is really *useful*, however, since constraints are
+lifted anyway, but perhaps there's some way to do something with it.
+
+The big downside I see to this approach is that it can't be retrofitted
+around existing classes; those must be *replaced*. For example, in order
+to implement ``reifyUnary``, we would need to write something like
+
+.. code-block:: haskell
+
+  class RC (SNat n) => KnownUnaryNat n
+  instance RC (SNat n) => KnownUnaryNat n
+
+whereas with the proposed approach we can use an existing user-defined
+``KnownUnaryNat`` class.
+
+Unresolved questions
+--------------------
+
+I have the nagging feeling that there should be some way to extend
+this proposal to include classes with superclasses or multiple methods
+in some fashion. I have not yet been able to come up with a design
+for that.
+
+
+Implementation Plan
+-------------------

--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -20,10 +20,18 @@ Add built-in support for class-based reflection
 The ``reflection`` package allows users to inject runtime values of arbitrary
 types into the constraint system. Other packages allow similar injection for
 singleton types. Unfortunately, these packages need to use ``unsafeCoerce`` to
-do their work, and as a result miss out on certain optimizations (such as
-inlining and unboxing). Furthermore, these packages rely on single-method
-classes being represented as newtypes. Furthermore, there is talk among GHC
-developers of changing that representation, which would break all the packages.
+do their work. As a result:
+
+1. They miss out on certain optimizations (such as
+inlining and unboxing).
+
+2. They rely on single-method
+classes being represented as newtypes. It is conceivable that this
+representation could change in the future, which would break all the packages. Such
+a change was considered in a previous version of
+`Separate Constraint from Type <https://github.com/ghc-proposals/ghc-proposals/pull/32>`_
+but seems to have been rejected.
+
 For both these reasons, I believe built-in support is justified. The ideas in
 this proposal were previously discussed on the GHC Wiki, in
 `MagicalReflectionSupport
@@ -35,57 +43,66 @@ Motivation
 
 Motivation for the core idea behind the ``reflection`` package can be found in
 "`Functional Pearl: Implicit Configurations — or, Type Classes Reflect the Values of Types <http://okmij.org/ftp/Haskell/tr-15-04.pdf>`_",
-by Oleg Kiselyov and Chung-chieh Shan.
+by Oleg Kiselyov and Chung-chieh Shan. Much of that paper discusses a very
+different (and much less efficient) implementation approach; only the general
+discussion and examples are really relevant. In determining the importance
+of supporting this idea, the committee is urged to consider the
+`reverse dependencies of the reflection package <http://packdeps.haskellers.com/reverse/reflection>`_.
 
-The specific fragments of the package covered by this proposal are ``Reifies``,
-``reify``, ``reifyNat``, ``reifySymbol``, ``Given``, and ``give``. The package
-also offers ``reifyTypeable``, which works using a completely different
-mechanism.
+Perhaps the canonical example of singleton reflection is the ``withSingI``
+function
+`in the singletons package <http://hackage.haskell.org/package/singletons-2.3.1/docs/src/Data-Singletons.html#withSingI>`_.
 
-The actual ``reflection`` package currently uses proxy-based type passing,
-but to make it easier to think about the generated Core, I will use a
-``Tagged``-based version. Translating between the two is straightforward.
+The specific fragments of ``reflection`` covered by this proposal are
+``Reifies``, ``reify``, ``reifyNat``, ``reifySymbol``, ``Given``, and ``give``.
+The package also offers ``reifyTypeable``, which works using a mechanism
+based on Kiselyov and Shan's.
+
+The rest of this proposal will focus on one class and one function from each
+of ``singletons`` and ``reflection``. In each case, I am using slightly
+different types than those in the actual packages, in order to make a
+cleaner, more direct (and in some cases more efficient) translation to Core.
+It is straightforward to apply the same mechanism to the exact existing
+APIs.
+
+From the ``singletons`` side
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: haskell
+
+  -- A family of singleton types
+  data family Sing (a :: k)
+
+  class SingI (a :: k) where
+    sing :: Sing a
+
+  withSingI :: (SingI n => r) -> Sing n -> r
+
+From the ``reflection`` side
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: haskell
 
   newtype Tagged s a = Tagged { unTagged :: a }
 
+  -- Reifies s a => X can be read, roughly speaking, as
+  --
+  -- \(s :: a) -> X
+  --
+  -- but rather than binding a *term variable* to a value, it binds
+  -- a *type variable* to a value.
   class Reifies s a | s -> a where
     reflect :: Tagged s a
 
+  -- reify f x can be read, roughly speaking, as "apply f to a".
   reify :: forall a r. (forall s. Reifies s a => Tagged s r) -> a -> r
-  reifyNat :: forall r. (forall n. KnownNat n => Tagged n r) -> Integer -> r
-  reifySymbol :: forall r. (forall n. KnownSymbol n => Tagged n r) -> String -> r
 
-  class Given a where
-    given :: a
-  give :: (Given a => r) -> a -> r
+Note the difference in quantification: whereas ``reify`` takes a function
+polymorphic in the type variable ``s`` (representing the fact that ``s``
+may be "bound" to multiple values), the inherent coherence of the
+``SingI`` class allows ``withSingI`` to accept a monomorphic value. Both
+these styles are used "in the wild" and should be supported.
 
-I will discuss ``Reifies`` and ``reify``; the other reification functions
-work similarly. ``Given`` and ``give`` are immediately implementable.
-
-From the singleton side, if we have
-
-.. code-block:: haskell
-
-  data Nat = Z | S Nat
-  data SNat n where
-    Zy :: SNat 'Z
-    Sy :: SNat n -> SNat ('S n)
-  class KnownUnaryNat n where
-    known :: SNat n
-
-then we would like to be able to write functions like
-
-.. code-block:: haskell
-
-  reifyUnaryNat :: forall n r. SNat n -> (KnownUnaryNat n => r) -> r
-
-Note the difference in quantification: whereas ``reifyNat`` takes a function
-polymorphic in the natural number, the inherent coherence of the
-``KnownUnaryNat`` class allows ``reifyUnary`` to accept a monomorphic value.
-Haskell programmers currently use both these styles, and therefore both should
-be supported.
 
 Proposed Change Specification
 -----------------------------
@@ -98,7 +115,8 @@ Offer a new derivable class
     type MethodType c :: *
     reify# :: (c => r) -> MethodType c -> r
 
-derivable for single-method classes without superclass constraints.
+derivable for single-method classes without superclass constraints
+whose method type does not quantify over any type variables.
 
 Given
 
@@ -117,60 +135,120 @@ we would produce an instance
     type MethodType (TheClass a) = T
     reify# = ...
 
-
 Operationally, ``reify# f x`` will package up ``x`` in a dictionary
 and pass that dictionary to ``f``. Currently, that means ``reify#``
-will actually just be a coercion. Later, it may mean something else.
+will actually just be a coercion. It could be implemented as a function today
+(perhaps disabling some optimizations, as ``Data.Reflection`` does):
+
+.. code-block:: haskell
+
+  newtype Magic c a = Magic (c => a)
+
+  reify#default :: forall c r a . (c => r) -> a -> r
+  reify#default f = unsafeCoerce (Magic f :: Magic c r)
+
+That is, we take a function that expects a *dictionary* argument and coerce
+it to a function expecting a regular argument.
+
+As Simon Peyton Jones pointed out, making ``reify#default`` (with its entirely
+over-general type) a primop would require giving it special typing rules. On
+the other hand, System FC is perfectly capable of handling a ``reify#`` function
+for each single-method class.
+
 
 Effect and Interactions
 -----------------------
 
 We can implement what we want
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Singleton reflection
+""""""""""""""""""""
 
 The above-described mechanism can implement singleton reflection
 directly. We could simply write, for example,
 
 .. code-block:: haskell
 
-  deriving instance Reflectable (KnownUnaryNat n)
+  deriving instance Reflectable (SingI n)
 
-  reifyUnaryNat :: forall n r. (KnownUnaryNat n => r) -> SNat n -> r
-  reifyUnaryNat = reify# @(KnownUnaryNat n)
+  withSingI :: forall n r. (SingI n => r) -> Sing n -> r
+  withSingI = reify# @(SingI n)
 
-Implementing ``reflection``'s ``reify`` function is a bit hairier, but it
-only needs to be done once.
+
+Reify
+"""""
+
+Implementing ``reflection``'s ``reify`` function is a bit hairier, but it only
+needs to be done once.
 
 .. code-block:: haskell
-
-  class Reifies s a | s -> a where
-    reflect :: Tagged s a
 
   deriving instance Reflectable (Reifies s a)
 
   reify :: forall a r. (forall s. Reifies s a => Tagged s r) -> a -> r
-  reify f a = unTagged (reify# @(Reifies s a) (f :: Tagged s r) a
-                          :: forall s. Tagged s r)
+  reify f = unTagged #. (reify# @(Reifies s a) (f :: Tagged s r)
+                          :: forall s. a -> Tagged s r)
 
-The optimizer has to be careful
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Neither ``withSingI`` nor ``reify`` actually does anything; they're just
+coercions.
+
+The optimizer has to be a bit careful
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 My main concern with regard to implementation has to do with
-specialization in the ``reflection`` case. ``reify`` desugars to a term
-that uses ``$fReflectableReifies @ Any @ a``. It's critical
-that the specializer never specializes this; ``Any`` must not equal ``Any``
-in this context! If I write ``reify (... (reify ... (3 :: Int))) (4 :: Int)``,
-it's impermissible to change 3 into 4 or vice versa.
+specialization in the ``reify`` case. Suppose we write
+
+.. code-block:: haskell
+
+  reify# f (A :: T)
+  ...
+  reify# f (B :: T)
+
+Inlining ``reify#`` could lead to something like
+
+.. code-block:: haskell
+
+  f (coerce A :: Reifies Any T)
+  f (coerce B :: Reifies Any T)
+
+We need to recognize that there can be multiple *different* dictionaries of
+type ``Reifies Any T``, and avoid replacing the one built from ``A`` with the
+one built from ``B`` and vice versa.
 
 
 Costs and Drawbacks
 -------------------
 
-The proposed mechanism allows users to subvert class coherence by
-implementing fundamentally illegitimate functions like ``give``.
-Coherence is only guaranteed when reflection is carefully protected
-by polymorphism (as in ``reify``) or when the reified type is truly
-a singleton. Others have told me that library authors, rather than
+The proposed mechanism allows users to subvert class coherence.
+For example, suppose
+
+.. code-block:: haskell
+
+  f :: C Int => R
+  instance C Int where
+    m = ...
+
+Then
+
+.. code-block:: haskell
+
+  reify# @(C Int) f a
+
+will pass ``f`` a dictionary built from ``a``, but ``f`` is free
+to ignore it completely and use the dictionary from the ``C Int``
+instance.
+
+Coherence (up to bottoms) is trivially ensured when the reified
+type is truly a singleton.
+
+``reify`` ensures safety primarily through rank-2 polymorphism:
+the function it is passed must be polymorphic in the type variable
+to be "bound". The existence of even a single concrete instance
+of ``Reifies`` prevents anyone from making trouble by writing
+an overly polymorphic instance.
+
+Others have said they believe that library authors, rather than
 GHC, should be responsible for using this mechanism responsibly.
 I think they are probably right.
 
@@ -179,7 +257,46 @@ Alternatives
 ------------
 
 Use a data family
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
+
+A first draft of this approach looks like this:
+
+.. code-block:: haskell
+
+  class Reflectable (c :: Constraint) where
+    data MethodType c :: *
+    reify# :: (c => r) -> MethodType c -> r
+
+In this version, the dictionary is represented by a data family instead of a
+type family. By using a data family, the data constructor on the argument to
+``reify#`` determines the class we are reifying, avoiding the need to use
+explicit type application to specify the class. This alternative has two
+benefits:
+
+1. We no longer need to prohibit the method type from quantifying
+   over type variables, as that quantification will be under
+   the newtype constructor. For example,
+
+   .. code-block:: haskell
+
+     class Foo a where
+       foo :: a -> b -> a
+
+     deriving instance Reflectable (Foo a)
+
+   would produce something like
+
+   .. code-block:: haskell
+
+     instance Reflectable (Foo a) where
+       newtype MethodType (Foo a) = FooCon (forall b. a -> b -> a)
+       reify# = ...
+
+2. The constraint in question is fixed by the newtype constructor,
+   so it does not have to be given using visible type application.
+
+The big difficulty is that we need to deal with *naming* the data constructor.
+A first-draft approach looks like this:
 
 .. code-block:: haskell
 
@@ -187,20 +304,37 @@ Use a data family
     data MethodType s c :: *
     reify# :: (c => r) -> MethodType s c -> r
 
-In this version, the dictionary is represented by a data family
-instead of a type family. By using a data family, the newtype
-constructor on the argument to ``reify#`` determines the class we are
-reifying, avoiding the need to use explicit type application to
-specify the class. The ``Symbol`` allows the user to name the
-newtype constructor for the ``MethodType``. This all seems reasonably
-convenient, but I think it's probably actually overkill. Using
-a bit of explicit type application to fix the constraint doesn't
-seem like a huge price to pay for simplicity.
+where the ``Symbol`` represents the desired name. A user could write
 
 .. code-block:: haskell
 
+  deriving instance Reflectable "MyWrapper" MyClass
+
+to derive
+
+.. code-block:: haskell
+
+  instance Reflectable "MyWrapper" MyClass where
+    data MethodType "MyWrapper" MyClass = MyWrapper T
+
+where ``T`` is the type of ``MyClass``'s method.
+
+Unfortunately, having ``s`` in the type of ``reify#`` is annoying—it's really
+only supposed to be used by the deriving mechanism! So the final draft (for
+now) of the data family version looks like this:
+
+.. code-block:: haskell
+
+  class s ~ ConName c => Reflectable (s :: Symbol) (c :: Constraint) where
+    data MethodData c :: *
+    type ConName c :: Symbol
+    reify# :: (c => r) -> MethodData c -> r
+
+This may actually be more usable.
+
+
 Build the constraint from the representation type
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A very different approach suggested earlier by Simon Peyton Jones uses a class
 of reifiable types rather than reflectable classes.
@@ -224,15 +358,15 @@ lifted anyway, but perhaps there's some way to do something with it.
 
 The big downside I see to this approach is that it can't be retrofitted
 around existing classes; those must be *replaced*. For example, in order
-to implement ``reifyUnary``, we would need to write something like
+to implement ``withSingI``, we would need to write something like
 
 .. code-block:: haskell
 
-  class RC (SNat n) => KnownUnaryNat n
-  instance RC (SNat n) => KnownUnaryNat n
+  class RC (Sing n) => SingI n
+  instance RC (Sing n) => SingI n
 
 whereas with the proposed approach we can use an existing user-defined
-``KnownUnaryNat`` class.
+``SingI`` class.
 
 Unresolved questions
 --------------------

--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -208,7 +208,7 @@ needs to be done once.
   deriving instance Reflectable "Box" (Reifies s a)
 
   reify :: forall a r. (forall s. Reifies s a => Tagged s r) -> a -> r
-  reify f = unTagged . (reify# f :: forall s. Reflected (Reifies s a) -> Tagged s r) . Box
+  reify f = unTagged . (reify# f :: Reflected (Reifies Any a) -> Tagged Any r) . Box
 
 Neither ``withSingI`` nor ``reify`` actually does anything; they're just
 coercions [#coercions]_.
@@ -223,7 +223,7 @@ by the following:
               => (c => r) -> a -> r
   reifyMono f = coerce (reify# f :: Reflected c -> r)
 
-  reify f = unTagged . (reifyMono @(Reifies s a) f :: forall s. a -> Tagged s r)
+  reify f = unTagged . (reifyMono @(Reifies Any a) f :: a -> Tagged Any r)
 
 For polymorphic methods, the coercion trick won't work; ``reify#`` must always be
 fully applied.
@@ -252,7 +252,9 @@ I imagine this could end up expanding to
 
 We need to recognize that there can be multiple *different* dictionaries of
 type ``Reifies Any T``, and avoid replacing the one built from ``A`` with the
-one built from ``B`` and vice versa.
+one built from ``B`` and vice versa. I think the simplest way is probably to
+designate a stuck type family that the specializer knows about. If a type
+has the designated stuck type in it, then it will never specialize it.
 
 
 Costs and Drawbacks

--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -111,14 +111,27 @@ Offer a new derivable class
 
 .. code-block:: haskell
 
+  Reflectable :: Symbol -> Constraint -> Constraint
+
+derivable for literal symbols and single-method classes without superclass
+constraints. Deriving this class would be enabled by a new
+``DeriveReflectable`` language extension, which would imply
+``StandaloneDeriving``, ``ConstraintKinds``, ``DataKinds``, and
+``MultiParamTypeClasses``.
+
+Unlike existing stock derived classes, the last parameter of ``Reflectable`` is
+a *class*.  Since class declarations do not have ``deriving`` clauses,
+``Reflectable`` could only be derived using ``StandaloneDeriving``.
+
+The ``Reflectable`` class would be defined thus:
+
+.. code-block:: haskell
+
   class s ~ ConName c => Reflectable (s :: Symbol) (c :: Constraint) where
     data Reflected c :: *
     type ConName c :: Symbol
 
     reify## :: (c => r) -> Reflected c -> r
-
-derivable for literal symbols and single-method classes without
-superclass constraints.
 
 The ``Symbol`` parameter is used solely to name the newtype
 constructor for the ``Reflected`` data instance. The ``ConName``

--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -379,7 +379,7 @@ to work is
   class name ~ ConName1 c => Reflectable1 (name :: Symbol) (c :: k -> Constraint) where
     data Reflected1 c :: *
     type ConName1 c :: Symbol
-    reify1# :: forall (q :: k). (forall s. c s => r s) -> Reflected1 c -> r q
+    reify1## :: forall (q :: k). (forall s. c s => f s) -> (forall s. f s -> r) -> Reflected1 c -> r
 
 The type checker could instantiate ``s`` to the special type of its choice,
 rather than making the user do so manually.
@@ -397,7 +397,7 @@ This easily supports a ``Reifies``-like class:
   deriving instance Reflectable1 "FR" (FlipReifies a)
 
   flipReify :: forall a r. (forall (s :: *). FlipReifies a s => Const r s) -> a -> r
-  flipReify f a = getConst $ reify1# f (FR a)
+  flipReify f a = reify1## f getConst (FR a)
 
 Unfortunately, implementing ``reify`` itself with this mechanism is really
 quite ugly, requiring an auxiliary class to "flip" ``Reifies`` and a newtype

--- a/proposals/0000-magic-reflection.rst
+++ b/proposals/0000-magic-reflection.rst
@@ -95,8 +95,8 @@ Offer a new derivable class
 .. code-block:: haskell
 
   class Reflectable (c :: Constraint) where
-    type DictRep c :: *
-    reify# :: (c => r) -> DictRep c -> r
+    type MethodType c :: *
+    reify# :: (c => r) -> MethodType c -> r
 
 derivable for single-method classes without superclass constraints.
 
@@ -114,7 +114,7 @@ we would produce an instance
 .. code-block:: haskell
 
   instance Reflectable (TheClass a) where
-    type DictRep (TheClass a) = T
+    type MethodType (TheClass a) = T
     reify# = ...
 
 
@@ -184,15 +184,15 @@ Use a data family
 .. code-block:: haskell
 
   class Reflectable (s :: Symbol) (c :: Constraint) where
-    data DictRep s c :: *
-    reify# :: (c => r) -> DictRep s c -> r
+    data MethodType s c :: *
+    reify# :: (c => r) -> MethodType s c -> r
 
 In this version, the dictionary is represented by a data family
 instead of a type family. By using a data family, the newtype
 constructor on the argument to ``reify#`` determines the class we are
 reifying, avoiding the need to use explicit type application to
 specify the class. The ``Symbol`` allows the user to name the
-newtype constructor for the ``DictRep``. This all seems reasonably
+newtype constructor for the ``MethodType``. This all seems reasonably
 convenient, but I think it's probably actually overkill. Using
 a bit of explicit type application to fix the constraint doesn't
 seem like a huge price to pay for simplicity.


### PR DESCRIPTION
Allow libraries like `reflection` to work better with GHC.
Specifically, remove the need for them to use `unsafeCoerce`, making
them robust against compiler changes and allowing code that uses
them to be optimized more aggressively.

[Rendered view](https://github.com/treeowl/ghc-proposals/blob/magic-reflection/proposals/0000-magic-reflection.rst)