### PR TITLE
Remove TypeOperators => NoStarIsType "migration"

### DIFF
--- a/proposals/0020-no-type-in-type.rst
+++ b/proposals/0020-no-type-in-type.rst
@@ -291,12 +291,11 @@ One alternative is to have additional *4.f* step in introduction of ``-XStarIsTy
       going against the three-release policy.) Users can re-enable ``-XStarIsType``
       after ``-XTypeOperators`` is enabled if they wish.
 
-This alternative is however problematic. It's intended to help migration,
-but implementation evidence shows it causes more trouble.
-
-For example code using generics (and therefore ``-XTypeOperators``) often
-enough define helper newtypes where ``ConstraintKinds`` is needed,
-with the clause it will be broken:
+This alternative is problematic. It's intended to help migration,
+but implementation evidence shows it causes more trouble. If we consider
+``-XTypeOperators`` as the only enabled extension, then 4.f will
+indeed help migration, but there are a lot of code in the wild
+also enabling ``-XKindSignatures`` where the clause changes semantics.
 
 ::
 
@@ -334,7 +333,8 @@ but in that case it would be better if ``-XTypeOperators`` implied
   data (:>) (a :: k) (b :: Type)
 
 Without the 4.f clause, some code using ``GHC.TypeLits.*`` will need to enable
-``-XNoStarIsType`` explicitly, like
+``-XNoStarIsType`` explicitly. ``-XNoStarIsType`` is required to make
+``* :: Nat -> Nat -> Nat`` usable in the definition of ``cast``.
 
 ::
 

--- a/proposals/0020-no-type-in-type.rst
+++ b/proposals/0020-no-type-in-type.rst
@@ -130,12 +130,6 @@ Proposed Change Specification
       scoping rules. (If ``-XTypeOperators`` is not in effect, use of ``*`` in
       a type will be an error.)
 
-   f. For two releases, ``-XTypeOperators`` will imply ``-XNoStarIsType``, to
-      provide a migration path for code that uses the binary operator ``*``. (After
-      two releases, this code can include ``-XNoStarIsType`` explicitly without
-      going against the three-release policy.) Users can re-enable ``-XStarIsType``
-      after ``-XTypeOperators`` is enabled if they wish.
-
    The ``-XStarIsType`` idea is due to David Feuer, @treeowl.
 
 Effect and Interactions

--- a/proposals/0020-no-type-in-type.rst
+++ b/proposals/0020-no-type-in-type.rst
@@ -186,7 +186,7 @@ Effect and Interactions
     mult _ _ = Proxy
 
   will need to explicitly enable ``-XNoStarIsType``.
-  See `Implication TypeOperators to NoStarIsType`_ for the alternative.
+  See `Have TypeOperators imply NoStarIsType`_ for an alternative.
 
 Costs and Drawbacks
 -------------------
@@ -278,8 +278,8 @@ Alternatives
    alternative. Nevertheless, I'm keeping it in the proposal in case someone wants to
    argue in support of it.
 
-Implication TypeOperators to NoStarIsType
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Have TypeOperators imply NoStarIsType
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 One alternative is to have an additional 4.f step in the Proposed Change Specification section:
 
@@ -293,13 +293,14 @@ This alternative is problematic. It's intended to help migration, but
 implementation evidence shows it causes more trouble.  If the code being
 migrated only enables ``-XTypeOperators``, then 4.f will indeed be helpful, but
 there is a lot of code which also enables ``-XKindSignatures`` in which
-``-XNoStarInType`` changes the semantics. For example code from ``hashable`` library
+``-XNoStarInType`` changes the semantics. For example, this code from the
+``hashable`` library
 
 ::
 
     newtype  Tagged  (s :: * -> *) = Tagged {unTagged :: Int}
 
-fails to compiler with the following error:
+would fail to compile with the following error:
 
 ::
 
@@ -317,9 +318,9 @@ including 4.f would break all of these libraries. While not having 4.f also
 results in some breakage, far fewer libraries in the wild break without 4.f
 than with 4.f, so this was ultimately decided against.
 
-These modules will suddenly have ``-XNoStarIsType`` in effect, meaning that
-their use of ``*`` will refer to a binary operator. These modules have a
-choice of how to proceed. They can either:
+If ``-XTypeOperators`` were to imply ``-XNoStarIsType``, then any code which
+uses ``*`` as kind instead of a binary operator would have to migrate somehow.
+Two migration options are:
 
 1. Declare ``-XStarIsType``. If they ever
    use ``*`` as a binary operator, those uses would have to be qualified


### PR DESCRIPTION
This step was intended to help migration, but emprical evidence
shows it breaks more than it allows to migrate.

As StarIsType change is now merged in master, many packages broke,
which you wouldn't expect: aeson, cassava, cereal to mention some.
They are broken due use of TypeOperators for GHC.Generics code
and authors writing down the kind signatures. There * is no longer
type, which causes compilation failures.

Other packages, which I suspect would break badly are e.g.
servant, which uses TypeOperators and also a lot of kind signatures.

If the extension implication is removed, then I'm able to compile
servant-client & servant-server with only three additions
of {-# LANGUAGE NoStarIsType #-}, two in `basement` and one in `memory`
packages (they genuinely use GHC.TypeLits.*).

Also compilation of `lens` needs only few fixes: lens have one module
using TypeInType, `constraints` uses GHC.TypeLits.*.

One can argue, that the packages where the extension implication
would help, will be broken by other TypeInType related changes anyway.

TL;DR it's less work to go without TypeOperator => NoStarIsType.