### PR TITLE
Unify type-level literals with their equivalent types

### DIFF
--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -104,7 +104,7 @@ For the specific example I used to motivate this change, the implementation of t
 
 ::
 
-    type ValidBS str = (KnownSymbol str, AllValidChars str) 
+    type ValidBS str = (KnownSymbol str, AllValidChars (SymbolToString str))
 
     type family AllValidChars (xs :: String) :: Constraint where
         AllValidChars (x:xs) = If (IsValidChar x) (AllValidChars xs) (TypeError (InvalidCharError x))

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -37,8 +37,6 @@ This is largely motivated by the discussion on ghc-proposals/ghc-proposals#124 i
 
 Proposed Change Specification
 -----------------------------
-The following is relative to the current behavior of ``DataKinds``.
-
 Grammar changes
 ^^^^^^^^^^^^^^^
 The lexical syntax would gain the following new case:

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -91,7 +91,7 @@ A new type family will be added, ``Data.Type.Equality.Cmp``, to provide a unifor
 
 ::
 
-    type family Cmp (m :: a) (n :: a) :: Ordering
+    type family Compare (m :: a) (n :: a) :: Ordering
 
 Here, ``a`` is at least the five literal types, but there are many more implementations that could be added.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -54,10 +54,10 @@ The kinds of type-level literals will be as follows:
 
 ::
 
-    "foo" :: String
+    "foo" :: k1 -- Where 'k1' can be Symbol or String, if OverloadedStrings is enabled. Defaults to Symbol otherwise.
     'f' :: Char
     -123 :: Integer
-    123 :: k -- Where 'k' can be either Integer or Rational
+    123 :: k2 -- Where 'k2' can be Natural, Integer or Rational
     3.14 :: Rational
 
 While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.
@@ -68,6 +68,7 @@ The obvious alternatives are:
 
 * Use a syntactic tweak to show when a positive ``Integer`` rather than a ``Natural`` is desired. This is a poor option because it will mean that the term-level and type-level syntax will become *less* similar, not more. This goes against a key aim of the proposal.
 * Don't have pure syntax for integer literals, and instead have magical type families ``Positive (n :: Natural) :: Integer`` and ``Negative (n :: Natural) :: Integer`` to create them.
+* E*xtend things out to match how literals work at the term level, with ``FromInteger :: Natural -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
 
 More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -83,31 +83,21 @@ All of the mathematical type families in ``GHC.TypeNats`` will be generalized to
 
 ::
 
-    type family Add a (m :: a) (n :: a) :: a
-    type family Mul a (m :: a) (n :: a) :: a
-    type family Exp a b (m :: a) (n :: b) :: a
-    type family Sub a (m :: a) (n :: a) :: a
-    type family DivI a (m :: a) (n :: a) :: a
-    type family ModI a (m :: a) (n :: a) :: a
-    type family Log2I b (m :: b) :: b
+    type family (m :: a) + (n :: a) :: a
+    type family (m :: a) * (n :: a) :: a
+    type family (m :: a) ^ (n :: b) :: a
+    type family (m :: a) - (n :: a) :: a
+    type family (m :: a) / (n :: a) :: a
+    type family (m :: a) % (n :: a) :: a
+    type family Div (m :: b) (n :: b) :: b
+    type family Mod (m :: b) (n :: b) :: b
+    type family Log2 (m :: b) :: b
 
-    type (m :: a) + (n :: a) = Add a m n
-    type (m :: a) * (n :: a) = Mul a m n
-    type (m :: a) ^ (n :: b) = Exp a b m n
-    type (m :: a) - (n :: a) = Sub a m n
-    type (m :: a) / (n :: a) = DivI a m n
-    type (m :: a) % (n :: a) = ModI a m n
-    type Div (m :: b) (n :: b) = DivI b m n
-    type Mod (m :: b) (n :: b) = ModI b m n
-    type Log2 (m :: b) = Log2I b m
-
-A new type family will be added, ``Data.Type.Equality.Cmp``, using a similar alias-wrapper trick to provide a uniform interface for comparisons.
+A new type family will be added, ``Data.Type.Equality.Cmp``, to provide a uniform interface for comparisons.
 
 ::
 
