### PR TITLE
Add notes on reStructuredText to the template

### DIFF
--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -14,6 +14,24 @@ This proposal is `discussed at this pull requst <https://github.com/ghc-proposal
 
 .. contents::
 
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose
+text in double backticks, ``like this``.  To get block code, use a double colon and
+indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore
+`like this <http://www.haskell.org/>`_.   
+
+
 Proposal title
 ==============
 


### PR DESCRIPTION
I imagine most submitters will not know how to use reStructuredText.  I've added to the template notes on the three most common types of Markup

* inline code
* block code
* hyperlinks