### PR TITLE
Type applications in patterns

### DIFF
--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -17,7 +17,7 @@ Motivation
 
 ``TypeApplications`` are a convenient and natural way to specifying types of polymorphic functions. Consider::
 
- data Foo a where MkFoo :: forall a, a -> Foo a
+ data Foo a where MkFoo :: forall a. a -> Foo a
  
 With ``TypeApplications``, I can replace the somewhat clumsy ``MkFoo (x :: ty)`` with ``MkFoo @ty x``. Seen this way,
 explicit type applications are merely alternative syntax for type signatures.
@@ -52,7 +52,7 @@ A type variable mentioned in a pattern (in a type signature or a type applicatio
 
 Consider a general data type and constructor::
 
-  data T a where MkT :: forall b, Ctx => ty1 -> T ty2
+  data T a where MkT :: forall b. Ctx => ty1 -> T ty2
   
 (using single variables and types as representatives for, in general, multiple variables and types) and the function definition::
 

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -20,7 +20,7 @@ Motivation
  data Foo a where MkFoo :: forall a. a -> Foo a
  
 With ``TypeApplications``, I can replace the somewhat clumsy ``MkFoo (x :: ty)`` with ``MkFoo @ty x``. Seen this way,
-explicit type applications are merely alternative syntax for type signatures.
+explicit type applications are merely an alternative syntax for type signatures.
 
 At the moment, this only works in terms, but not in patterns: We can use type signatures in patterns
 (if ``PatternSignatures`` or ``ScopedTypeVariables`` are enabled), but not type applications. Given the strong
@@ -32,29 +32,23 @@ but not::
 
     foo (MkFoo @ty x) = …
 
-This proposal fills this gap, by allowing type applications in pattern syntax and specifying it to behave
-“just like type signatures”.
+This proposal fills this gap: It allows type applications in patterns, and specifies them to behave “just like type signatures”.
 
-The intention of the following specification is that the following holds: For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. 
+The intention of the following specification is that the following holds: For a constructor with type like ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. 
 
 Proposed Change Specification
 -----------------------------
 
-When both ``TypeApplications`` and ``PatternSignatures`` are enabled, then type application syntax is
-available in patterns. 
+When both ``TypeApplications`` and ``ScopedtypeVariables`` are enabled, then type application syntax is
+available in constructor patterns.
 
-If ``ScopedTypeVariables`` is enabled, then type applications and type signatures in pattern may mention type variables.
+A pattern ``C @a``, where ``C`` is a data constructor and ``a`` is a type variable that is not yet in scope, matches if ``C`` matches. It brings ``a`` into scope so that ``a`` stands for the corresponding type that was passed to ``C`` upon construction.
 
-A type variable mentioned in a pattern (in a type signature or a type application) that is not already in scope is brought into scope. The scope spans the pattern and the corresponding right-hand side.
+More complicated cases such as ``C @ty``, where ``ty`` is not just a plain type variable, are handled like `type signatures in patterns <https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#pattern-type-sigs>`_. A full and formal description of the scoping and typing rules for this feature can be found in `“Type variable in pattern” by Richard Eisenberg, Joachim Breitner and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>`_.
 
-Typechecking a type application in a pattern follows the same rules as typechecking a pattern signature. This proposal does not propose any changes to the mechanism. In particular
+Like with type signatures in patterns, type variables in type applications in patterns can only bind type variables. If `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ get accepted, then this condition will be lifted also in type applications.
 
-* type variables in type applications in patterns can only bind type variables, just as it is the case for type variables in pattern signatures (unless `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ gets accepted first).
-* patterns are type-checked from left to right. This means when type-checking the type application in a pattern ``(MkT @ty)``, type equatlities from matches further to the left, as well as the type equalities from the context of ``MkT`` itself are in scope, but not type equalities from constructors further to the right (see below for an example).
-
-A more formal description of these rules can be found in `“Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>`_.
-
-An underscore in a type signature or type application in a pattern is not treated as a hole.
+An underscore in a type signature or type application in a pattern is allowed, does not bind any variables, and is not treated as a partial type signature (i.e. does not cause warnings with ``-Wpartial-type-signatures``).
 
 Examples
 --------
