### PR TITLE
Add Dependent Haskell quantifiers (including the new "foreach")

### DIFF
--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -305,6 +305,16 @@ Alternatives
   not sure that ``'`` is the right way to denote matchability. But it's nicely
   backward compatible.
 
+  * One suggestion (from @Saagar-A) is to put the ``'`` on the ``.`` or ``->``
+    in ``pi``\/``forall`` syntax. So, unmatchable ``pi`` and ``forall`` stays
+    as above, but matchable would look like ``pi a '.`` or ``pi a '->`` or
+    ``forall a '.`` or ``forall a '->``. This has a nice parallel with the
+    ``'->`` used for matchable non-dependent quantifiers. However, there is
+    potential confusion if the user writes, e.g., ``forall a'.`` Is that binding
+    ``a'`` unmatchably? Or is it binding ``a`` matchably? I think it would
+    mean the former, and thus the ``'.`` or ``'->`` syntax would require
+    preceding whitespace.
+
 * We could reserve the syntax while making it an error to use any of it.
 
 * We could use a different extension name than ``-XDependentTypes``, which

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -17,127 +17,169 @@ This proposal is `discussed at this pull request <https://github.com/ghc-proposa
 ``pi``, and other quantifiers for Dependent Haskell
 ===================================================
 
-My thesis_ describes (page 59, section 4.2.5) 12
-quantifiers for Dependent Haskell. This proposal reserves syntax for these twelve and allows the use of the new ``pi`` quantifier in
-the one place it makes sense in today's Haskell: in type constructor kinds. It also allows the use of the matchable arrow
-in the places where it makes sense in today's Haskell: in type constructor kinds and data constructor types.
+My thesis_ describes (page 59, section 4.2.5) 12 quantifiers for Dependent
+Haskell. This proposal reserves syntax for these twelve and allows the use of
+the new ``pi`` quantifier in the one place it makes sense in today's Haskell:
+in type constructor kinds. It also allows the use of the matchable arrow in
+the places where it makes sense in today's Haskell: in type constructor kinds
+and data constructor types.
 
 .. _thesis: https://repository.brynmawr.edu/cgi/viewcontent.cgi?article=1074&context=compsci_pubs
 
 Motivation
 ------------
 
-The motivation for this proposal is as a step toward full dependent types. In order to retain the type inference and type erasure
-properties of Haskell, it is necessary to consider a variety of axes along which quantifiers may vary. My thesis_ (section 4.2) has
-all the details; that section is approachable without reading other parts of the thesis, and should be helpful to anyone considering
-this proposal. I summarize the main points here, however.
+The motivation for this proposal is as a step toward full dependent types. In
+order to retain the type inference and type erasure properties of Haskell, it
+is necessary to consider a variety of axes along which quantifiers may vary.
+My thesis_ (section 4.2) has all the details; that section is approachable
+without reading other parts of the thesis, and should be helpful to anyone
+considering this proposal. I summarize the main points here, however.
 
 There are four axes quantifiers may vary on:
 
-1. Dependency: Can later parts of a type *depend* on the quantified variable (henceforth, quantifiee). In the type ``forall a. a -> a``,
-   the ``a`` is quantified dependently; the visible argument (of type ``a``) is quantified non-dependently. (We don't say "independent".)
+1. Dependency: Can later parts of a type *depend* on the quantified variable
+   (henceforth, quantifiee). In the type ``forall a. a -> a``, the ``a`` is
+   quantified dependently; the visible argument (of type ``a``) is quantified
+   non-dependently. (We don't say "independent".)
 
-2. Relevance: Can the operation of a construct (function, datatype) use the quantified argument in a computation? This is closely related
-   both to parametricity and type erasure. Consider ``id :: forall a. a -> a``. That function has *two* quantifiers, the ``forall`` and the
-   ``->``; we say it has two arguments. The first argument is irrelevant: the operation of ``id`` can *not* change depending on the choice
-   of the type ``a`` is instantiated at. This is what allows type erasure to work; the choice of type is erased at runtime, because no
-   function can branch on this choice. In contrast the second argument of ``id`` is relevant, as it informs the return value of the function.
+2. Relevance: Can the operation of a construct (function, datatype) use the
+   quantified argument in a computation? This is closely related both to
+   parametricity and type erasure. Consider ``id :: forall a. a -> a``. That
+   function has *two* quantifiers, the ``forall`` and the ``->``; we say it
+   has two arguments. The first argument is irrelevant: the operation of
+   ``id`` can *not* change depending on the choice of the type ``a`` is
+   instantiated at. This is what allows type erasure to work; the choice of
+   type is erased at runtime, because no function can branch on this choice.
+   In contrast the second argument of ``id`` is relevant, as it informs the
+   return value of the function.
 
-   Note that relevance is not only type erasure. A type family argument can either be relevant or irrelevant, based on whether or not
-   the operation of the type family branches on the choice of argument. GHC currently allows only *relevant* quantification in type
-   families (if you write ``type family Id (x :: a) :: a``, then different equations for ``Id`` can check what the choice of ``a`` is),
-   but irrelevant quantification would also be useful, in order to enforce parametricity and avoid coding errors.
+   Note that relevance is not only type erasure. A type family argument can
+   either be relevant or irrelevant, based on whether or not the operation of
+   the type family branches on the choice of argument. GHC currently allows
+   only *relevant* quantification in type families (if you write
+   ``type family Id (x :: a) :: a``, then different equations for ``Id`` can
+   check what the choice of ``a`` is), but irrelevant quantification would
+   also be useful, in order to enforce parametricity and avoid coding errors.
 
-   Relevance also affects whether or not a data constructor stores its arguments. When we say ``Just :: forall a. a -> Maybe a``, we mean
-   that a ``Just`` cell contains only one argument, something of type ``a``. The ``Just`` cell does *not* contain the choice of ``a``
-   (``Int``, say). However, we could imagine storing type information explicitly in a way that could be branched on later; that would
-   be relevant quantification. (Today, we can do this with ``Typeable``; in effect, ``f :: forall a. Typeable a => a -> a`` quantifies
-   ``a`` relevantly.)
+   Relevance also affects whether or not a data constructor stores its
+   arguments. When we say ``Just :: forall a. a -> Maybe a``, we mean that a
+   ``Just`` cell contains only one argument, something of type ``a``. The
+   ``Just`` cell does *not* contain the choice of ``a`` (``Int``, say).
+   However, we could imagine storing type information explicitly in a way that
+   could be branched on later; that would be relevant quantification. (Today,
+   we can do this with ``Typeable``; in effect,
+   ``f :: forall a. Typeable a => a -> a`` quantifies ``a`` relevantly.)
 
-3. Visibility: Is the argument always supplied when the function is called? Currently, all type arguments are invisible. Term-level
-   arguments of kind ``Type`` are visible, which term-level arguments of kind ``Constraint`` are invisible. Proposal
-   `#81`_ describes adding a syntax for visible dependent quantification,
-   which is already allowed in datatype kinds, albeit indirectly. Visible type application provides a mechanism for overriding the
-   choice of invisible quantification.
+3. Visibility: Is the argument always supplied when the function is called?
+   Currently, all type arguments are invisible. Term-level arguments of kind
+   ``Type`` are visible, which term-level arguments of kind ``Constraint`` are
+   invisible. Proposal `#81`_ describes adding a syntax for visible dependent
+   quantification, which is already allowed in datatype kinds, albeit
+   indirectly. Visible type application provides a mechanism for overriding
+   the choice of invisible quantification.
 
 .. _`#81`: https://github.com/ghc-proposals/ghc-proposals/pull/81
 