-    type family CmpI a (m :: a) (n :: a) :: Ordering
-
-    type Cmp (m :: a) (n :: a) = CmpI a m n
+    type family Cmp (m :: a) (n :: a) :: Ordering
 
 Here, ``a`` is at least the five literal types, but there are many more implementations that could be added.
 
@@ -121,7 +111,7 @@ For the specific example I used to motivate this change, the implementation of t
 
     type family AllValidChars (xs :: String) :: Constraint where
         AllValidChars (x:xs) = If (IsValidChar x) (AllValidChars xs) (TypeError (InvalidCharError x))
-        AllValidChars '[]    = True ~ True
+        AllValidChars '[]    = ()
 
     type IsValidChar c = CmpChar c '\256' == LT
     type InvalidCharError c = ShowType c :<>: Text " is not a single-byte character."

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -72,7 +72,7 @@ The obvious alternatives are:
 
 More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 
-To handle the legacy case, ``Symbol`` and ``Nat`` will become aliases for ``String`` and ``Natural``, respectively.
+To handle the legacy case, ``Nat`` will become an alias for ``Natural``.
 
 All of the mathematical type families in ``GHC.TypeNats`` will be generalized to be poly-kinded so that they work for these new numeric kinds, with the exception of a ``Rational`` implementation for  ``Div``, ``Mod``, and ``Log2``. ``/`` and ``%`` will be added for ``Rational``. Put more explicitly, their interfaces will be as listed in the block below, where ``a`` means any of ``Integer``, ``Natural``, or ``Rational`` and ``b`` means either ``Integer`` or ``Rational``.
 
@@ -119,8 +119,6 @@ In general, this makes this already well-loved feature of GHC even better, allow
 Costs and Drawbacks
 -------------------
 The development time will be fairly minimal, because the "new" functionality represents no novel codepaths or design challenges, merely adding additional parallel constructors and cases to code that already handles the existing type-level literals.
-
-One potential drawback is that type-level strings are currently efficiently represented as ``FastString``\s, but these changes require a change to keeping them always as large, troublesome type-level lists of type-level ``Char``\s. The alternatives are either to (as I have implemented currently) keep ``Symbol``\s as they are but add a type family to convert them into promoted ``String``\s or to hack type-level pattern matching so that they extensively seem to be ``[Char]`` but are actually still efficient.
 
 Alternatives
 ------------

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -62,7 +62,7 @@ The kinds of type-level literals will be as follows:
 
 While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.
 
-If the type of numeric literals is now ``Integer``, then how does one get access to ``Nat``s by default, as required for backwards compatability? This propoasl introduces three new type families, ``GHC.TypeNats.FromInteger :: Integer -> a``, ``GHC.TypeNats.FromRational :: Rational -> a`` and ``GHC.TypeLits.FromSymbol :: Symbol -> a`` that mirror how overloaded literals work at the type level, with similar desugaring. ``FromSymbol`` will only be used when OverloadedStrings is enabled. The asymmetry (Symbol as default rather than String) is to maintain compatability with existing programs that use ``Symbol``s but not ``OverloadedString``.
+If the type of numeric literals is now ``Integer``, then how does one get access to ``Nat``\s by default, as required for backwards compatability? This propoasl introduces three new type families, ``GHC.TypeNats.FromInteger :: Integer -> a``, ``GHC.TypeNats.FromRational :: Rational -> a`` and ``GHC.TypeLits.FromSymbol :: Symbol -> a`` that mirror how overloaded literals work at the type level, with similar desugaring. ``FromSymbol`` will only be used when OverloadedStrings is enabled. The asymmetry (Symbol as default rather than String) is to maintain compatability with existing programs that use ``Symbol``s but not ``OverloadedString``.
 
 The obvious alternatives are:
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -68,7 +68,7 @@ The obvious alternatives are:
 
 * Use a syntactic tweak to show when a positive ``Integer`` rather than a ``Natural`` is desired. This is a poor option because it will mean that the term-level and type-level syntax will become *less* similar, not more. This goes against a key aim of the proposal.
 * Don't have pure syntax for integer literals, and instead have magical type families ``Positive (n :: Natural) :: Integer`` and ``Negative (n :: Natural) :: Integer`` to create them.