@@ -71,79 +65,69 @@ This should type-check, because the following code does::
     foo :: T Bool -> ()
     foo (MkT (_ ::Int _)) = ()
 
+Note that the data constructor expects up-to two type arguments (``forall b a.…``), but we are passing only one type argument, which then corresponds to the *first* type argument of of the data constructor.
 
-A more complex example is this (also inspired by _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050>_)::
+A more complex example is this (also inspired by `#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050>`_)::
 
     data T a where
       MkT1 :: forall a.              T a
       MkT2 :: forall a.              T (a,a)
-      MkT3 :: forall a b. b ~ Int => T a
-      MkT4 :: forall a b.            T a
+      MkT3 :: forall a b.            T a
+      MkT4 :: forall a b. b ~ Int => T a
       MkT5 :: forall a b c. b ~ c => T a
       
     foo :: T (Int, Int) -> ()
     foo (MkT1 @(Int,Int))  = ()
     foo (MkT2 @x)          = (() :: x ~ Int => ())
-    foo (MkT3 @_ @Int)     = ()
-    foo (MkT4 @_ @x)       = (() :: x ~ x => ()) -- (these constraints here just to
-    foo (MkT5 @_ @x @x)    = (() :: x ~ x => ()) --  demonstrate that x is in scope)
+    foo (MkT3 @_ @x)       = (() :: x ~ x => ()) -- nb: x is in scope
+    foo (MkT4 @_ @x)       = (() :: x ~ Int => ())
+    foo (MkT4 @_ @Int)     = ()
+    foo (MkT5 @_ @x @x)    = (() :: x ~ x => ()) 
 
 All of these equations type-check (just like they would if added value arguments of type ``a``, ``b``,... to the constructors and turned the type applications into type signatures).
 
-This example demonstrated why we need to typecheck nested patterns left-to-right::
+Note that the ``@_`` are not treated like partial type signatures.
 
- data T a where
-   T1 :: T Int
-   T2 :: T a
-
- f :: Int -> Char -> Bool
-
- g :: (a, Char, T a) -> blah
- g (x :: Int, (f x -> True), T1) = ..
-
-``g`` must not be accepted: Until we match on ``T1`` we have no idea if ``a ~ Int``.
-And, with Haskell's left-to-right pattern matching we'll
-match the view pattern ``(f x -> True)`` first. It looks ok, because
-you can see that ``x :: Int``; but it will seg-fault in a call of
-``g`` involving ``T2`` and a first argument that is (say) a list.
+Note that it is usually a type error to supply a non-tyvar type, or an in-scope tyvar, in an existential position (e.g. ``MkT3 @_ @Int`` is wrong), unless the data constructor has constraints that equate the existential type variable to some type (as in the equations involving ``MkT4`` and ``MkT5`` above).
 
 Scoping
 ~~~~~~~
 
 The scoping works just like with ``ScopedTypeVariables``. Just for reference, here are some examples of how that feature works now::
 
- f :: forall a b. ([a], b) -> INt
- f (x :: [v], y) = ...
+ f1 :: forall a b. ([a], b) -> Int
+ f1 (x :: [c], y) = ...
 
-brings ``v`` into scope, together with ``a`` and ``b``, which are already in scope.
+brings ``c`` into scope, together with ``a`` and ``b``, which are already in scope. The type variables ``c`` and ``a`` refer to the same type.
 
 But the pattern in::
 
- f :: forall a b. ([a], b) -> INt
- f (x :: [b], y) = ...
+ f2 :: forall a b. ([a], b) -> Int
+ f2 (x :: [b], y) = ...
 