-4. Matchability: If we know ``a b ~ c d``, can we deduce ``a ~ c`` and ``b ~ d``? If so, then both ``a`` and ``c`` are *matchable*.
-   (Matchable = injective and generative.) Datatypes and data constructors are matchable; ordinary functions and type families are
-   not. Note that matchability affects more than just types: the fact that data constructor arguments are matchable is what gives
-   meaning to pattern matching. Think of how silly it would be to pattern match on functions, and you'll get a better appreciation
-   for this. Indeed, the difference between data constructors and ordinary functions is precisely that the former are matchable.
+4. Matchability: If we know ``a b ~ c d``, can we deduce ``a ~ c`` and
+   ``b ~ d``? If so, then both ``a`` and ``c`` are *matchable*. (Matchable =
+   injective and generative.) Datatypes and data constructors are matchable;
+   ordinary functions and type families are not. Note that matchability
+   affects more than just types: the fact that data constructor arguments are
+   matchable is what gives meaning to pattern matching. Think of how silly it
+   would be to pattern match on functions, and you'll get a better
+   appreciation for this. Indeed, the difference between data constructors and
+   ordinary functions is precisely that the former are matchable.
 
-These all exist in Haskell today, albeit in ways that may be hard to disentangle. Just about all dependent quantification is both
-irrelevant and invisible. (Exceptions: see `#81`_ and in type families.) Matchability is all tied in with datatype declaration.
-Yet there's no reason we can't make these more flexible. In some sense, adding dependent types just means allowing dependent,
-relevant quantification -- that is, an argument that can be mentioned in a type and inspected at runtime. (Singletons allow
-us to simulate dependent types by linking a dependent, irrelevant argument (``forall a``) with a non-dependent, relevant one (``Sing a``).)
+These all exist in Haskell today, albeit in ways that may be hard to
+disentangle. Just about all dependent quantification is both irrelevant and
+invisible. (Exceptions: see `#81`_ and in type families.) Matchability is all
+tied in with datatype declaration. Yet there's no reason we can't make these
+more flexible. In some sense, adding dependent types just means allowing
+dependent, relevant quantification -- that is, an argument that can be
+mentioned in a type and inspected at runtime. (Singletons allow us to simulate
+dependent types by linking a dependent, irrelevant argument (``forall a``)
+with a non-dependent, relevant one (``Sing a``).)
 
-Visibility is solely about programmer convenience: we could live without invisible arguments, but surely it would be annoying to
-have to say ``id Int 5`` every time.
+Visibility is solely about programmer convenience: we could live without
+invisible arguments, but surely it would be annoying to have to say
+``id Int 5`` every time.
 
-Matchability is about type inference (mostly; see `GHC#7205
-<https://ghc.haskell.org/trac/ghc/ticket/7205>`_ which describes a feature
+Matchability is about type inference (mostly; see
+`GHC#7205 <https://ghc.haskell.org/trac/ghc/ticket/7205>`_ which describes a feature
 requiring matchability in Core). When we know, say, ``m a ~ Maybe Int``, can
 we conclude ``m ~ Maybe`` and ``a ~ Int``? This is essential for, say, monadic
 code to continue to be accepted. Having a first-class notion of matchability
 is needed in order to have partially-applied type-level operations, which in
-turn allow proper functional programming in types. See proposal `#52 <https://github.com/ghc-proposals/ghc-proposals/pull/52>`_
-for more discussion.
+turn allow proper functional programming in types. See proposal
+`#52 <https://github.com/ghc-proposals/ghc-proposals/pull/52>`_ for more discussion.
 
-All these axes are orthogonal. However, having something that's both irrelevant and non-dependent is useless, and so is not
-included in the plan.
+All these axes are orthogonal. However, having something that's both
+irrelevant and non-dependent is useless, and so is not included in the plan.
 
-Separately from reserving syntax for all the quantifiers, this proposal suggests using ``pi`` and ``'->`` to more accurately
-describe existing features:
+Separately from reserving syntax for all the quantifiers, this proposal
+suggests using ``pi`` and ``'->`` to more accurately describe existing
+features:
 
-1. Type constructors use *relevant* quantification for all their arguments. Consider ``data Proxy k (a :: k) = P``. Note that
-   the kind argument is visible here for easy reference. Is ``Proxy Type`` distinct from ``Proxy (Type -> Type)``? Could a type
-   family match on these and then compute based on the difference between ``Type`` and ``Type -> Type``? Surely, yes. That
-   means that the kind ``k`` is quantified *relevantly*. Accordingly, because ``pi`` is the relevant counterpart to ``forall``,
-   we really should use ``pi`` in type constructor kinds: ``data Proxy :: pi k -> k -> Type`` (or, if we want the kind to
-   be invisible, ``data ProxyInvis :: pi k. k -> Type``).
+1. Type constructors use *relevant* quantification for all their arguments.
+   Consider ``data Proxy k (a :: k) = P``. Note that the kind argument is
+   visible here for easy reference. Is ``Proxy Type`` distinct from
+   ``Proxy (Type -> Type)``? Could a type family match on these and then compute based
+   on the difference between ``Type`` and ``Type -> Type``? Surely, yes. That
+   means that the kind ``k`` is quantified *relevantly*. Accordingly, because
+   ``pi`` is the relevant counterpart to ``forall``, we really should use
+   ``pi`` in type constructor kinds: ``data Proxy :: pi k -> k -> Type`` (or,
+   if we want the kind to be invisible,
+   ``data ProxyInvis :: pi k. k -> Type``).
 
-2. As described above in the part introducing matchability data constructor arguments are matchable (as are type constructor
-   arguments). Thus, they should be able to use the matchable arrow ``'->``.
+2. As described above in the part introducing matchability data constructor
+   arguments are matchable (as are type constructor arguments). Thus, they
+   should be able to use the matchable arrow ``'->``.
 
 Proposed Change Specification
 -----------------------------
 
 **Extension:**
 
-Introduce a new GHC extension, ``-XDependentTypes``. This extension would be a catchall for the dependent features being
-proposed here and elsewhere. It will be expected that this extension is unstable for a few years, and we make no guarantees
-about backward compatibility. By introducing one new extension, we avoid the need for many extensions for different slices
-of the Dependent Haskell feature set.
+Introduce a new GHC extension, ``-XDependentTypes``. This extension would be a
+catchall for the dependent features being proposed here and elsewhere. It will
+be expected that this extension is unstable for a few years, and we make no
+guarantees about backward compatibility. By introducing one new extension, we
+avoid the need for many extensions for different slices of the Dependent
+Haskell feature set.
 
 **Lexical Syntax:**
 
-1. Introduce a new keyword ``pi``, syntactically identical in behavior to ``forall``. With ``-XUnicodeSyntax``, users
-   could write |pi| (Unicode U+220F) instead of ``pi``. Note that this character is not the Greek capital letter |greekpi|,
-   (Unicode U+3A0). This new keyword would exist only with ``-XDependentTypes``.
+1. Introduce a new keyword ``pi``, syntactically identical in behavior to
+   ``forall``. With ``-XUnicodeSyntax``, users could write |pi| (Unicode
+   U+220F) instead of ``pi``. Note that this character is not the Greek
+   capital letter |greekpi|, (Unicode U+3A0). This new keyword would exist
+   only with ``-XDependentTypes``.
 
 .. |pi| unicode:: U+220F .. \prod operator
 .. |greekpi| unicode:: U+3A0 .. Greek Π
 
-2. Introduce a new type-level operator ``'->``, syntactically identical in behavior (and fixity) to ``->``.
-   In keeping with current treatment of the ``'`` prefix, it is allowed (but discouraged)
-   to separate the ``'`` from the ``->`` with whitespace. This new operator would exist regardless of the ``-XDependentTypes``
-   extension.
+2. Introduce a new type-level operator ``'->``, syntactically identical in
+   behavior (and fixity) to ``->``. In keeping with current treatment of the
+   ``'`` prefix, it is allowed (but discouraged) to separate the ``'`` from
+   the ``->`` with whitespace. This new operator would exist regardless of the
+   ``-XDependentTypes`` extension.
 
 3. Introduce ``'=>`` with the same syntactic behavior as ``=>``.
 
-4. Allow ``'`` to be a prefix to the ``pi`` and ``forall`` quantifiers. Syntactically, ``'pi`` and ``'forall`` are
-   identical to ``pi`` and ``forall``.
+4. Allow ``'`` to be a prefix to the ``pi`` and ``forall`` quantifiers.
+   Syntactically, ``'pi`` and ``'forall`` are identical to ``pi`` and
+   ``forall``.
 
-5. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of `#81`_.) The new syntax would be
-   enabled by ``-XDependentTypes``.
+5. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of
+   `#81`_.) The new syntax would be enabled by ``-XDependentTypes``.
 
 **Semantics:**
 
