### PR TITLE
NoFieldSelectors

### DIFF
--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -36,6 +36,7 @@ Possible Alternative Designs
 - namespaced lenses
 - overloaded-labels based accessors / lenses
 - row types
+- https://github.com/ghc-proposals/ghc-proposals/pull/158
 - ...
 
 Proposed Change Specification
@@ -123,9 +124,6 @@ None.
 
 Unresolved questions
 --------------------
-
-Should exporting ``Foo(..)`` also export functions based on the name of the
-field accessors?
 
 
 Implementation Plan

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -50,9 +50,8 @@ by default to match the current behavior, but may be disabled per-module with
 the ``NoFieldSelectors`` language pragma.
 
 When ``NoFieldSelectors`` is enabled, Record construction/update syntax and
-pattern matching will work as before, and the behavior of
-``DuplicateRecordFields`` will be enabled by implication. The
-``DuplicateRecordFields`` will be deprecated in favor of ``NoFieldSelectors``.
+pattern matching will work as before, as will the disambiguation handled by
+``DuplicateRecordFields``.
 
 Record fields will still be part of a ``Record(..)`` export, or can also be
 named individually. They always have to be associated with the data type though,
@@ -192,11 +191,6 @@ Effect and Interactions
 
 `HasField` will work as before, if the corresponding field has been exported. It
 doesn't need to be exported as function.
-
-Interaction with DuplicateRecordFields
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Setting ``NoFieldSelectors`` implies ``DuplicateRecordFields``.
 
 Breakage estimation
 ^^^^^^^^^^^^^^^^^^^

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -15,8 +15,7 @@ NoToplevelFieldSelectors
 
 Enabling this Language Extension removes the default of Haskell data
 declarations to generate toplevel field accessor functions for records, such
-that the user can define their own, either via OverloadedRecordFields, or via
-Generic.
+that the user can define their own via Generic or positional extraction.
 
 Motivation
 ------------
@@ -117,6 +116,9 @@ because they all have to be exported manually.
 Effect and Interactions
 -----------------------
 
+`HasField` will work as before, if the corresponding field has been exported. It
+doesn't need to be exported as function.
+
 Breakage estimation
 ^^^^^^^^^^^^^^^^^^^
 
@@ -149,6 +151,10 @@ None.
 
 Unresolved questions
 --------------------
+
+- How exactly should the implementation look like?
+- How should the differentiation on TH work? There now needs to be a different
+  function to look up a selector function and a regular function via `Name`.
 
 
 Implementation Plan

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -132,7 +132,7 @@ constructor ``Foo``, but instead exports the toplevel bind ``baz``.
     data Foo = Foo { bar :: Int, baz :: Int }
     baz = 42
 
-The updaters can still be used when exported (as in module ``A``).
+The fields can still be used when exported (as in module ``A``).
 
 .. code-block:: haskell
 
@@ -155,6 +155,24 @@ The value ``baz`` is only exported from module ``B``, not ``A``. This would fail
 
     import A
     main = print baz