-does not bring ``b`` into scope; here ``b`` refers to the ``b`` from the type signature.
+does not bring ``a`` into scope; here ``b`` refers to the ``b`` from the type signature. This leads to an type error, because in general ``a`` and ``b`` do not refer to the same types.
 
 And the pattern in::
  
- f :: forall a b. ([a], b) -> INt
- f (x :: [v], y :: v) = ...
+ f3 :: forall a b. ([a], b) -> Int
+ f3 (x :: [c], y :: c) = ...
 
-brings one ``v`` into scope; the second occurence in the pattern does not shadow the first one, but rather refers to the same type (this would lead to a type error because ``v`` needs to be equal to both ``a`` and ``b``, but maybe they are not the same).
+brings one ``c`` into scope; the second occurence in the pattern does not shadow the first one, but rather refers to the same type. This example, too,  leads to a type error because ``c`` needs to be equal to both ``a`` and ``b``.
 
-The same rules apply for type applications, and similarly to the last example, the following should not type-check:
+The same rules apply for type applications, so the above examples could be re-written as follows, with identical behaviour::
 
- data T where
-   MkT :: a -> b -> T
-
- f (MkT @p @p a b) = ...
+ f1 :: forall a b. ([a], b) -> Int
+ f1 ((,) @[c] x y) = ...
+ f2 :: forall a b. ([a], b) -> Int
+ f2 ((,) @[b] x y) = ...
+ f3 :: forall a b. ([a], b) -> Int
+ f3 ((,) @[c] @c x y) = ...
 
 Effect and Interactions
 -----------------------
