### PR TITLE
Record the implemented version in 0004 and 0009

### DIFF
--- a/proposals/0004-hexFloats.rst
+++ b/proposals/0004-hexFloats.rst
@@ -2,7 +2,7 @@
 
 .. trac-ticket:: https://ghc.haskell.org/trac/ghc/ticket/13126
 
-.. implemented:: No
+.. implemented:: 8.4.1
 
 .. highlight:: haskell
 

--- a/proposals/0009-numeric-underscores.rst
+++ b/proposals/0009-numeric-underscores.rst
@@ -1,6 +1,6 @@
 .. proposal-number:: 0009
 .. trac-ticket:: 14473
-.. implemented:: not yet
+.. implemented:: 8.6.1
 .. highlight:: haskell
 
 This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/76>`_.


### PR DESCRIPTION
Record the implemented version in 0004 and 0009

* 0004 (`HexFloatLiterals`) is implemented in ghc 8.4.1
  * https://phabricator.haskell.org/rGHCb0b80e90c0382a6cdb61c96c860feac27482d6e8

* 0009 (`NumericUnderscores`) is implemented in 8.6.1 (8.5)
  * https://phabricator.haskell.org/rGHC4a13c5b1f4beb53cbf1f3529acdf3ba37528e694