+
+If you wanted to use both, you'd have to export both explicitly:
+
+.. code-block:: haskell
+
+    {-# LANGUAGE NoFieldSelectors #-}
+    module C where (Foo(Foo, bar, baz), baz)
+    data Foo = Foo { bar :: Int, baz :: Int }
+    baz = 42
+
+Now ``baz`` here assigns the value ``42`` to the field ``baz``.
+
+.. code-block:: haskell
+
+   import C
+    foo = Foo 23 1
+    foo { baz = baz }
+
 
 Template Haskell
 ^^^^^^^^^^^^^^^^

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -1,0 +1,128 @@
+NoToplevelFieldSelectors
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Enabling this Language Extension removes the default of Haskell data
+declarations to generate toplevel field accessor functions for records, such
+that the user can define their own, either via OverloadedRecordFields, or via
+Generic.
+
+Motivation
+------------
+
+There have been proposals to extend the usage of records in Haskell
+(DuplicateRecordFields, OverloadedRecordFields, DeriveGeneric to name a few),
+but none of them address the original issue where record fields steal the
+toplevel function name for each field for selector purposes. This proposal
+intends to open the design space to this issue by removing the generation of
+these toplevel selector functions.
+
+Proposed Change Specification
+-----------------------------
+
+Record definition no longer defines toplevel selector functions when the
+``NoToplevelFieldSelectors`` extension is enabled. A
+``NoToplevelFieldSelectors`` pragma for records will also be available, such
+that this extension can be enabled on a per-record basis.
+
+Record construction/update syntax and pattern matching will work as before, the
+disambiguation handled by ``DuplicateRecordFields``. The necessary selectors
+will be part of a ``Record(..)`` export, or can also be named one by one. They
+always have to be associated with the data type though, because there is no more
+toplevel selector.
+
+A function for Template Haskell to go from a record field name to a selector for
+that field will be provided, because it's not possible anymore to go from field
+name directly to selector.
+
+Example
+^^^^^^^
+
+Given a data structure
+
+    data Foo = Foo { bar :: Int, baz :: String }
+
+The following will be available:
+
+- the type ``Foo``
+- the constructor ``Foo``
+- the two functions ``bar`` and ``baz``
+- the names ``bar`` and ``baz`` for record construction (``Foo { bar = 3, baz = "foo" }``)
+- the names ``bar`` and ``baz`` for ``RecordWildCards``
+
+If the language extension ``NoToplevelFieldSelectors`` is enabled for the module
+or ``Foo`` specifically, all of the above will be generated, except for the two
+functions ``bar`` and ``baz``.
+
+Wildcard exports will work as before, except for the two functions. Even if
+these functions are otherwise defined, the wildcard will not export them.
+Exporting the names for record construction now has to be specific to the
+record. Without ambiguitiy, previously this was equivalent
+
+    module A where (Foo(Foo, bar, baz))
+
+    module A where (Foo(Foo, bar), baz)
+
+Because of the new semantics, these two export statements are now different.
+Maybe a wildcard export will export functions of the same name as well, this
+question isn't resolved yet.
+
+Effect and Interactions
+-----------------------
+
+Breakage estimation
+^^^^^^^^^^^^^^^^^^^
+
+Enabling this extension will break a lot of Template Haskell. Going from record
+field name to selector won't work anymore. A new way to go from record field
+name to selector has to be found.
+
+Anything that generates code with the help of Generic should be fine. The same
+functionality that generates the anonymous functions for Generic could be used
+to provide TH functionality to replace the existing toplevel functions.
+
+The record extensions NamedFieldPuns, RecordWildCards, DisambiguateRecordFields,
+and DuplicateRecordFields are unaffected by this change.
+
+
+Costs and Drawbacks
+-------------------
+
+This might cause some confusion that record fields can't be accessed by toplevel
+selectors anymore - however, that shouldn't be too big of an issue, because some
+library authors already stopped exporting these selectors so they don't have to
+break downstream software on record changes.
+
+
+Alternatives
+------------
+
+None.
+
+
+Unresolved questions
+--------------------
+
+Should exporting ``Foo(..)`` also export functions based on the name of the
+field accessors?
+
+
+Implementation Plan
+-------------------
+
+For deriving the Generic instances, either ``Record.fieldName``,
+``OverloadedRecordFields`` or an anonymous function which generates the
+corresponding selector in core will be used. (to be clarified)

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -45,9 +45,7 @@ Proposed Change Specification
 -----------------------------
 
 Record definition no longer defines toplevel selector functions when the
-``NoToplevelFieldSelectors`` extension is enabled. A
-``NoToplevelFieldSelectors`` pragma for records will also be available, such
-that this extension can be enabled on a per-record basis.
+``NoToplevelFieldSelectors`` extension is enabled.
 
 Record construction/update syntax and pattern matching will work as before, the
 disambiguation handled by ``DuplicateRecordFields``. The necessary selectors
@@ -81,26 +79,6 @@ The following will be available:
 If the language extension ``NoToplevelFieldSelectors`` is enabled for the module
 or ``Foo`` specifically, all of the above will be generated, except for the two
 functions ``bar`` and ``baz``.
-
-The following declarations would be equivalent:
-
-::
-
-    {-# LANGUAGE NoToplevelFieldSelectors #-}
-
-    data Foo = Foo { bar :: Int, baz :: String }
-
-::
-
-    {-# NoToplevelFieldSelectors #-}
-    data Foo = Foo { bar :: Int, baz :: String }
-
-::
-
-    data Foo = Foo { bar :: Int, baz :: String }
-    {-# NoToplevelFieldSelectors Foo #-}
-
-
 
 Wildcard exports will work as before, except for the two functions. Even if
 these functions are otherwise defined, the wildcard will not export them.

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -59,6 +59,10 @@ A function for Template Haskell to go from a record field name to a selector for
 that field will be provided, because it's not possible anymore to go from field
 name directly to selector.
 
+A new `TH` function is added which takes two `Name` and returns an `Exp` which
+is equivalent to `a -> b`, where `a` is the record type specified by the second
+argument, and `b` the contents of the field specified by the first argument.
+
 Example
 ^^^^^^^
 
@@ -153,8 +157,7 @@ Unresolved questions
 --------------------
 
 - How exactly should the implementation look like?
-- How should the differentiation on TH work? There now needs to be a different
-  function to look up a selector function and a regular function via `Name`.
+- Which order of arguments in the new TH function?
 
 
 Implementation Plan

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -28,8 +28,11 @@ toplevel function name for each field for selector purposes. This proposal
 intends to open the design space to this issue by removing the generation of
 these toplevel selector functions.
 
-Possible Alternative Designs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Possible Alternative Use Cases for Record Names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After removing the toplevel selector names, the field names could be used as
+bindings for other values.
 
 - A `generic-lens` equivalent for toplevel lenses
 - namespaced accessors

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -134,13 +134,21 @@ None.
 Unresolved questions
 --------------------
 
-- How exactly should the implementation look like?
 - Which order of arguments in the new TH function?
 
 
 Implementation Plan
 -------------------
 
-For deriving the Generic instances, either ``Record.fieldName``,
-``OverloadedRecordFields`` or an anonymous function which generates the
-corresponding selector in core will be used. (to be clarified)
+I'm currently on the way of implementing this extension. It's roughly as
+follows:
+
+- Add new `NameSpace` to `OccName`: `RecordSelector String`
+- Remove `flSelector` from `FieldLabel`, add an flag which denotes if it should
+  be found as `VarName`
+- Remove `FlParent`
+- Change any field lookup code to look for new `OccName`
+- Implement `ToplevelFieldSelector` flag to look for selectors if you're looking
+  for `VarName`
+- Adjust `Generic` instances
+- Add new `TH` function to access record selectors

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -79,6 +79,26 @@ If the language extension ``NoToplevelFieldSelectors`` is enabled for the module
 or ``Foo`` specifically, all of the above will be generated, except for the two
 functions ``bar`` and ``baz``.
 
+The following declarations would be equivalent:
+
+::
+
+    {-# LANGUAGE NoToplevelFieldSelectors #-}
+
+    data Foo = Foo { bar :: Int, baz :: String }
+
+::
+
+    {-# NoToplevelFieldSelectors #-}
+    data Foo = Foo { bar :: Int, baz :: String }
+
+::
+
+    data Foo = Foo { bar :: Int, baz :: String }
+    {-# NoToplevelFieldSelectors Foo #-}
+
+
+
 Wildcard exports will work as before, except for the two functions. Even if
 these functions are otherwise defined, the wildcard will not export them.
 Exporting the names for record construction now has to be specific to the

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -168,8 +168,6 @@ selector / selector doesn't exist.
 
     mkFieldSelector :: Name -> String -> Q Exp
 
-Additionally, ``NameSpace`` will be extended with a new constructor ``FieldName``.
-
 Effect and Interactions
 -----------------------
 

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -118,7 +118,7 @@ is different from
     module Exports where (Foo(Foo, bar, baz))
     data Foo = Foo { bar :: Int, baz :: Int }
 
-Because the functions in the furst example don't get exported.
+Because the functions in the first example don't get exported.
 
 Let's take a module ``A`` with a function with the same name as a field, with
 the extension enabled:
@@ -150,8 +150,8 @@ can still be used when exported (as in module ``A``).
     data Foo = Foo { bar :: Int, baz :: Int }
     baz = 42
 
-Using ``baz`` when importing ``B`` will fail, because the field ``baz`` is not
-in scope anymore, because it is not exported by ``B``.
+Using ``baz`` as a field when importing ``B`` will fail, because the field
+``baz`` is not in scope anymore, because it is not exported by ``B``.
 
 .. code-block:: haskell
 
@@ -236,10 +236,10 @@ None.
 Unresolved questions
 --------------------
 
-- What would TH code look like in the future? The disambiguating field name is
-  always the first constructor, maybe introducing a new `Newtype` might make it
-  easier to use the function? Or should all constructors work, by having TH
-  normalize to the first one?
+- What would TH code look like in the future? The disambiguating record
+  constructor is always the first constructor, maybe introducing a new `Newtype`
+  might make it easier to use the function? Or should all constructors work, by
+  having TH normalize to the first one?
 - Should this extension imply DuplicateRecordFields?
 
 

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -110,7 +110,9 @@ record. Without ambiguitiy, previously this was equivalent
 
 Because of the new semantics, these two export statements are now different. The
 first one will export the field ``baz``, but not the function ``baz``, while the
-second one will export the function ``baz``, but not the field ``baz``.
+second one will export the function ``baz``, but not the field ``baz``. Because
+of this change, writing out all selector functions by hand is still different,
+because they all have to be exported manually.
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -108,9 +108,9 @@ record. Without ambiguitiy, previously this was equivalent
 
     module A where (Foo(Foo, bar), baz)
 
-Because of the new semantics, these two export statements are now different.
-Maybe a wildcard export will export functions of the same name as well, this
-question isn't resolved yet.
+Because of the new semantics, these two export statements are now different. The
+first one will export the field ``baz``, but not the function ``baz``, while the
+second one will export the function ``baz``, but not the field ``baz``.
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-no-toplevel-field-selectors.rst
+++ b/proposals/0000-no-toplevel-field-selectors.rst
@@ -9,9 +9,7 @@ NoToplevelFieldSelectors
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/160>`_.
 .. sectnum::
 .. contents::
 
@@ -29,6 +27,16 @@ but none of them address the original issue where record fields steal the
 toplevel function name for each field for selector purposes. This proposal
 intends to open the design space to this issue by removing the generation of
 these toplevel selector functions.
+
+Possible Alternative Designs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- A `generic-lens` equivalent for toplevel lenses
+- namespaced accessors
+- namespaced lenses
+- overloaded-labels based accessors / lenses
+- row types
+- ...
 
 Proposed Change Specification
 -----------------------------


### PR DESCRIPTION
This is the proposal to remove toplevel field selector generation - e.g. the toplevel functions `bar` and `baz` that are being generator from the declaration `data Foo = Foo { bar :: String, baz :: Int}`.

[Rendered](https://github.com/reactormonk/ghc-proposals/blob/master/proposals/0000-no-toplevel-field-selectors.rst)

<!-- probot = {"1313345":{"who":"gridaphobe","what":"accept this proposal","when":"2019-08-23T09:00:00.000Z"}} -->