-By motivation our answer the question of “what should ``@ty`` mean in patterns” with an existing feature (type signatures in patterns), we fill an obvious hole in the syntax in a way that is consistent with existing features: The analogy between type applications and type signatures will hold the same way in terms as it would in types.
+We answer the question “what should ``@ty`` mean in patterns” based on an existing feature (“what should ``_ :: ty`` mean in patterns”. This fills an obvious hole in the syntax in a way that is consistent with existing features. In particular analogy between type applications and type signatures that we currently have in terms will now hold the same way in patterns.
 
-Furthermore, type application arguments to ``C`` refer to the corresponding parameters in both terms and types (which
-is not the case for alternative proposals.)
+Furthermore, type application arguments to ``C`` refer to the corresponding parameters in both terms and types, irregardless of whether they are considered universal or existential variables (this is not the case for alternative proposals, as explained below under “Alternatives”).
 
 This proposals allows the binding of existential type variables of constructors, and hence subsumes `Proposal #96 <https://github.com/ghc-proposals/ghc-proposals/pull/96>`_.
 
@@ -151,20 +135,20 @@ Costs and Drawbacks
 -------------------
 Given that the specification is inspired by an existing feature, I expect the implementation cost to be low; mostly work in the parser. I believe that learners will benefit from the homogenousness that this proposals preserves.
 
-A drawback is that it piggy backs on ``ScopedTypeVariables``, which – to some people – has its warts and unprettiness.
-This is a fair concern that needs to be weighed against the cost of introducing a meaning for type applciations that does
-*not* match the behaviour of type signatures.
-
 For users who want this mainly to instantiate existential variables may find that they have to write ``C @_ @x`` to
 go past the universial variables, which is mildly inconvenient. It may be fixed in some cases by changing the order
 of the type variables of ``C``. This is unavoidable if we want to preserve the symmetry between terms and types, though. A mitigation for this is offerend in `proposal #99 (explicit specificity) <https://github.com/ghc-proposals/ghc-proposals/pull/99>`_.
 
+Open Questions
+------------
+* How is the ambiguity with as-patterns resolved?
+
 Alternatives
 ------------
 `Proposal #96 <https://github.com/ghc-proposals/ghc-proposals/pull/96>`_ proposes a variant where ``@x`` may only mention type variables and only existential type variables may be
-bound this way. See there for a in depth discussion; a summary of the main criticism that the proposal at hand tries
+bound this way. See there for an in depth discussion; a summary of the main criticism that the proposal at hand tries
 to fixes preserving the symmetry between type applications in terms and patters, and preserving the analogy between
-type applications and type signatures. Furthermore, it does not introduce new concepts (e.g. the distinction between
+type applications and type signatures, and also in Section 6.1 of `the paper <https://arxiv.org/abs/1806.03476>`_. Furthermore, it does not introduce new concepts (e.g. the distinction between
 existential and universal parameters) to the Haskell programmer.
 
 The existing restriction of ``ScopedTypeVariabes`` that type variables in pattern signatures may only be bound to type variables, and not types, carries over to type variables in type applications. One could discuss lifting this restriction, but this question is completely orthotogonal to the proposal at hand, and should be discussed elsewhere (e.g. in `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ and `ticket _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>`_).

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -35,12 +35,10 @@ but not::
 This proposal fills this gap, by allowing type applications in pattern syntax and specifying it to behave
 “just like type signatures”.
 
+The intention of the following specification is that the following holds: For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. 
+
 Proposed Change Specification
 -----------------------------
-
-Preliminary remark 1: The intention of the following specification is that the following holds: For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. If that is not the case, then this is likely a bug in the specification. In any case, this principle should answer most, if not all, questions about how this proposal should be interpreted.
-
-Preliminary remark 2: The ``ScopedTypeVariables`` is not very well specified. The following attempts to specify it, and may make more programs type check, but should not change the meaning of existing programs. If so, then that is likely a bug in the specification.
 
 When both ``TypeApplications`` and ``PatternSignatures`` are enabled, then type application syntax is
 available in patterns. 
@@ -51,18 +49,15 @@ A type variable mentioned in a pattern (in a type signature or a type applicatio
 
 Typechecking a type application in a pattern follows the same rules as typechecking a pattern signature. This proposal does not propose any changes to the mechanism. In particular
 
-* type variables in type applications in patterns can only bind type variables, just as it is the case for type variables in pattern signatures (unless #128 gets accepted first).
+* type variables in type applications in patterns can only bind type variables, just as it is the case for type variables in pattern signatures (unless `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ gets accepted first).
 * patterns are type-checked from left to right. This means when type-checking the type application in a pattern ``(MkT @ty)``, type equatlities from matches further to the left, as well as the type equalities from the context of ``MkT`` itself are in scope, but not type equalities from constructors further to the right (see below for an example).
 
-A more formal description of these rules can be found in “Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>_.
+A more formal description of these rules can be found in `“Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>_.
 
 An underscore in a type signature or type application in a pattern is not treated as a hole.
 
-Further changes to ``ScopedTypeVariables`` (e.g. _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>_) should apply analogously to type applications in patterns.
-
 Examples
 --------
-
 
 Here is an example (taken from _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>_)::
 
@@ -145,20 +140,16 @@ The same rules apply for type applications, and similarly to the last example, t
 
 Effect and Interactions
 -----------------------
-By reducing the question of “what should ``@ty`` mean in patterns” to an existing feature, we fill an obvious
-hole in the syntax in a way that is consistent with existing features: The analogy between type applications
-and type signatures will hold the same way in terms as it would in types.
+By motivation our answer the question of “what should ``@ty`` mean in patterns” with an existing feature (type signatures in patterns), we fill an obvious hole in the syntax in a way that is consistent with existing features: The analogy between type applications and type signatures will hold the same way in terms as it would in types.
 
-Furthermore, type application arguments to ``C`` refer to the same parameters in both terms and types (which
+Furthermore, type application arguments to ``C`` refer to the corresponding parameters in both terms and types (which
 is not the case for alternative proposals.)
 
-This proposals allows the binding of existential type variables of constructors, and hence subsumes #96.
+This proposals allows the binding of existential type variables of constructors, and hence subsumes `Proposal #96 <https://github.com/ghc-proposals/ghc-proposals/pull/96>`_.
 
 Costs and Drawbacks
 -------------------
-Given that we built upon an existing feature, I expect the implementation cost to be less than with other proposals.
-
-I believe that learners will benefit from the homogenousness that this proposals preserves.
+Given that the specification is inspired by an existing feature, I expect the implementation cost to be low; mostly work in the parser. I believe that learners will benefit from the homogenousness that this proposals preserves.
 
 A drawback is that it piggy backs on ``ScopedTypeVariables``, which – to some people – has its warts and unprettiness.
 This is a fair concern that needs to be weighed against the cost of introducing a meaning for type applciations that does
@@ -176,8 +167,4 @@ to fixes preserving the symmetry between type applications in terms and patters,
 type applications and type signatures. Furthermore, it does not introduce new concepts (e.g. the distinction between
 existential and universal parameters) to the Haskell programmer.
 
-The existing restriction of ``ScopedTypeVariabes`` that type variables in pattern signatures may only be bound to type variables, and not types, carries over to type variables in type applications. One could discuss lifting this restriction, but this question is completely orthotogonal to the proposal at hand, and should be discussed elsewhere (e.g. in (e.g. _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>_).
-
-Unresolved questions
---------------------
-This is a very naive attempt at giving ``ScopedTypeVariables`` (and hence this feature) a formal specification, and I am happy to refine it.
+The existing restriction of ``ScopedTypeVariabes`` that type variables in pattern signatures may only be bound to type variables, and not types, carries over to type variables in type applications. One could discuss lifting this restriction, but this question is completely orthotogonal to the proposal at hand, and should be discussed elsewhere (e.g. in `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ and `ticket _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>`_).

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -50,10 +50,11 @@ If ``ScopedTypeVariables`` is enabled, then type applications and type signature
 A type variable mentioned in a pattern (in a type signature or a type application) that is not already in scope is brought into scope. The scope spans the pattern and the corresponding right-hand side.
 
 Typechecking a type application in a pattern follows the same rules as typechecking a pattern signature. This proposal does not propose any changes to the mechanism. In particular
+
 * type variables in type applications in patterns can only bind type variables, just as it is the case for type variables in pattern signatures (unless #128 gets accepted first).
 * patterns are type-checked from left to right. This means when type-checking the type application in a pattern ``(MkT @ty)``, type equatlities from matches further to the left, as well as the type equalities from the context of ``MkT`` itself are in scope, but not type equalities from constructors further to the right (see below for an example).
 
-An attempt to formalize these rules is spelled out in <https://www.overleaf.com/15743151qmfpncmjfcks>, which uses the syntax of the `OutsideIn paper <https://www.microsoft.com/en-us/research/publication/outsideinx-modular-type-inference-with-local-assumptions/>`_. It gives type-checking rules for plain Haskell (with GADTs), Haskell+PatternSignatures, Haskell+PatternSignatures+TypeApplications (which is this proposal) and, just for reference, Haskell+PatternSignatures+TypeApplications+#15050.
+A more formal description of these rules can be found in “Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>_.
 
 An underscore in a type signature or type application in a pattern is not treated as a hole.
 

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -40,7 +40,16 @@ Proposed Change Specification
 -----------------------------
 
 When both ``TypeApplications`` and ``ScopedtypeVariables`` are enabled, then type application syntax is
-available in constructor patterns.
+available in constructor patterns. Concretely, the grammar for constructor pattern is extended from::
+
+  pat   → gcon apat1 … apatk --  (arity gcon  =  k, k ≥ 1) 
+        … 
+
+to::
+
+  pat   → gcon tyapp1 … tyappn  apat1 … apatk --  (arity gcon  =  k, k ≥ 1, n ≥ 0)
+        …
+  tyapp → @ atype
 
 A pattern ``C @a``, where ``C`` is a data constructor and ``a`` is a type variable that is not yet in scope, matches if ``C`` matches. It brings ``a`` into scope so that ``a`` stands for the corresponding type that was passed to ``C`` upon construction.
 
@@ -131,6 +140,13 @@ Furthermore, type application arguments to ``C`` refer to the corresponding para
 
 This proposals allows the binding of existential type variables of constructors, and hence subsumes `Proposal #96 <https://github.com/ghc-proposals/ghc-proposals/pull/96>`_.
 
+There is almost a syntactic ambiguity with as-patterns, but in fact there is not: The grammar of as-pattern is::
+
+  apat 	→ 	var [ @ apat] 	    (as pattern) 
+        …
+        
+so it always has a variable on its left, whereas a type application is always headed by a constructor.
+
 Costs and Drawbacks
 -------------------
 Given that the specification is inspired by an existing feature, I expect the implementation cost to be low; mostly work in the parser. I believe that learners will benefit from the homogenousness that this proposals preserves.
@@ -138,6 +154,8 @@ Given that the specification is inspired by an existing feature, I expect the im
 For users who want this mainly to instantiate existential variables may find that they have to write ``C @_ @x`` to
 go past the universial variables, which is mildly inconvenient. It may be fixed in some cases by changing the order
 of the type variables of ``C``. This is unavoidable if we want to preserve the symmetry between terms and types, though. A mitigation for this is offerend in `proposal #99 (explicit specificity) <https://github.com/ghc-proposals/ghc-proposals/pull/99>`_.
+
+A possible future proposal that extends as-patterns to allow patterns on both sides of the `@` would now introduce ambiguities, e.g. in `Nothing @ a`.
 
 Open Questions
 ------------

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -155,7 +155,17 @@ For users who want this mainly to instantiate existential variables may find tha
 go past the universial variables, which is mildly inconvenient. It may be fixed in some cases by changing the order
 of the type variables of ``C``. This is unavoidable if we want to preserve the symmetry between terms and types, though. A mitigation for this is offerend in `proposal #99 (explicit specificity) <https://github.com/ghc-proposals/ghc-proposals/pull/99>`_.
 
-A possible future proposal that extends as-patterns to allow patterns on both sides of the `@` would now introduce ambiguities, e.g. in `Nothing @ a`.
+A possible future proposal that extends as-patterns to allow patterns on both sides of the `@` would now introduce ambiguities, e.g. in `Nothing @ a`, and will require disambiguation. This disambiguation could be
+
+* extra parenthesis: ``(Nothing) @ a`` is an as-pattern, vs. ``Nothing @ a`` is a type application.
+* using a helper pattern synonym::
+
+        pattern And p q = p@q
+
+        foo (Nothing `And` a) = …
+  
+  These questions will have to be resolve if and when such extended as-patterns are requested.
+
 
 Open Questions
 ------------
@@ -169,4 +179,4 @@ to fixes preserving the symmetry between type applications in terms and patters,
 type applications and type signatures, and also in Section 6.1 of `the paper <https://arxiv.org/abs/1806.03476>`_. Furthermore, it does not introduce new concepts (e.g. the distinction between
 existential and universal parameters) to the Haskell programmer.
 
-The existing restriction of ``ScopedTypeVariabes`` that type variables in pattern signatures may only be bound to type variables, and not types, carries over to type variables in type applications. One could discuss lifting this restriction, but this question is completely orthotogonal to the proposal at hand, and should be discussed elsewhere (e.g. in `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ and `ticket _#15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>`_).
+The existing restriction of ``ScopedTypeVariabes`` that type variables in pattern signatures may only be bound to type variables, and not types, carries over to type variables in type applications. One could discuss lifting this restriction, but this question is completely orthotogonal to the proposal at hand, and should be discussed elsewhere (e.g. in `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ and `ticket #15050 <https://ghc.haskell.org/trac/ghc/ticket/15050#comment:10>`_).

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -1,0 +1,101 @@
+Type Applications in Patterns
+=============================
+
+.. proposal-number::
+.. trac-ticket::
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+We have ``TypeApplications`` in terms. This proposal brings them to patterns in a way that preserves analogy to type signatures.
+
+
+Motivation
+------------
+
+``TypeApplications`` are a convenient and natural way to specifying types of polymorphic functions. Consider::
+
+ data Foo a where MkFoo :: forall a, a -> Foo a
+ 
+With ``TypeApplications``, I can replace the somewhat clumsy ``MkFoo (x :: ty)`` with ``MkFoo @ty x``. Seen this way,
+explicit type applications are merely alternative syntax for type signatures.
+
+At the moment, this only works in terms, but not in patterns: We can use type signatures in patterns
+(if ``PatternSignatures`` or ``ScopedTypeVariables`` are enabled), but not type applications. Given the strong
+relation between these syntactic forms, this is odd – why can I write::
+
+    foo (MkFoo (x :: ty)) = …
+   
+but not::
+
+    foo (MkFoo @ty x) = …
+
+This proposal fills this gap, by allowing type applications in pattern syntax and specifying it to behave
+“just like type signatures”.
+
+Proposed Change Specification
+-----------------------------
+
+When both ``TypeApplications`` and ``PatternSignatures`` are enabled, then type application syntax is
+available in patterns.
+
+The meaning of ``C @_`` is simply ``C``, i.e. underscores in type applications in patterns are not treated as holes.
+
+For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` is specified to
+coincide with the existing form ``C (x :: ty)``.
+
+Equivalently, for a constructor with type ``C :: forall a. Proxy a -> …`` the meaning of ``C @ty x`` is specified to
+coincide with the existing form ``C (x :: Proxy ty)``.
+
+For a constructor with a type variable ``a`` that is not the type of any term argument, the meaning is 
+what it would be if it had corresponding proxy arguments.
+
+If ``ScopedTypeVariables`` is enabled, then ``ty`` may bring type variables into scope; the same rules
+as for ``ScopedTypeVariables`` apply.
+
+Further changes to ``ScopedTypeVariables`` will apply analogously to type applications in patterns.
+
+
+Effect and Interactions
+-----------------------
+By reducing the question of “what should ``@ty`` mean in patterns” to an existing feature, we fill an obvious
+hole in the syntax in a way that is consistent with existing features: The analogy between type applications
+and type signatures will hold the same way in terms as it would in types.
+
+Furthermore, type application arguments to ``C`` refer to the same parameters in both terms and types (which
+is not the case for alternative proposals.)
+
+This proposals allows the binding of existential type variables of constructors, and hence subsumes #96.
+
+Costs and Drawbacks
+-------------------
+Given that we built upon an existing feature, I expect the implementation cost to be less than with other proposals.
+
+I believe that learners will benefit from the homogenousness that this proposals preserves.
+
+A drawback is that it piggy backs on ``ScopedTypeVariables``, which – to some people – has its warts and unprettiness.
+This is a fair concern that needs to be weighed against the cost of introducing a meaning for type applciations that does
+*not* matc the behaviour of type signatures.
+
+For users who want this mainly to instantiate existential variables may find that they have to write ``C @_ @x`` to
+go past the universial variables, which is mildly inconvenient. It may be fixed in some cases by changing the order
+of the type variables of ``C``. This is unavoidable if we want to preserve the symmetry between terms and types, though.
+
+Alternatives
+------------
+Proposal #96 proposes a variant where ``@x`` may only mention type variables and only existential type variables may be
+bound this way. See there for a in depth discussion; a summary of the main criticism that the proposal at hand tries
+to fixes preserving the symmetry between type applications in terms and patters, and preserving the analogy between
+type applications and type signatures. Furthermore, it does not introduce new concecpts (e.g. the distinction between
+existential and universal parameters) to the Haskell programmer.
+
+
+Unresolved questions
+--------------------
+The specification is a bit vague for constructors who have type variables that are neither the type of a term
+parameter, nor the argument to a proxy type in a the type of a term parameter. I hope the intent is still clear, 
+but I would appreciate help phrasing it in a more satisfying way.

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -52,7 +52,7 @@ Typechecking a type application in a pattern follows the same rules as typecheck
 * type variables in type applications in patterns can only bind type variables, just as it is the case for type variables in pattern signatures (unless `Proposal #128 <https://github.com/ghc-proposals/ghc-proposals/pull/128>`_ gets accepted first).
 * patterns are type-checked from left to right. This means when type-checking the type application in a pattern ``(MkT @ty)``, type equatlities from matches further to the left, as well as the type equalities from the context of ``MkT`` itself are in scope, but not type equalities from constructors further to the right (see below for an example).
 
-A more formal description of these rules can be found in `“Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>_.
+A more formal description of these rules can be found in `“Type variable in pattern” by Richard Eisenberg, Joachim Breitner  and Simon Peyton Jones <https://arxiv.org/abs/1806.03476>`_.
 
 An underscore in a type signature or type application in a pattern is not treated as a hole.
 

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -38,7 +38,7 @@ This proposal fills this gap, by allowing type applications in pattern syntax an
 Proposed Change Specification
 -----------------------------
 
-Preliminary remark 1: The intention of the following specification is that the following holds: For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. If that is not the case, then this is likely a bug in the specification.
+Preliminary remark 1: The intention of the following specification is that the following holds: For a constructor with type ``C :: forall a. a -> …`` the meaning of ``C @ty x`` should coincide with the existing form ``C (x :: ty)``. If that is not the case, then this is likely a bug in the specification. In any case, this principle should answer most, if not all, questions about how this proposal should be interpreted.
 
 Preliminary remark 2: The ``ScopedTypeVariables`` is not very well specified. The following attempts to specify it, and may make more programs type check, but should not change the meaning of existing programs. If so, then that is likely a bug in the specification.
 
@@ -50,21 +50,7 @@ If ``ScopedTypeVariables`` is enabled, then type applications and type signature
 
 A type variable mentioned in a pattern (in a type signature or a type application) that is not already in scope is brought into scope. The scope contains the pattern and the corresponding right-hand side.
 
-Consider a general data type and constructor::
-
-  data T a where MkT :: forall b. Ctx => ty1 -> T ty2
-  
-(using single variables and types as representatives for, in general, multiple variables and types) and the function definition::
-
-   foo :: T ty3 -> …
-   foo (MkT @ty4 (x :: ty5)) = e
-
-and assume that ``free_ty_vars(ty4, ty5) = {c}``. This pattern is well-typed if, for a fresh rigid variable ``b'``, there exists a type ``ty6`` (which may depend on ``b'``) such that type equations
-
-* ``ty2[b'/b] ~ ty3, Ctx[b'/b] => ty4[ty6/c] = b'`` and
-* ``ty2[b'/b] ~ ty3, Ctx[b'/b] => ty5[ty6/c] = ty1[b'/b]``
-
-hold. The right-hand-side ``e`` is then checked in a contex that contains the type variables  ``b'``, ``c``, the equality ``c ~ ty6`` and the typing judgement ``x :: ty1[b'/b]``.
+The typing rule for (non-nested) case expressions is spelled out in <https://www.overleaf.com/15743151qmfpncmjfcks>, which uses the syntax of the `OutsideIn paper <https://www.microsoft.com/en-us/research/publication/outsideinx-modular-type-inference-with-local-assumptions/>`_.
 
 An underscore in a type signature or type application in a pattern is not treated as a hole.
 

--- a/proposals/type-applications-in-patterns.rst
+++ b/proposals/type-applications-in-patterns.rst
@@ -5,9 +5,7 @@ Type Applications in Patterns
 .. trac-ticket::
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/126>`_.
 .. sectnum::
 .. contents::
 


### PR DESCRIPTION
[Rendered](https://github.com/ghc-proposals/ghc-proposals/blob/type-applications-in-patterns/proposals/type-applications-in-patterns.rst)

This proposal gives type applications (`@…`) meaning in patterns, by making sure they behave like type signatures.

This happens to also allow binding existential type variables, and hence subsumes #96. But that is a side-product: I believe that the proposal has merits on its own and should “obviously be the case” anyways. 