### PR TITLE
Extension to Infix Syntax, inspired by PureScript

### DIFF
--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -83,7 +83,8 @@ Costs and Drawbacks
 -------------------
 
 The only cost I can see as of right now is the work to implement this.
-Admittedly I do not know how.
+Admittedly I do not know how, but I would be willing to do the work if given
+guidance.
 
 Alternatives
 ------------

--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -40,6 +40,7 @@ from the use of ``<>`` do not confusingly reference ``app``. The top-level bindi
 would look like this:
 
 .. code-block:: haskell
+  
   infixr 5 <>
 
   (<>) :: Semigroup a => a -> a -> a

--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -31,7 +31,7 @@ Consider the following typeclass, and associated infix operator:
   (<>) :: Semigroup a => a -> a -> a
   (<>) = app
 
-With -XInfixAs enabled, one <i>must</i> write the following instead:
+With -XInfixAs enabled, one must write the following instead:
 
 .. code-block:: haskell
   

--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -35,6 +35,16 @@ With this extension to the syntax, one could write the following:
   foo :: String
   foo = "Hello " <> "World!"
 
+This will actually generate a top-level binding, so that error messages arising
+from the use of ``<>`` do not confusingly reference ``app``. The top-level binding
+would look like this:
+
+.. code-block:: haskell
+  infixr 5 <>
+
+  (<>) :: Semigroup a => a -> a -> a
+  (<>) = app
+
 Another example:
 
 .. code-block:: haskell

--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -1,0 +1,87 @@
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/141>`_.
+
+.. contents::
+
+Extensions to Infix Syntax
+==========================
+
+This is a proposal to extend Haskell's ``infix`` syntax to include a feature of PureScript's.
+
+Consider the following typeclass:
+
+.. code-block:: haskell
+
+  class Semigroup a where
+    app :: a -> a -> a
+
+With this extension to the syntax, one could write the following:
+
+.. code-block:: haskell
+  
+  infixr 5 app as <>
+
+  foo :: String
+  foo = "Hello " <> "World!"
+
+Another example:
+
+.. code-block:: haskell
+
+  append :: [a] -> [a] -> [a]
+  append xs [] = xs
+  append [] ys = ys
+  append (x:xs) ys = x : append xs ys
+
+  infixr 5 append as ++
+
+  oneToThree :: [Int]
+  oneToThree = [1,2,3]
+
+  fourToSix :: [Int]
+  fourToSix = [4,5,6]
+
+  oneToSix :: [Int]
+  oneToSix = oneToThree ++ fourToSix
+
+Motivation
+------------
+
+This proposal makes it easier to define infix synonyms for binary operators/functions,
+a relatively common pattern employed by library authors.
+
+Proposed Change Specification
+-----------------------------
+
+Effect and Interactions
+-----------------------
+
+I don't know of any interactions other than making it syntactically simpler to define infix functions.
+
+Costs and Drawbacks
+-------------------
+
+The only cost I can see as of right now is the work to implement this.
+Admittedly I do not know how.
+
+Alternatives
+------------
+
+Unresolved questions
+--------------------
+
+Implementation Plan
+-------------------
+
+Currently Unknown.

--- a/proposals/0141-infix-as.rst
+++ b/proposals/0141-infix-as.rst
@@ -14,30 +14,35 @@ This proposal is `discussed at this pull request <https://github.com/ghc-proposa
 
 .. contents::
 
-Extensions to Infix Syntax
+InfixAs Extension
 ==========================
 
-This is a proposal to extend Haskell's ``infix`` syntax to include a feature of PureScript's.
+This is a proposal for a language extension that provides some benefits to readability and conformity in the declaration of infix operators.
 
-Consider the following typeclass:
+Consider the following typeclass, and associated infix operator:
 
 .. code-block:: haskell
 
   class Semigroup a where
     app :: a -> a -> a
 
-With this extension to the syntax, one could write the following:
+  infixr 5 <>
+
+  (<>) :: Semigroup a => a -> a -> a
+  (<>) = app
+
+With -XInfixAs enabled, one <i>must</i> write the following instead:
 
 .. code-block:: haskell
   
+  class Semigroup a where
+    app :: a -> a -> a
+
   infixr 5 app as <>
 
-  foo :: String
-  foo = "Hello " <> "World!"
-
-This will actually generate a top-level binding, so that error messages arising
-from the use of ``<>`` do not confusingly reference ``app``. The top-level binding
-would look like this:
+For code generation, this will generate a top-level binding, so that error messages arising
+from the use of ``<>`` do not confusingly reference ``app`` (i.e., ``<>`` would not just be a function 'synonym' ala type synonyms).
+The top-level binding would look like this:
 
 .. code-block:: haskell
   
@@ -69,8 +74,7 @@ Another example:
 Motivation
 ------------
 
-This proposal makes it easier to define infix synonyms for binary operators/functions,
-a relatively common pattern employed by library authors.
+The point of this syntax is to ensure that there is no other way to define an operator, which guarantees by construction that all operators will have a corresponding function name, thus avoiding the situation in Haskell where it is sometimes unclear what the canonical pronunciation of an operator is. It also forces you to write a fixitiy declaration for every operator. Enabling this language extension would make operator definitions a compile-time error.
 
 Proposed Change Specification
 -----------------------------
@@ -78,14 +82,13 @@ Proposed Change Specification
 Effect and Interactions
 -----------------------
 
-I don't know of any interactions other than making it syntactically simpler to define infix functions.
+I don't currently know of any.
 
 Costs and Drawbacks
 -------------------
 
 The only cost I can see as of right now is the work to implement this.
-Admittedly I do not know how, but I would be willing to do the work if given
-guidance.
+Admittedly I do not know how, but I would be willing to do the work if given guidance.
 
 Alternatives
 ------------


### PR DESCRIPTION
This is a simple proposal to extend Haskell's `infix` syntax to have similar capabilities as PureScript's.

[Rendered](https://github.com/chessai/ghc-proposals/blob/infix-as/proposals/0141-infix-as.rst)