-* Extend things out to match how literals work at the term level, with ``FromInteger :: Natural -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
+* Extend things out to match how literals work at the term level, with ``FromInteger :: Integer -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
 
 More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -68,7 +68,7 @@ The obvious alternatives are:
 
 * Use a syntactic tweak to show when a positive ``Integer`` rather than a ``Natural`` is desired. This is a poor option because it will mean that the term-level and type-level syntax will become *less* similar, not more. This goes against a key aim of the proposal.
 * Don't have pure syntax for integer literals, and instead have magical type families ``Positive (n :: Natural) :: Integer`` and ``Negative (n :: Natural) :: Integer`` to create them.
-* E*xtend things out to match how literals work at the term level, with ``FromInteger :: Natural -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
+* Extend things out to match how literals work at the term level, with ``FromInteger :: Natural -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
 
 More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -39,22 +39,12 @@ Proposed Change Specification
 -----------------------------
 Grammar changes
 ^^^^^^^^^^^^^^^
-The lexical syntax would gain the following new case:
-
-::
-
-    signedint -> ['+'|'-'] integer
-
-The ``atype`` non-terminal would gain new cases as follows:
+The ``atype`` non-terminal would gain the following new case:
 
 ::
 
     atype -> ...
-           | string
-           | char
-           | integer
-           | signedint
-           | float
+           | literal
 
 This is relative to the specification, not the current effects of ``DataKinds``.
 
@@ -67,13 +57,19 @@ The kinds of type-level literals will be as follows:
     "foo" :: String
     'f' :: Char
     -123 :: Integer
-    +123 :: Integer
-    123 :: Natural
+    123 :: k -- Where 'k' can be either Integer or Rational
     3.14 :: Rational
 
 While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.
 
-The case of positive ``Integer`` literals is challenging. The syntax above is not great, but the obvious alternatives are a subkinding relation or an explicit conversion and I'd consider both of those to be worse.
+The case of positive ``Integer`` literals is challenging. I am concerned about cases where monomorphism is being relied upon, but I think this seems like the best option currently.
+
+The obvious alternatives are:
+
+* Use a syntactic tweak to show when a positive ``Integer`` rather than a ``Natural`` is desired. This is a poor option because it will mean that the term-level and type-level syntax will become *less* similar, not more. This goes against a key aim of the proposal.
+* Don't have pure syntax for integer literals, and instead have magical type families ``Positive (n :: Natural) :: Integer`` and ``Negative (n :: Natural) :: Integer`` to create them.
+
+More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 
 To handle the legacy case, ``Symbol`` and ``Nat`` will become aliases for ``String`` and ``Natural``, respectively.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -88,7 +88,7 @@ All of the mathematical type families in ``GHC.TypeNats`` will be generalized to
     type family Mod (m :: b) (n :: b) :: b
     type family Log2 (m :: b) :: b
 
-A new type family will be added, ``Data.Type.Equality.Cmp``, to provide a uniform interface for comparisons.
+A new type family will be added, ``Data.Type.Equality.Compare``, to provide a uniform interface for comparisons.
 
 ::
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -33,6 +33,8 @@ It is currently impossible to inspect the contents of a Symbol, because it is an
 
 Turning compile-time problems into compile-time errors is one of the main reasons that I use Haskell, and this value-transparency would allow that to be done cleanly in more cases, and the opacity of ``Symbol``\s is not the only restriction that is unfortunately limiting.
 