-Note that the proposed semantics are not the full meaning of these constructs, as this proposal does *not* cover
-all of Dependent Haskell. Instead, the semantics are meant to allow the new syntax to be used with existing constructs.
+Note that the proposed semantics are not the full meaning of these constructs,
+as this proposal does *not* cover all of Dependent Haskell. Instead, the
+semantics are meant to allow the new syntax to be used with existing
+constructs.
 
 1. In type constructor kinds (e.g., ``data T :: <right here>``), allow the use
    of ``pi`` instead of ``forall``. That is ``data Proxy :: pi k. k -> Type``
@@ -150,35 +192,41 @@ all of Dependent Haskell. Instead, the semantics are meant to allow the new synt
 
 2. Any other use of the ``pi`` keyword is an error.
 
-3. The matchable arrows ``'->`` and ``'=>`` are allowed in type constructor kinds and GADT-style
-   data constructor types with ``-XDependentTypes``.
-   The meaning of these new constructs is identical to the meaning of the old ones. A new warning
-   flag ``-Wmatchable-arrows`` (not bundled in any warning group) would warn if an unmatchable arrow
-   ``->`` is used in either place (in a non-higher-order situation).
+3. The matchable arrows ``'->`` and ``'=>`` are allowed in type constructor
+   kinds and GADT-style data constructor types with ``-XDependentTypes``. The
+   meaning of these new constructs is identical to the meaning of the old
+   ones. A new warning flag ``-Wmatchable-arrows`` (not bundled in any warning
+   group) would warn if an unmatchable arrow ``->`` is used in either place
+   (in a non-higher-order situation).
 
