### PR TITLE
The deprecate STM invariants proposal will debut in 8.6

### DIFF
--- a/proposals/0011-deprecate-stm-invariants.rst
+++ b/proposals/0011-deprecate-stm-invariants.rst
@@ -3,7 +3,7 @@ Deprecating STM invariant mechanism
 
 .. proposal-number:: 11
 .. trac-ticket:: `#14324 <https://ghc.haskell.org/trac/ghc/ticket/14324>`_
-.. implemented:: Not yet
+.. implemented:: 8.6
 .. highlight:: haskell
 .. sectnum::
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/77>`_.


### PR DESCRIPTION
See http://git.haskell.org/ghc.git/commit/a122d4fdd0a5858e44f9d3be90a258903e0288b2 .