+In addition, it will greatly increase the number of types that can be promoted, making type-level Haskell cleaner and easier.
+
 This is largely motivated by the discussion on ghc-proposals/ghc-proposals#124 into a way to use type-level verification to make it safe to implement overloaded literals for the many types for which it is currently not possible, but I feel that this is both a substantial enough change and a potentially useful enough feature to be its own proposal rather than something added to a continuation of that work.
 
 Proposed Change Specification

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -1,0 +1,156 @@
+Unify type-level literals with their equivalent types
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/154>`_.
+.. sectnum::
+.. contents::
+
+The kinds of type-level literals not correspond to their term-level equivalents' types. This makes promoting many common data structures useless, increasing code duplication. In addition, the current type-level literal types leave out trivially-addable functionality that would make them more broadly useful.
+
+Motivation
+----------
+It is currently impossible to inspect the contents of a Symbol, because it is an opaque kind that only exposes equality, ordering, and appending. This means that it is impossible to use type-level strings to add compile-time validation of string-like values without using Template Haskell or a compiler plugin, meaning there is no way to write code that looks like the following:
+
+::
+
+    safePackBS :: forall str. (ValidBS str) => BS.ByteString
+    safePackBS = BS.pack $ symbolVal (Proxy :: Proxy str)
+
+    validBS, invalidBS :: BS.ByteString
+    validBS = safePackBS @"foo"
+    -- works!
+    invalidBS = safePackBS @"中国語"
+    -- fails with error: '\20013' is not a single-byte character.
+    -- Gives clean, helpful error message for invalid input at compile time.
+
+Turning compile-time problems into compile-time errors is one of the main reasons that I use Haskell, and this value-transparency would allow that to be done cleanly in more cases, and the opacity of ``Symbol``\s is not the only restriction that is unfortunately limiting.
+
+This is largely motivated by the discussion on ghc-proposals/ghc-proposals#124 into a way to use type-level verification to make it safe to implement overloaded literals for the many types for which it is currently not possible, but I feel that this is both a substantial enough change and a potentially useful enough feature to be its own proposal rather than something added to a continuation of that work.
+
+Proposed Change Specification
+-----------------------------
+The following is relative to the current behavior of ``DataKinds``.
+
+Grammar changes
+^^^^^^^^^^^^^^^
+The lexical syntax would gain the following new case:
+
+::
+
+    signedint -> ['+'|'-'] integer
+
+The ``atype`` non-terminal would gain new cases as follows:
+
+::
+
+    atype -> ...
+           | string
+           | char
+           | integer
+           | signedint
+           | float
+
+This is relative to the specification, not the current effects of ``DataKinds``.
+
+Semantics
+^^^^^^^^^
+The kinds of type-level literals will be as follows:
+
+::
+
+    "foo" :: String
+    'f' :: Char
+    -123 :: Integer
+    +123 :: Integer
+    123 :: Natural
+    3.14 :: Rational
+
+While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.
+
+The case of positive ``Integer`` literals is challenging. The syntax above is not great, but the obvious alternatives are a subkinding relation or an explicit conversion and I'd consider both of those to be worse.
+
+To handle the legacy case, ``Symbol`` and ``Nat`` will become aliases for ``String`` and ``Natural``, respectively.
+
+All of the mathematical type families in ``GHC.TypeNats`` will be generalized to be poly-kinded so that they work for these new numeric kinds, with the exception of a ``Rational`` implementation for  ``Div``, ``Mod``, and ``Log2``. ``/`` and ``%`` will be added for ``Rational``. Put more explicitly, their interfaces will be as listed in the block below, where ``a`` means any of ``Integer``, ``Natural``, or ``Rational`` and ``b`` means either ``Integer`` or ``Rational``.
+
+::
+
+    type family Add a (m :: a) (n :: a) :: a
+    type family Mul a (m :: a) (n :: a) :: a
+    type family Exp a b (m :: a) (n :: b) :: a
+    type family Sub a (m :: a) (n :: a) :: a
+    type family DivI a (m :: a) (n :: a) :: a
+    type family ModI a (m :: a) (n :: a) :: a
+    type family Log2I b (m :: b) :: b
+
+    type (m :: a) + (n :: a) = Add a m n
+    type (m :: a) * (n :: a) = Mul a m n
+    type (m :: a) ^ (n :: b) = Exp a b m n
+    type (m :: a) - (n :: a) = Sub a m n
+    type (m :: a) / (n :: a) = DivI a m n
+    type (m :: a) % (n :: a) = ModI a m n
+    type Div (m :: b) (n :: b) = DivI b m n
+    type Mod (m :: b) (n :: b) = ModI b m n
+    type Log2 (m :: b) = Log2I b m
+
+A new type family will be added, ``Data.Type.Equality.Cmp``, using a similar alias-wrapper trick to provide a uniform interface for comparisons.
+
+::
+
+    type family CmpI a (m :: a) (n :: a) :: Ordering
+
+    type Cmp (m :: a) (n :: a) = CmpI a m n
+
+Here, ``a`` is at least the five literal types, but there are many more implementations that could be added.
+
+Effect and Interactions
+-----------------------
+For the specific example I used to motivate this change, the implementation of the ``ValidBS`` constraint is as follows:
+
+::
+
+    type ValidBS str = (KnownSymbol str, AllValidChars str) 
+
+    type family AllValidChars (xs :: String) :: Constraint where
+        AllValidChars (x:xs) = If (IsValidChar x) (AllValidChars xs) (TypeError (InvalidCharError x))
+        AllValidChars '[]    = True ~ True
+
+    type IsValidChar c = CmpChar c '\256' == LT
+    type InvalidCharError c = ShowType c :<>: Text " is not a single-byte character."
+
+This is a simple example, but it is a clear example of a program that is not possible to write as it stands and that would have practical applications.
+
+In general, this makes this already well-loved feature of GHC even better, allowing more advanced uses of type-level strings and more flexible uses of type-level numerics for cases that require more than just the natural numbers. 
+
+
+Costs and Drawbacks
+-------------------
+The development time will be fairly minimal, because the "new" functionality represents no novel codepaths or design challenges, merely adding additional parallel constructors and cases to code that already handles the existing type-level literals.
+
+One potential drawback is that type-level strings are currently efficiently represented as ``FastString``\s, but these changes require either a change to keeping them always as large, troublesome type-level lists of type-level ``Char``\s. The alternatives are either to (as I have implemented currently) keep ``Symbol``\s as they are but add a type family to convert them into promoted ``String``\s or to hack type-level pattern matching so that 
+
+Alternatives
+------------
+Use of Template Haskell
+^^^^^^^^^^^^^^^^^^^^^^^
+Template Haskell is very flexible, but it carries both performance and readability drawbacks. There is no way to make a splice look "natural" in normal code, rather than adding what is likely unfamiliar syntax for beginning Haskellers. While the implementation of something like ``ValidBS`` is not entirely trivial, once written it looks perfectly natural.
+
+Use of type-checker plugins
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Type-checker plugins are hard to write, intimidating for those who are not familiar with the GHC API, and require an explicit (and non-trivial) pragma in every file where they are used. While this will not replace every case where they are required (not even close!), it does increase the utility of type-level strings without them substantially.
+
+Unresolved questions
+--------------------
+- Should this be a modification of ``DataKinds``, since it is (appears to be?) a strict superset of the previous behavior? Should it be a new extension?
+
+Implementation Plan
+-------------------
+I have already written a patch that provides a basic implementation of much of the above, and I would be more than happy to implement the final state of this proposal myself.

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -54,21 +54,21 @@ The kinds of type-level literals will be as follows:
 
 ::
 
-    "foo" :: k1 -- Where 'k1' can be Symbol or String, if OverloadedStrings is enabled. Defaults to Symbol otherwise.
+    "foo" :: Symbol
     'f' :: Char
-    -123 :: k2 -- where 'k2' can be Integer or Rational
-    123 :: k3 -- Where 'k3' can be Natural, Integer or Rational
+    -123 :: Integer
+    123 :: Integer
     3.14 :: Rational
 
 While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.
 
-The case of positive ``Integer`` literals is challenging. I am concerned about cases where monomorphism is being relied upon, but I think this seems like the best option currently.
+If the type of numeric literals is now ``Integer``, then how does one get access to ``Nat``s by default, as required for backwards compatability? This propoasl introduces three new type families, ``GHC.TypeNats.FromInteger :: Integer -> a``, ``GHC.TypeNats.FromRational :: Rational -> a`` and ``GHC.TypeLits.FromSymbol :: Symbol -> a`` that mirror how overloaded literals work at the type level, with similar desugaring. ``FromSymbol`` will only be used when OverloadedStrings is enabled. The asymmetry (Symbol as default rather than String) is to maintain compatability with existing programs that use ``Symbol``s but not ``OverloadedString``.
 
 The obvious alternatives are:
 
 * Use a syntactic tweak to show when a positive ``Integer`` rather than a ``Natural`` is desired. This is a poor option because it will mean that the term-level and type-level syntax will become *less* similar, not more. This goes against a key aim of the proposal.
 * Don't have pure syntax for integer literals, and instead have magical type families ``Positive (n :: Natural) :: Integer`` and ``Negative (n :: Natural) :: Integer`` to create them.
-* Extend things out to match how literals work at the term level, with ``FromInteger :: Integer -> a``, ``FromRational :: Rational -> a`` and ``IsString :: Symbol -> a`` type families allowing extension of these mechanisms. The latter, as implied above, would only be enabled if OverloadedStrings is used.
+* Make numeric (and with OverloadedStrings on, string) literals inherently polymorphic, but not in the extensible way that they are in the main proposal.
 
 More suggestions are welcome as this is one of the biggest discomfort points for the proposal as it stands.
 

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -135,7 +135,7 @@ Costs and Drawbacks
 -------------------
 The development time will be fairly minimal, because the "new" functionality represents no novel codepaths or design challenges, merely adding additional parallel constructors and cases to code that already handles the existing type-level literals.
 
-One potential drawback is that type-level strings are currently efficiently represented as ``FastString``\s, but these changes require either a change to keeping them always as large, troublesome type-level lists of type-level ``Char``\s. The alternatives are either to (as I have implemented currently) keep ``Symbol``\s as they are but add a type family to convert them into promoted ``String``\s or to hack type-level pattern matching so that 
+One potential drawback is that type-level strings are currently efficiently represented as ``FastString``\s, but these changes require a change to keeping them always as large, troublesome type-level lists of type-level ``Char``\s. The alternatives are either to (as I have implemented currently) keep ``Symbol``\s as they are but add a type family to convert them into promoted ``String``\s or to hack type-level pattern matching so that they extensively seem to be ``[Char]`` but are actually still efficient.
 
 Alternatives
 ------------

--- a/proposals/0000-unify-type-level-literals.rst
+++ b/proposals/0000-unify-type-level-literals.rst
@@ -56,8 +56,8 @@ The kinds of type-level literals will be as follows:
 
     "foo" :: k1 -- Where 'k1' can be Symbol or String, if OverloadedStrings is enabled. Defaults to Symbol otherwise.
     'f' :: Char
-    -123 :: Integer
-    123 :: k2 -- Where 'k2' can be Natural, Integer or Rational
+    -123 :: k2 -- where 'k2' can be Integer or Rational
+    123 :: k3 -- Where 'k3' can be Natural, Integer or Rational
     3.14 :: Rational
 
 While the ``Rational`` literals are the most dubious, they require very minimal changes (since ``Ratio Integer`` will now work correctly "for free") and are needed to satisfy the original impetus for this change.


### PR DESCRIPTION
This proposal would bring the types/kinds and variety of type-level literals more in line with their term-level counterparts.

[Rendered](https://github.com/typedrat/ghc-proposals/blob/master/proposals/0000-unify-type-level-literals.rst)