-4. The matchable arrow ``'->`` is *required* (with ``-XDependentTypes``)
-   in kinds. It is allowed also with ``-XKindSignatures`` (but not required).
-   Thus, ``-XDependentTypes`` requires (and ``-XKindSignatures`` allows) ``return :: forall (m :: Type '-> Type) a. Monad m => a -> m a``
-   (if you are going to write the kind of ``m``, which of course can still be inferred).
-   Here, a "kind" is one that can be syntactically recognized as such, by appearing to
-   the right of a ``::`` in a type. The use of ``'->`` here reflects today's truth that
-   all kind-level operations are matchable. In the future, we might want unmatchable
-   kinds, meaning that ``forall (m :: Type '-> Type). ...`` and ``forall (m :: Type -> Type). ...`` will be different;
-   the former corresponds to what is written today.
+4. The matchable arrow ``'->`` is *required* (with ``-XDependentTypes``) in
+   kinds. It is allowed also with ``-XKindSignatures`` (but not required).
+   Thus, ``-XDependentTypes`` requires (and ``-XKindSignatures`` allows)
+   ``return :: forall (m :: Type '-> Type) a. Monad m => a -> m a`` (if you
+   are going to write the kind of ``m``, which of course can still be
+   inferred). Here, a "kind" is one that can be syntactically recognized as
+   such, by appearing to the right of a ``::`` in a type. The use of ``'->``
+   here reflects today's truth that all kind-level operations are matchable.
+   In the future, we might want unmatchable kinds, meaning that
+   ``forall (m :: Type '-> Type). ...`` and
+   ``forall (m :: Type -> Type). ...`` will be
+   different; the former corresponds to what is written today.
 
-5. ``-Wcompat`` and ``-XKindSignatures`` will warn if ``->`` is used in a way that would
-   be an error under ``-XDependentTypes``.
+5. ``-Wcompat`` and ``-XKindSignatures`` will warn if ``->`` is used in a way
+   that would be an error under ``-XDependentTypes``.
 
 6. Any other use of ``'->`` or ``'=>`` is an error.
 
-7. The rules requiring/allowing ``'`` with ``pi`` and ``forall`` are the same as those with ``->``. Thus
-   the ``'`` is optional in a non-higher-order situation in a type/data constructor kind/type but required
-   in kinds in other contexts.
+7. The rules requiring/allowing ``'`` with ``pi`` and ``forall`` are the same
+   as those with ``->``. Thus the ``'`` is optional in a non-higher-order
+   situation in a type/data constructor kind/type but required in kinds in
+   other contexts.
 
 8. The meaning of the ``->`` after ``pi`` or ``forall`` is given in `#81`_.
 
-9. With ``-XDependentTypes`` on, error messages will use ``pi`` and ``'->``, etc., as appropriate. Without
-   ``-XDependentTypes``, error messages will not change.
+9. With ``-XDependentTypes`` on, error messages will use ``pi`` and ``'->``,
+   etc., as appropriate. Without ``-XDependentTypes``, error messages will not
+   change.
 
 
 Effect and Interactions
@@ -186,43 +234,54 @@ Effect and Interactions
 
 This change is fully backward compatible.
 
-With ``-XDependentTypes`` enabled, code might not be backward compatible, as ``-XDependentTypes`` requires the correct labeling
-of matchable kinds (outside of type/data constructor types, where matchability is assumed for convenience). The ability
-to use ``'->`` with ``-XKindSignatures`` is to prepare for a future where ``->`` and ``'->`` can mix in types. This will
-have to be a breaking change (because ``->`` will line up with its term-level meaning of unmatchable instead of its kind-level
-meaning of matchable), and so we might as well prepare for it now.
+With ``-XDependentTypes`` enabled, code might not be backward compatible, as
+``-XDependentTypes`` requires the correct labeling of matchable kinds (outside
+of type/data constructor types, where matchability is assumed for
+convenience). The ability to use ``'->`` with ``-XKindSignatures`` is to
+prepare for a future where ``->`` and ``'->`` can mix in types. This will have
+to be a breaking change (because ``->`` will line up with its term-level
+meaning of unmatchable instead of its kind-level meaning of matchable), and so
+we might as well prepare for it now.
 
 
 Costs and Drawbacks
 -------------------
 
-This should be fairly easy to implement, as it's largely syntactical. Note that type inference is unaffected, as is Core.
+This should be fairly easy to implement, as it's largely syntactical. Note
+that type inference is unaffected, as is Core.
 
-This proposal increases the surface area of the language in strange ways. Users not looking for trouble won't find any,
-but all this will have to be documented and may be scary. Code written with ``-XDependentTypes`` shouldn't be shown
-to Haskell learners for a bit, so I don't think this will have immediate impact on education. However, there may be
-impacts down the road caused by dependent types.
+This proposal increases the surface area of the language in strange ways.
+Users not looking for trouble won't find any, but all this will have to be
+documented and may be scary. Code written with ``-XDependentTypes`` shouldn't
+be shown to Haskell learners for a bit, so I don't think this will have
+immediate impact on education. However, there may be impacts down the road
+caused by dependent types.
 
 Alternatives
 ------------
 
-* Concrete syntax always has alternatives. Suggest some. In particular, I'm not sure that ``'`` is the right way to denote
-  matchability. But it's nicely backward compatible.
+* Concrete syntax always has alternatives. Suggest some. In particular, I'm
+  not sure that ``'`` is the right way to denote matchability. But it's nicely
+  backward compatible.
 
 * We could reserve the syntax while making it an error to use any of it.
 
-* We could use a different extension name than ``-XDependentTypes``, which promises much more than it delivers. But I favor
-  making the extension now, so it has room to grow.
+* We could use a different extension name than ``-XDependentTypes``, which
+  promises much more than it delivers. But I favor making the extension now,
+  so it has room to grow.
 
-* Change behavior around ``-Wcompat`` to be less annoying. I'm pretty sure I see where all this is going (see my thesis_),
-  but I could well be wrong, and it would be a shame if ``-Wcompat`` told users to do the wrong thing. This is all bleeding
-  edge, after all.
+* Change behavior around ``-Wcompat`` to be less annoying. I'm pretty sure I
+  see where all this is going (see my thesis_), but I could well be wrong, and
+  it would be a shame if ``-Wcompat`` told users to do the wrong thing. This
+  is all bleeding edge, after all.
 
 Unresolved questions
 --------------------
 
+None to my knowledge.
 
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?
+
+I or a close collaborator volunteer to implement. Offers for help are welcome.

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -136,6 +136,44 @@ features:
    arguments are matchable (as are type constructor arguments). Thus, they
    should be able to use the matchable arrow ``'->``.
 
+The Quantifier Table
+--------------------
+
+This proposal includes syntax for distinguishing quantifiers. Here is the
+master table of the quantifiers. The specifics in this proposal are in the
+specification below this table.
+
++------------------+---------------+--------------+-------------------+--------------+
+|                  |               |              |                   |              |
+|Quantifier        | Dependence    | Relevance    | Visibility        | Matchability |
+|                  |               |              |                   |              |
++------------------+---------------+--------------+-------------------+--------------+
+| ``forall a.``    | dependent     | irrelevant   | invisible (unif)  | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``'forall a.``   | dependent     | irrelevant   | invisible (unif)  | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+| ``forall a ->``  | dependent     | irrelevant   | visible           | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``'forall a ->`` | dependent     | irrelevant   | visible           | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+| ``pi a.``        | dependent     | relevant     | invisible (unif)  | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``'pi a.``       | dependent     | relevant     | invisible (unif)  | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+| ``pi a ->``      | dependent     | relevant     | visible           | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``'pi a ->``     | dependent     | relevant     | visible           | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+| ``ty =>``        | non-dependent | relevant     | invisible (solve) | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``ty '=>``       | non-dependent | relevant     | invisible (solve) | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+| ``ty ->``        | non-dependent | relevant     | visible           | unmatchable  |
++------------------+---------------+--------------+-------------------+--------------+
+| ``ty '->``       | non-dependent | relevant     | visible           | matchable    |
++------------------+---------------+--------------+-------------------+--------------+
+
+
 Proposed Change Specification
 -----------------------------
 

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -1,0 +1,228 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_. **After creating the pull request, edit this file again, update the number in the link, and delete this bold sentence.**
+
+.. contents::
+
+``pi``, and other quantifiers for Dependent Haskell
+===================================================
+
+My thesis_ describes (page 59, section 4.2.5) 12
+quantifiers for Dependent Haskell. This proposal reserves syntax for these twelve and allows the use of the new ``pi`` quantifier in
+the one place it makes sense in today's Haskell: in type constructor kinds. It also allows the use of the matchable arrow
+in the places where it makes sense in today's Haskell: in type constructor kinds and data constructor types.
+
+.. _thesis: https://repository.brynmawr.edu/cgi/viewcontent.cgi?article=1074&context=compsci_pubs
+
+Motivation
+------------
+
+The motivation for this proposal is as a step toward full dependent types. In order to retain the type inference and type erasure
+properties of Haskell, it is necessary to consider a variety of axes along which quantifiers may vary. My thesis_ (section 4.2) has
+all the details; that section is approachable without reading other parts of the thesis, and should be helpful to anyone considering
+this proposal. I summarize the main points here, however.
+
+There are four axes quantifiers may vary on:
+
+1. Dependency: Can later parts of a type *depend* on the quantified variable (henceforth, quantifiee). In the type ``forall a. a -> a``,
+   the ``a`` is quantified dependently; the visible argument (of type ``a``) is quantified non-dependently. (We don't say "independent".)
+
+2. Relevance: Can the operation of a construct (function, datatype) use the quantified argument in a computation? This is closely related
+   both to parametricity and type erasure. Consider ``id :: forall a. a -> a``. That function has *two* quantifiers, the ``forall`` and the
+   ``->``; we say it has two arguments. The first argument is irrelevant: the operation of ``id`` can *not* change depending on the choice
+   of the type ``a`` is instantiated at. This is what allows type erasure to work; the choice of type is erased at runtime, because no
+   function can branch on this choice. In contrast the second argument of ``id`` is relevant, as it informs the return value of the function.
+
+   Note that relevance is not only type erasure. A type family argument can either be relevant or irrelevant, based on whether or not
+   the operation of the type family branches on the choice of argument. GHC currently allows only *relevant* quantification in type
+   families (if you write ``type family Id (x :: a) :: a``, then different equations for ``Id`` can check what the choice of ``a`` is),
+   but irrelevant quantification would also be useful, in order to enforce parametricity and avoid coding errors.
+
+   Relevance also affects whether or not a data constructor stores its arguments. When we say ``Just :: forall a. a -> Maybe a``, we mean
+   that a ``Just`` cell contains only one argument, something of type ``a``. The ``Just`` cell does *not* contain the choice of ``a``
+   (``Int``, say). However, we could imagine storing type information explicitly in a way that could be branched on later; that would
+   be relevant quantification. (Today, we can do this with ``Typeable``; in effect, ``f :: forall a. Typeable a => a -> a`` quantifies
+   ``a`` relevantly.)
+
+3. Visibility: Is the argument always supplied when the function is called? Currently, all type arguments are invisible. Term-level
+   arguments of kind ``Type`` are visible, which term-level arguments of kind ``Constraint`` are invisible. Proposal
+   `#81`_ describes adding a syntax for visible dependent quantification,
+   which is already allowed in datatype kinds, albeit indirectly. Visible type application provides a mechanism for overriding the
+   choice of invisible quantification.
+
+.. _`#81`: https://github.com/ghc-proposals/ghc-proposals/pull/81
+
+4. Matchability: If we know ``a b ~ c d``, can we deduce ``a ~ c`` and ``b ~ d``? If so, then both ``a`` and ``c`` are *matchable*.
+   (Matchable = injective and generative.) Datatypes and data constructors are matchable; ordinary functions and type families are
+   not. Note that matchability affects more than just types: the fact that data constructor arguments are matchable is what gives
+   meaning to pattern matching. Think of how silly it would be to pattern match on functions, and you'll get a better appreciation
+   for this. Indeed, the difference between data constructors and ordinary functions is precisely that the former are matchable.
+
+These all exist in Haskell today, albeit in ways that may be hard to disentangle. Just about all dependent quantification is both
+irrelevant and invisible. (Exceptions: see `#81`_ and in type families.) Matchability is all tied in with datatype declaration.
+Yet there's no reason we can't make these more flexible. In some sense, adding dependent types just means allowing dependent,
+relevant quantification -- that is, an argument that can be mentioned in a type and inspected at runtime. (Singletons allow
+us to simulate dependent types by linking a dependent, irrelevant argument (``forall a``) with a non-dependent, relevant one (``Sing a``).)
+
+Visibility is solely about programmer convenience: we could live without invisible arguments, but surely it would be annoying to
+have to say ``id Int 5`` every time.
+
+Matchability is about type inference (mostly; see `GHC#7205
+<https://ghc.haskell.org/trac/ghc/ticket/7205>`_ which describes a feature
+requiring matchability in Core). When we know, say, ``m a ~ Maybe Int``, can
+we conclude ``m ~ Maybe`` and ``a ~ Int``? This is essential for, say, monadic
+code to continue to be accepted. Having a first-class notion of matchability
+is needed in order to have partially-applied type-level operations, which in
+turn allow proper functional programming in types. See proposal `#52 <https://github.com/ghc-proposals/ghc-proposals/pull/52>`_
+for more discussion.
+
+All these axes are orthogonal. However, having something that's both irrelevant and non-dependent is useless, and so is not
+included in the plan.
+
+Separately from reserving syntax for all the quantifiers, this proposal suggests using ``pi`` and ``'->`` to more accurately
+describe existing features:
+
+1. Type constructors use *relevant* quantification for all their arguments. Consider ``data Proxy k (a :: k) = P``. Note that
+   the kind argument is visible here for easy reference. Is ``Proxy Type`` distinct from ``Proxy (Type -> Type)``? Could a type
+   family match on these and then compute based on the difference between ``Type`` and ``Type -> Type``? Surely, yes. That
+   means that the kind ``k`` is quantified *relevantly*. Accordingly, because ``pi`` is the relevant counterpart to ``forall``,
+   we really should use ``pi`` in type constructor kinds: ``data Proxy :: pi k -> k -> Type`` (or, if we want the kind to
+   be invisible, ``data ProxyInvis :: pi k. k -> Type``).
+
+2. As described above in the part introducing matchability data constructor arguments are matchable (as are type constructor
+   arguments). Thus, they should be able to use the matchable arrow ``'->``.
+
+Proposed Change Specification
+-----------------------------
+
+**Extension:**
+
+Introduce a new GHC extension, ``-XDependentTypes``. This extension would be a catchall for the dependent features being
+proposed here and elsewhere. It will be expected that this extension is unstable for a few years, and we make no guarantees
+about backward compatibility. By introducing one new extension, we avoid the need for many extensions for different slices
+of the Dependent Haskell feature set.
+
+**Lexical Syntax:**
+
+1. Introduce a new keyword ``pi``, syntactically identical in behavior to ``forall``. With ``-XUnicodeSyntax``, users
+   could write |pi| (Unicode U+220F) instead of ``pi``. Note that this character is not the Greek capital letter |greekpi|,
+   (Unicode U+3A0). This new keyword would exist only with ``-XDependentTypes``.
+
+.. |pi| unicode:: U+220F .. \prod operator
+.. |greekpi| unicode:: U+3A0 .. Greek Π
+
+2. Introduce a new type-level operator ``'->``, syntactically identical in behavior (and fixity) to ``->``.
+   In keeping with current treatment of the ``'`` prefix, it is allowed (but discouraged)
+   to separate the ``'`` from the ``->`` with whitespace. This new operator would exist regardless of the ``-XDependentTypes``
+   extension.
+
+3. Introduce ``'=>`` with the same syntactic behavior as ``=>``.
+
+4. Allow ``'`` to be a prefix to the ``pi`` and ``forall`` quantifiers. Syntactically, ``'pi`` and ``'forall`` are
+   identical to ``pi`` and ``forall``.
+
+5. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of `#81`_.) The new syntax would be
+   enabled by ``-XDependentTypes``.
+
+**Semantics:**
+
+Note that the proposed semantics are not the full meaning of these constructs, as this proposal does *not* cover
+all of Dependent Haskell. Instead, the semantics are meant to allow the new syntax to be used with existing constructs.
+
+1. In type constructor kinds (e.g., ``data T :: <right here>``), allow the use
+   of ``pi`` instead of ``forall``. That is ``data Proxy :: pi k. k -> Type``
+   would be accepted. With ``-Wcompat`` (and ``-XDependentTypes``), warn on
+   the use of ``forall`` in such a kind. Such ``pi``\-quantification is
+   allowed in a non-prenex position (``data (:~~:) :: pi a. a -> pi b. b ->
+   Type``), but not in a higher-rank position (``data T :: (pi k. k -> Type)
+   -> Type`` would be rejected). The static and dynamic semantics of ``pi``
+   and ``forall`` would be identical.
+
+2. Any other use of the ``pi`` keyword is an error.
+
+3. The matchable arrows ``'->`` and ``'=>`` are allowed in type constructor kinds and GADT-style
+   data constructor types with ``-XDependentTypes``.
+   The meaning of these new constructs is identical to the meaning of the old ones. A new warning
+   flag ``-Wmatchable-arrows`` (not bundled in any warning group) would warn if an unmatchable arrow
+   ``->`` is used in either place (in a non-higher-order situation).
+
+4. The matchable arrow ``'->`` is *required* (with ``-XDependentTypes``)
+   in kinds. It is allowed also with ``-XKindSignatures`` (but not required).
+   Thus, ``-XDependentTypes`` requires (and ``-XKindSignatures`` allows) ``return :: forall (m :: Type '-> Type) a. Monad m => a -> m a``
+   (if you are going to write the kind of ``m``, which of course can still be inferred).
+   Here, a "kind" is one that can be syntactically recognized as such, by appearing to
+   the right of a ``::`` in a type. The use of ``'->`` here reflects today's truth that
+   all kind-level operations are matchable. In the future, we might want unmatchable
+   kinds, meaning that ``forall (m :: Type '-> Type). ...`` and ``forall (m :: Type -> Type). ...`` will be different;
+   the former corresponds to what is written today.
+
+5. ``-Wcompat`` and ``-XKindSignatures`` will warn if ``->`` is used in a way that would
+   be an error under ``-XDependentTypes``.
+
+6. Any other use of ``'->`` or ``'=>`` is an error.
+
+7. The rules requiring/allowing ``'`` with ``pi`` and ``forall`` are the same as those with ``->``. Thus
+   the ``'`` is optional in a non-higher-order situation in a type/data constructor kind/type but required
+   in kinds in other contexts.
+
+8. The meaning of the ``->`` after ``pi`` or ``forall`` is given in `#81`_.
+
+9. With ``-XDependentTypes`` on, error messages will use ``pi`` and ``'->``, etc., as appropriate. Without
+   ``-XDependentTypes``, error messages will not change.
+
+
+Effect and Interactions
+-----------------------
+
+This change is fully backward compatible.
+
+With ``-XDependentTypes`` enabled, code might not be backward compatible, as ``-XDependentTypes`` requires the correct labeling
+of matchable kinds (outside of type/data constructor types, where matchability is assumed for convenience). The ability
+to use ``'->`` with ``-XKindSignatures`` is to prepare for a future where ``->`` and ``'->`` can mix in types. This will
+have to be a breaking change (because ``->`` will line up with its term-level meaning of unmatchable instead of its kind-level
+meaning of matchable), and so we might as well prepare for it now.
+
+
+Costs and Drawbacks
+-------------------
+
+This should be fairly easy to implement, as it's largely syntactical. Note that type inference is unaffected, as is Core.
+
+This proposal increases the surface area of the language in strange ways. Users not looking for trouble won't find any,
+but all this will have to be documented and may be scary. Code written with ``-XDependentTypes`` shouldn't be shown
+to Haskell learners for a bit, so I don't think this will have immediate impact on education. However, there may be
+impacts down the road caused by dependent types.
+
+Alternatives
+------------
+
+* Concrete syntax always has alternatives. Suggest some. In particular, I'm not sure that ``'`` is the right way to denote
+  matchability. But it's nicely backward compatible.
+
+* We could reserve the syntax while making it an error to use any of it.
+
+* We could use a different extension name than ``-XDependentTypes``, which promises much more than it delivers. But I favor
+  making the extension now, so it has room to grow.
+
+* Change behavior around ``-Wcompat`` to be less annoying. I'm pretty sure I see where all this is going (see my thesis_),
+  but I could well be wrong, and it would be a shame if ``-Wcompat`` told users to do the wrong thing. This is all bleeding
+  edge, after all.
+
+Unresolved questions
+--------------------
+
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -10,7 +10,7 @@
 
 .. highlight:: haskell
 
-This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_. **After creating the pull request, edit this file again, update the number in the link, and delete this bold sentence.**
+This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/102>`_.
 
 .. contents::
 

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -150,19 +150,19 @@ specification below this table.
 +------------------+----------------+---------------+-------------------+------------------+
 | ``forall a.``    | dependent      | irrelevant    | invisible (unif)  | unmatchable      |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``'forall a.``   | dependent      | irrelevant    | invisible (unif)  | matchable        |
+| ``forall a '.``  | dependent      | irrelevant    | invisible (unif)  | matchable        |
 +------------------+----------------+---------------+-------------------+------------------+
 | ``forall a ->``  | dependent      | irrelevant    | visible           | unmatchable      |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``'forall a ->`` | dependent      | irrelevant    | visible           | matchable        |
+| ``forall a '->`` | dependent      | irrelevant    | visible           | matchable        |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``pi a.``        | dependent      | relevant      | invisible (unif)  | unmatchable      |
+| ``pi a '.``      | dependent      | relevant      | invisible (unif)  | unmatchable      |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``'pi a.``       | dependent      | relevant      | invisible (unif)  | matchable        |
+| ``pi a '.``      | dependent      | relevant      | invisible (unif)  | matchable        |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``pi a ->``      | dependent      | relevant      | visible           | unmatchable      |
+| ``pi a '->``     | dependent      | relevant      | visible           | unmatchable      |
 +------------------+----------------+---------------+-------------------+------------------+
-| ``'pi a ->``     | dependent      | relevant      | visible           | matchable        |
+| ``pi a '->``     | dependent      | relevant      | visible           | matchable        |
 +------------------+----------------+---------------+-------------------+------------------+
 | ``ty =>``        | non-dependent  | relevant      | invisible (solve) | unmatchable      |
 +------------------+----------------+---------------+-------------------+------------------+
@@ -208,12 +208,12 @@ Haskell feature set.
 
 3. Introduce ``'=>`` with the same syntactic behavior as ``=>``.
 
-4. Allow ``'`` to be a prefix to the ``pi`` and ``forall`` quantifiers.
-   Syntactically, ``'pi`` and ``'forall`` are identical to ``pi`` and
-   ``forall``.
-
-5. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of
+4. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of
    `#81`_.) The new syntax would be enabled by ``-XDependentTypes``.
+
+5. Allow ``'`` to be a prefix to the ``.`` or ``->`` used with ``pi`` and ``forall`` quantifiers.
+   Syntactically, ``'.`` and ``'->`` behave identically to ``.`` and ``->``.
+
 
 **Semantics:**
 
@@ -284,6 +284,12 @@ to be a breaking change (because ``->`` will line up with its term-level
 meaning of unmatchable instead of its kind-level meaning of matchable), and so
 we might as well prepare for it now.
 
+The use of the ``'`` prefix means that more whitespace may have to be used.
+For example, ``forall a'.`` would be ambiguous. Is that declaring a type variable
+``a'`` and quantifying it unmatchably? Or is it declaring a type variable ``a``
+and quantifying it matchably? It would be the former, but this is
+a small soft spot in the syntax.
+
 
 Costs and Drawbacks
 -------------------
@@ -305,16 +311,10 @@ Alternatives
   not sure that ``'`` is the right way to denote matchability. But it's nicely
   backward compatible.
 
-  * One suggestion (from @Saagar-A) is to put the ``'`` on the ``.`` or ``->``
-    in ``pi``\/``forall`` syntax. So, unmatchable ``pi`` and ``forall`` stays
-    as above, but matchable would look like ``pi a '.`` or ``pi a '->`` or
-    ``forall a '.`` or ``forall a '->``. This has a nice parallel with the
-    ``'->`` used for matchable non-dependent quantifiers. However, there is
-    potential confusion if the user writes, e.g., ``forall a'.`` Is that binding
-    ``a'`` unmatchably? Or is it binding ``a`` matchably? I think it would
-    mean the former, and thus the ``'.`` or ``'->`` syntax would require
-    preceding whitespace.
-
+  * An earlier version of this proposal put the ``'`` on matchable, dependent
+    quantification before the keyword (viz. ``'forall a. ...``). The syntax
+    proposed here came from the discussion and was warmly received.
+  
 * We could reserve the syntax while making it an error to use any of it.
 
 * We could use a different extension name than ``-XDependentTypes``, which
@@ -325,6 +325,23 @@ Alternatives
   see where all this is going (see my thesis_), but I could well be wrong, and
   it would be a shame if ``-Wcompat`` told users to do the wrong thing. This
   is all bleeding edge, after all.
+
+* This proposal envisions a future where writing ::
+
+    data Proxy :: pi k. k -> Type
+
+  is accepted. However, it would be more accurate to say ::
+
+    data Proxy :: pi k '. k '-> Type
+
+  because the quantification is really matchable. Both of these declarations are
+  allowed under this proposal, and it is my expectation where both would continue
+  to be accepted in the future. However, it might be better to error on the first
+  version, because the second one really is more accurate. My design decision to
+  allow the first is that most people won't care deeply about matchability, and
+  the matchable nature of a type constructor is an immutable fact (and thus can
+  always be inferred correctly). I would support ``-Wpedantic-matchability``, off
+  by default and not in ``-Wall``, that would warn about the first declaration.
 
 Unresolved questions
 --------------------

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -14,12 +14,13 @@ This proposal is `discussed at this pull request <https://github.com/ghc-proposa
 
 .. contents::
 
-``pi``, and other quantifiers for Dependent Haskell
-===================================================
+Quantifiers for Dependent Haskell
+==================================
 
 My thesis_ describes (page 59, section 4.2.5) 12 quantifiers for Dependent
 Haskell. This proposal reserves syntax for these twelve and allows the use of
-the new ``pi`` quantifier in the one place it makes sense in today's Haskell:
+the new dependent quantifier (proposed to be spelled ``foreach``, not ``pi`` as has been
+previously mooted) in the one place it makes sense in today's Haskell:
 in type constructor kinds. It also allows the use of the matchable arrow in
 the places where it makes sense in today's Haskell: in type constructor kinds
 and data constructor types.
@@ -118,7 +119,7 @@ All these axes are orthogonal. However, having something that's both
 irrelevant and non-dependent is useless, and so is not included in the plan.
 
 Separately from reserving syntax for all the quantifiers, this proposal
-suggests using ``pi`` and ``'->`` to more accurately describe existing
+suggests using ``foreach`` and ``'->`` to more accurately describe existing
 features:
 
 1. Type constructors use *relevant* quantification for all their arguments.
@@ -127,10 +128,10 @@ features:
    ``Proxy (Type -> Type)``? Could a type family match on these and then compute based
    on the difference between ``Type`` and ``Type -> Type``? Surely, yes. That
    means that the kind ``k`` is quantified *relevantly*. Accordingly, because
-   ``pi`` is the relevant counterpart to ``forall``, we really should use
-   ``pi`` in type constructor kinds: ``data Proxy :: pi k -> k -> Type`` (or,
+   ``foreach`` is the relevant counterpart to ``forall``, we really should use
+   ``foreach`` in type constructor kinds: ``data Proxy :: foreach k -> k -> Type`` (or,
    if we want the kind to be invisible,
-   ``data ProxyInvis :: pi k. k -> Type``).
+   ``data ProxyInvis :: foreach k. k -> Type``).
 
 2. As described above in the part introducing matchability data constructor
    arguments are matchable (as are type constructor arguments). Thus, they
@@ -143,35 +144,35 @@ This proposal includes syntax for distinguishing quantifiers. Here is the
 master table of the quantifiers. The specifics in this proposal are in the
 specification below this table.
 
-+------------------+----------------+---------------+-------------------+------------------+
-|                  |                |               |                   |                  |
-| **Quantifier**   | **Dependence** | **Relevance** | **Visibility**    | **Matchability** |
-|                  |                |               |                   |                  |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``forall a.``    | dependent      | irrelevant    | invisible (unif)  | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``forall a '.``  | dependent      | irrelevant    | invisible (unif)  | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``forall a ->``  | dependent      | irrelevant    | visible           | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``forall a '->`` | dependent      | irrelevant    | visible           | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``pi a .``       | dependent      | relevant      | invisible (unif)  | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``pi a '.``      | dependent      | relevant      | invisible (unif)  | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``pi a ->``      | dependent      | relevant      | visible           | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``pi a '->``     | dependent      | relevant      | visible           | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``ty =>``        | non-dependent  | relevant      | invisible (solve) | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``ty '=>``       | non-dependent  | relevant      | invisible (solve) | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``ty ->``        | non-dependent  | relevant      | visible           | unmatchable      |
-+------------------+----------------+---------------+-------------------+------------------+
-| ``ty '->``       | non-dependent  | relevant      | visible           | matchable        |
-+------------------+----------------+---------------+-------------------+------------------+
++-------------------+----------------+---------------+-------------------+------------------+
+|                   |                |               |                   |                  |
+|**Quantifier**     | **Dependence** | **Relevance** | **Visibility**    | **Matchability** |
+|                   |                |               |                   |                  |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``forall a.``     | dependent      | irrelevant    | invisible (unif)  | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``forall a '.``   | dependent      | irrelevant    | invisible (unif)  | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``forall a ->``   | dependent      | irrelevant    | visible           | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``forall a '->``  | dependent      | irrelevant    | visible           | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``foreach a .``   | dependent      | relevant      | invisible (unif)  | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``foreach a '.``  | dependent      | relevant      | invisible (unif)  | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``foreach a ->``  | dependent      | relevant      | visible           | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``foreach a '->`` | dependent      | relevant      | visible           | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``ty =>``         | non-dependent  | relevant      | invisible (solve) | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``ty '=>``        | non-dependent  | relevant      | invisible (solve) | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``ty ->``         | non-dependent  | relevant      | visible           | unmatchable      |
++-------------------+----------------+---------------+-------------------+------------------+
+| ``ty '->``        | non-dependent  | relevant      | visible           | matchable        |
++-------------------+----------------+---------------+-------------------+------------------+
 
 The "(unif)" and "(solve)" notation above indicates how GHC infers invisible arguments.
 For dependent arguments, GHC can use unification. For non-dependent arguments, it
@@ -191,9 +192,9 @@ Haskell feature set.
 
 **Lexical Syntax:**
 
-1. Introduce a new keyword ``pi``, syntactically identical in behavior to
+1. Introduce a new keyword ``foreach``, syntactically identical in behavior to
    ``forall``. With ``-XUnicodeSyntax``, users could write |pi| (Unicode
-   U+220F) instead of ``pi``. Note that this character is not the Greek
+   U+220F) instead of ``foreach``. Note that this character is not the Greek
    capital letter |greekpi|, (Unicode U+3A0). This new keyword would exist
    only with ``-XDependentTypes``.
 
@@ -208,10 +209,10 @@ Haskell feature set.
 
 3. Introduce ``'=>`` with the same syntactic behavior as ``=>``.
 
-4. Allow ``->`` in place of ``.`` after ``pi`` or ``forall``. (This is part of
+4. Allow ``->`` in place of ``.`` after ``foreach`` or ``forall``. (This is part of
    `#81`_.) The new syntax would be enabled by ``-XDependentTypes``.
 
-5. Allow ``'`` to be a prefix to the ``.`` or ``->`` used with ``pi`` and ``forall`` quantifiers.
+5. Allow ``'`` to be a prefix to the ``.`` or ``->`` used with ``foreach`` and ``forall`` quantifiers.
    Syntactically, ``'.`` and ``'->`` behave identically to ``.`` and ``->``.
 
 
@@ -223,20 +224,20 @@ semantics are meant to allow the new syntax to be used with existing
 constructs.
 
 1. In type constructor kinds (e.g., ``data T :: <right here>``), allow the use
-   of ``pi`` instead of ``forall``. That is ``data Proxy :: pi k. k -> Type``
+   of ``foreach`` instead of ``forall``. That is ``data Proxy :: foreach k. k -> Type``
    would be accepted. With ``-Wcompat`` (and ``-XDependentTypes``), warn on
-   the use of ``forall`` in such a kind. Such ``pi``\-quantification is
-   allowed in a non-prenex position (``data (:~~:) :: pi a. a -> pi b. b ->
-   Type``), but not in a higher-rank position (``data T :: (pi k. k -> Type)
-   -> Type`` would be rejected). The static and dynamic semantics of ``pi``
+   the use of ``forall`` in such a kind. Such ``foreach``\-quantification is
+   allowed in a non-prenex position (``data (:~~:) :: foreach a. a -> foreach b. b ->
+   Type``), but not in a higher-rank position (``data T :: (foreach k. k -> Type)
+   -> Type`` would be rejected). The static and dynamic semantics of ``foreach``
    and ``forall`` would be identical.
 
-2. Any other use of the ``pi`` keyword is an error.
+2. Any other use of the ``foreach`` keyword is an error.
 
 3. The matchable arrows ``'->`` and ``'=>`` are allowed in type constructor
    kinds and GADT-style data constructor types with ``-XDependentTypes``. The
    meaning of these new constructs is identical to the meaning of the old
-   ones. A new warning flag ``-Wmatchable-arrows`` (not bundled in any warning
+   ones. A new warning flag ``-Wpedantic-matchability`` (not bundled in any warning
    group) would warn if an unmatchable arrow ``->`` is used in either place
    (in a non-higher-order situation).
 
@@ -258,14 +259,14 @@ constructs.
 
 6. Any other use of ``'->`` or ``'=>`` is an error.
 
-7. The rules requiring/allowing ``'`` with ``pi`` and ``forall`` are the same
+7. The rules requiring/allowing ``'`` with ``foreach`` and ``forall`` are the same
    as those with ``->``. Thus the ``'`` is optional in a non-higher-order
    situation in a type/data constructor kind/type but required in kinds in
    other contexts.
 
-8. The meaning of the ``->`` after ``pi`` or ``forall`` is given in `#81`_.
+8. The meaning of the ``->`` after ``foreach`` or ``forall`` is given in `#81`_.
 
-9. With ``-XDependentTypes`` on, error messages will use ``pi`` and ``'->``,
+9. With ``-XDependentTypes`` on, error messages will use ``foreach`` and ``'->``,
    etc., as appropriate. Without ``-XDependentTypes``, error messages will not
    change.
 
@@ -306,6 +307,24 @@ caused by dependent types.
 
 Alternatives
 ------------
+* For a long time, the keyword for relevant quantification has been thought to
+  be ``pi``. This is the symbol universally used in type theory for such a
+  construct. However, @glaebhoeri rightly points out that this choice of keyword
+  is non-sensical to anyone who is not a type theorist. Adding the keyword
+  to the language will make learners wonder what relevant quantification has
+  to do with the ratio between a circle's circumference and its diameter; when
+  they learn more about this choice, it will confirm their suspicion that Haskell
+  is only for folks with PhDs in programming language theory.
+
+  The suggestion of ``foreach`` (thanks to @int-index) works nicely here.
+  Something that's ``forall`` must work identically for all possible choices:
+  there's one property for all possibilities. Something that's ``foreach``
+  must work for all possible choices, but not identically: there's one
+  property for each possibility. Nothing's ever a perfect fit, but this
+  is pretty good, I think.
+
+  Note that type theorists can still turn on ``-XUnicodeSyntax`` and use
+  |pi|.
 
 * Concrete syntax always has alternatives. Suggest some. In particular, I'm
   not sure that ``'`` is the right way to denote matchability. But it's nicely
@@ -328,11 +347,11 @@ Alternatives
 
 * This proposal envisions a future where writing ::
 
-    data Proxy :: pi k. k -> Type
+    data Proxy :: foreach k. k -> Type
 
   is accepted. However, it would be more accurate to say ::
 
-    data Proxy :: pi k '. k '-> Type
+    data Proxy :: foreach k '. k '-> Type
 
   because the quantification is really matchable. Both of these declarations are
   allowed under this proposal, and it is my expectation where both would continue

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -305,6 +305,105 @@ be shown to Haskell learners for a bit, so I don't think this will have
 immediate impact on education. However, there may be impacts down the road
 caused by dependent types.
 
+In the debate about this proposal, I wanted to write down some of these
+drawbacks about full dependent types (though not, strictly, of the
+features proposed here.) Here are some:
+
+- The language becomes more complicated. Haskell already has a reputation of
+  being impossible to learn, and if dependent types appear everywhere, this
+  reputation will be reinforced, to the language's detriment. I am indeed
+  worried about this. Care will have to be taken by library authors to make
+  dependent types an opt-in experience.
+
+- Error messages might worsen. I'm actually not terribly worried about this,
+  as I believe clever engineering can avoid it. There was not a degradation in error messages from
+  ``-XTypeInType``. Errors still use the words "kind" and "type" to mean different
+  things! Even forgetting about dependent types, I think GHC's error messages
+  need an overhaul, basically to become more like Idris's. (That is,
+  interactive.) Especially if we have interactivity in error messages, then
+  there are even more ways to mitigate the potential trouble of dependent
+  types. Note that Haskell's tradition of language extensions help us here: if
+  a user makes a type error in simple code -- but that code might have a
+  meaning in a dependently typed setting -- then we can use the presence or
+  absence of language extensions to tailor the message. (In particular, we
+  might want to be conservative in recommending that the user enable
+  -XDependentTypes.)
+
+- The abstraction will sometimes leak. The most glaring example of this is
+  when the type of ``($)`` started muttering about levity polymorphism. That was
+  terrible! I do think that, with care, we can avoid this, by continuing to
+  use compiler flags to tailor output and/or adding interactivity to GHC's
+  output.
+
+- The implementation becomes more complicated. Well, yes, though perhaps we'll
+  lose some duplication once GHC no longer has separate Expr and Type types.
+
+Why 12 quantifiers?
+-------------------
+
+A particular pain point of this proposal is that it suggests using *twelve*
+quantifiers in place of Haskell's current three. This section discusses this
+design decision in detail.
+
+First off, to preserve type erasure, we need to distinguish between arguments
+needed at runtime and those that can be erased. Let's see some alternatives to
+the ``forall`` / ``foreach`` distinction proposed here:
+
+* Coq does this through its ``Set`` vs. ``Prop`` mechanism, where erased arguments live
+  in their own sort. Such a route is viable for Haskell, I think, but I've
+  never been much enamored of it, personally. For example, the ``Nat`` in a vector
+  type really can be erased, while ``Nat``\s in many other places can't be, and it
+  seems a shame to need two different ``Nat`` types to pull off this dichotomy.
+
+* Agda uses the term *irrelevant* to describe type indices that are ignored
+  during type equality checks. This is related to the type erasure property,
+  but it's not quite the same thing. It's unclear to me what types Agda can
+  erase, and I don't think Agda gives any solid guarantees as to erasure. (As
+  a language aiming for performance, Haskell needs to provide such a
+  guarantee.)
+
+* Idris does whole-program analysis to determine erasability. I can't imagine
+  this scales well.
+
+The choice I've made in the design of Dependent Haskell is to have the user
+choose whether to keep an argument or not, leading to the ``forall`` / ``foreach``
+distinction. This brings us from 3 quantifiers to 4. In truth, 4 is enough to
+power dependent types! But read on.
+
+All dependently typed languages give a facility for the user to control the
+visibility of arguments. If we want to do the same, we go from 4 quantifiers
+to 6. (We don't go to 8 because the original ``->`` and ``=>`` already differ in
+visibility.) Note, though, that Coq doesn't consider visibility as a feature
+of a type, instead using, essentially, pragmas to control visibility. This has
+some benefits (higher-order usages of functions can't fall over based on
+visibility), but it doesn't seem well-suited for Haskell.
+
+Quite separately, we also will likely want to allow currying in type-level
+operations. Partially-applied type families are currently forbidden because
+doing so would wreak havoc with type inference. The solution I've proposed
+here is a notion of *matchability*, described above and in Section 4.2.4 of my
+thesis_ (which can be read independently of the rest of it).
+It turns out that all previous 6 quantifiers are
+useful in both the matchable and unmatchable varieties, bringing us to 12.
+
+Note that other dependently typed languages don't have a notion of
+matchability. They generally also don't have injective type constructors (you
+can't derive ``a ~ b`` from ``Maybe a ~ Maybe b``) and don't have the guess-free
+type inference Haskell has. Instead, those languages generally rely on
+higher-order unification, which is a best-guess algorithm (as I understand
+it). GHC has stayed away from guessing. We might imagine a future for GHC that
+allows partially-applied type functions without using matchability, but I
+conjecture that any such future would also have to offer weaker guarantees for
+the predictability and stability of type inference. It might be a fruitful
+debate to see which is better -- stable type inference or fewer quantifiers.
+
+My bottom line: I don't like the 12 quantifiers either. And dependent types
+require really only 1 new one. Two more come along for the convenience of
+invisible arguments. And then we have to double for matchability. (Note that
+matchability can be considered quite orthogonally to dependent types -- it has
+even been proposed separately in #52.) Perhaps I've overshot in the design
+here and some healthy debate here can whittle the number down.
+
 Alternatives
 ------------
 * For a long time, the keyword for relevant quantification has been thought to

--- a/proposals/0000-pi.rst
+++ b/proposals/0000-pi.rst
@@ -143,36 +143,39 @@ This proposal includes syntax for distinguishing quantifiers. Here is the
 master table of the quantifiers. The specifics in this proposal are in the
 specification below this table.
 
-+------------------+---------------+--------------+-------------------+--------------+
-|                  |               |              |                   |              |
-|Quantifier        | Dependence    | Relevance    | Visibility        | Matchability |
-|                  |               |              |                   |              |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``forall a.``    | dependent     | irrelevant   | invisible (unif)  | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``'forall a.``   | dependent     | irrelevant   | invisible (unif)  | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``forall a ->``  | dependent     | irrelevant   | visible           | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``'forall a ->`` | dependent     | irrelevant   | visible           | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``pi a.``        | dependent     | relevant     | invisible (unif)  | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``'pi a.``       | dependent     | relevant     | invisible (unif)  | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``pi a ->``      | dependent     | relevant     | visible           | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``'pi a ->``     | dependent     | relevant     | visible           | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``ty =>``        | non-dependent | relevant     | invisible (solve) | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``ty '=>``       | non-dependent | relevant     | invisible (solve) | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``ty ->``        | non-dependent | relevant     | visible           | unmatchable  |
-+------------------+---------------+--------------+-------------------+--------------+
-| ``ty '->``       | non-dependent | relevant     | visible           | matchable    |
-+------------------+---------------+--------------+-------------------+--------------+
++------------------+----------------+---------------+-------------------+------------------+
+|                  |                |               |                   |                  |
+| **Quantifier**   | **Dependence** | **Relevance** | **Visibility**    | **Matchability** |
+|                  |                |               |                   |                  |
++------------------+----------------+---------------+-------------------+------------------+
+| ``forall a.``    | dependent      | irrelevant    | invisible (unif)  | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``'forall a.``   | dependent      | irrelevant    | invisible (unif)  | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
+| ``forall a ->``  | dependent      | irrelevant    | visible           | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``'forall a ->`` | dependent      | irrelevant    | visible           | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
+| ``pi a.``        | dependent      | relevant      | invisible (unif)  | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``'pi a.``       | dependent      | relevant      | invisible (unif)  | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
+| ``pi a ->``      | dependent      | relevant      | visible           | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``'pi a ->``     | dependent      | relevant      | visible           | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
+| ``ty =>``        | non-dependent  | relevant      | invisible (solve) | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``ty '=>``       | non-dependent  | relevant      | invisible (solve) | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
+| ``ty ->``        | non-dependent  | relevant      | visible           | unmatchable      |
++------------------+----------------+---------------+-------------------+------------------+
+| ``ty '->``       | non-dependent  | relevant      | visible           | matchable        |
++------------------+----------------+---------------+-------------------+------------------+
 
+The "(unif)" and "(solve)" notation above indicates how GHC infers invisible arguments.
+For dependent arguments, GHC can use unification. For non-dependent arguments, it
+uses constraint solving.
 
 Proposed Change Specification
 -----------------------------


### PR DESCRIPTION
This proposal reserves syntax for all the quantifiers of Dependent Haskell, along with introducing the `-XDependentTypes` extension and allowing the new quantifiers to be used in very limited contexts. This proposal does *not* actually add dependent types.

[Rendered](https://github.com/goldfirere/ghc-proposals/blob/pi/proposals/0000-pi.rst)