### PR TITLE
Control what sort of entity a deprecated pragma applies to

### DIFF
--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -86,8 +86,8 @@ There are currently no known drawbacks to this feature.
 Alternatives
 ------------
 * The usual workaround would be to have a module that imports one but not the other.
-Unfortunately this workaround is limited as it would only work for types, but not for data constructors.
-Another option would be to refactor data constructor names, which is not backward compatible and inefficient.
+  Unfortunately this workaround is limited as it would only work for types, but not for data constructors.
+  Another option would be to refactor data constructor names, which is not backward compatible and inefficient.
 
 * Another alternative would be to try to utilize Haddock annotations. Example: ::
 

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -98,8 +98,8 @@ Unresolved Questions
 1) What specifier should be used for data constructors?
 `Initial feature request <https://ghc.haskell.org/trac/ghc/ticket/3427>`_ suggested to use `constructor` but
 using `specifiers from disambiguation in export list proposal <https://ghc.haskell.org/trac/ghc/wiki/Design/TypeNaming>`_
-seems better since it does not require new keywords to be introduced. Another disadvantage of using `constructor` is
-is that it is quite a widely used identifier which is bad for bakward compatibility
+seems better since it does not require new keywords to be introduced. Another disadvantage of using `constructor`
+is that it is quite a widely used identifier which is bad for backward compatibility
 (for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ )
 
 Implementation Plan

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -11,7 +11,7 @@ Deprecated Entities
 .. sectnum::
 .. contents::
 
-This feature would allow to control what sort of entity a DEPRECATED pragma applies to.
+This feature would allow to control what sort of entity a ``DEPRECATED`` pragma applies to.
 
 Motivation
 ------------
@@ -31,7 +31,7 @@ Proposed Change Specification
 
 Effect and Interactions
 -----------------------
-An example of a use case for this is the following. Given the following module:
+An example of a use case for this is the following. Given the following module: ::
 
     module A where
 
@@ -44,7 +44,7 @@ An example of a use case for this is the following. Given the following module:
     data Baz = Baz
     {-# DEPRECATED data Baz "Don't use data constructor Baz" #-}
 
-When compiling the code which happens to use data constructor or type ``Foo``, we will see the following warnings:
+When compiling the code which happens to use data constructor or type ``Foo``, we will see the following warnings: ::
 
     Main.hs:5:8: warning: [-Wdeprecations (in -Wdefault)]
         In the use of type constructor or class ‘Foo’ (imported from A):
@@ -56,13 +56,13 @@ When compiling the code which happens to use data constructor or type ``Foo``, w
 
 In the same vein, if we use data constructor or type ``Bar``,
 we will be warned only when we use the type, but not constructor,
-since we specified which entity we want to deprecate in above mentioned module ``A``:
+since we specified which entity we want to deprecate in above mentioned module ``A``: ::
 
     Main.hs:8:8: warning: [-Wdeprecations (in -Wdefault)]
         In the use of type constructor or class ‘Bar’ (imported from A):
         Deprecated: "Don't use type Bar"
 
-Same logic applies to ``Baz``, we will be warned only when its data constructor is used:
+Same logic applies to ``Baz``, we will be warned only when its data constructor is used: ::
 
     Main.hs:12:7: warning: [-Wdeprecations (in -Wdefault)]
         In the use of data constructor ‘Baz’ (imported from A):
@@ -71,11 +71,11 @@ Same logic applies to ``Baz``, we will be warned only when its data constructor 
 
 When specifying several entities in one pragma,
 the sort of deprecated entity we've specified will apply to all listed entities.
-This will work - warn when these types are used(but not their constructors):
+This will work - warn when these types are used(but not their constructors): ::
 
     {-# DEPRECATED type Qux, Quux "Don't use this" #-}
 
-This will not work (parse error):
+This will not work (parse error): ::
 
     {-# DEPRECATED type Qux, constructor Quux "Don't use this" #-}
 

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -113,6 +113,23 @@ such that the following example is accepted? ::
 
     {-# DEPRECATED type Qux, data Quux "Don't use this" #-}
 
+3) Current proposal is limited in scope to disambiguating prefix type constructors from prefix data constructors.
+But what about the following scenario? ::
+
+    module A where
+
+    type a <+> b = ...
+
+    (<+>) :: Int -> Int -> Int
+    a <+> b = ...
+
+    {-# DEPRECATED (<+>) "Don't use (<+>)" #-}
+
+It's unclear which (<+>) we are referring to.
+In this case it might be a good idea to have more fine-grained "deprecation" control at term-level.
+One of the ways to achieve this would be to introduce another disambiguating qualifier.
+Another option would be to have more inclusive term-level qualifier (for example, ``value``).
+
 Implementation Plan
 -------------------
 * add new reserved keyword for disambiguating data constructors (?)

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -18,14 +18,15 @@ Motivation
 It is a very common idiom to have a type and an identically named data constructor.
 Sometimes one would want to deprecate the use of constructor
 (for example, when using smart constructors) with a help of ``DEPRECATED`` pragma.
-However, according to the user guide, there is currently no way to deprecate one thing without the other.
+However, according to the user guide, `there is currently no way to deprecate one thing without the other.
+<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#warning-deprecated-pragma>`_
 The usual workaround would be to have a module that imports one but not the other,
 however while that's possible for the type it's not possible for the constructor.
 
 Proposed Change Specification
 -----------------------------
 
-* extend DEPRECATED pragma with a disambiguating specifier: ``data`` for data constructors and ``type`` for types.
+* extend ``DEPRECATED`` pragma with a disambiguating specifier: ``data`` for data constructors and ``type`` for types.
 * the unqualified case would mean deprecating both entities as it does now.
 
 
@@ -55,14 +56,14 @@ When compiling the code which happens to use data constructor or type ``Foo``, w
         Deprecated: "Don't use type and data constructor Foo"
 
 In the same vein, if we use data constructor or type ``Bar``,
-we will be warned only when we use the type, but not constructor,
-since we specified which entity we want to deprecate in above mentioned module ``A``: ::
+we will be warned **only when we use the type**, but not the constructor,
+since we specified which entity we want to deprecate in the above mentioned module ``A``: ::
 
     Main.hs:8:8: warning: [-Wdeprecations (in -Wdefault)]
         In the use of type constructor or class ‘Bar’ (imported from A):
         Deprecated: "Don't use type Bar"
 
-Same logic applies to ``Baz``, we will be warned only when its data constructor is used: ::
+Same logic applies to ``Baz``, we will be warned **only when its data constructor** is used(but not its type): ::
 
     Main.hs:12:7: warning: [-Wdeprecations (in -Wdefault)]
         In the use of data constructor ‘Baz’ (imported from A):
@@ -79,7 +80,7 @@ This will not work (parse error): ::
 
     {-# DEPRECATED type Qux, constructor Quux "Don't use this" #-}
 
-This feature does not work on ``module`` level since it does not make sense.
+This feature does not work on ``module`` level.
 Module level deprecation already implies the entity - the module itself.
 
 Costs and Drawbacks
@@ -109,5 +110,5 @@ Implementation Plan
 * during the renaming phase, in `warnIfDeprecated` do extra check for the deprecated entity
 * perform check against ``DeprEntity`` and ``Namespace``
 
-If accepted, I (`@nineonine <https://github.com/ninonine>`_) volunteer to implement this change.
+If accepted, I (`@nineonine <https://github.com/nineonine>`_) volunteer to implement this change.
 `Phab Diff <https://phabricator.haskell.org/D5126>`_

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -90,6 +90,7 @@ Alternatives
 * The usual workaround would be to have a module that imports one but not the other.
 Unfortunately this workaround is limited as it would only work for types, but not for data constructors.
 Another option would be to refactor data constructor names, which is not backward compatible and inefficient.
+
 * Another alternative would be to try to utilize Haddock annotations. Example: ::
 
     -- | DEPRECATE: This type is deprecated
@@ -105,6 +106,7 @@ using `specifiers from disambiguation in export list proposal <https://ghc.haske
 seems better since it does not require new keywords to be introduced. Another disadvantage of using ``constructor``
 is that it is quite a widely used identifier so making it a keyword is bad for backward compatibility
 (for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ ).
+
 2) Although `DEPRECATED` pragma isn't often used with multiple entities specified,
 would it be nicer to have ``type``/``data`` qualifier specified for each entity,
 such that the following example is accepted? ::

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -24,13 +24,10 @@ however while that's possible for the type it's not possible for the constructor
 Proposed Change Specification
 -----------------------------
 
-* extend ``DEPRECATED`` pragma with a disambiguating specifiers:
-  ``pattern`` - for value-level things,
+* extend ``DEPRECATED`` pragma with disambiguating specifiers:
+  ``value`` - for value-level things,
   ``type`` - for types.
 * the unqualified case would mean deprecating both entities as it does now.
-
-Although, ``pattern`` seems like a weird choice, we are using it deliberately to be consistent
-with other language features(for example, `PatternSynonyms <https://downloads.haskell.org/~ghc/master/users-guide/glasgow_exts.html#patsyn-impexp>`_).
 
 Effect and Interactions
 -----------------------
@@ -45,7 +42,7 @@ An example of a use case for this is the following. Given the following module: 
     {-# DEPRECATED type Bar "Don't use type Bar" #-}
 
     data Baz = Baz
-    {-# DEPRECATED pattern Baz "Don't use data constructor Baz" #-}
+    {-# DEPRECATED value Baz "Don't use data constructor Baz" #-}
 
 When compiling the code which happens to use data constructor or type ``Foo``, we will see the following warnings: ::
 
@@ -74,9 +71,9 @@ Same logic applies to ``Baz``, we will be warned **only when its data constructo
 When having several entities in one pragma, specifiers can be supplied per entity.
 This will work: ::
 
-    {-# DEPRECATED type Qux, pattern Quux "Don't use this" #-}
+    {-# DEPRECATED type Qux, value Quux "Don't use this" #-}
 
-This feature does not work on ``module`` level.
+This feature does not work at ``module`` level.
 Module level deprecation already implies the entity - the module itself.
 
 Costs and Drawbacks

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -30,7 +30,7 @@ Proposed Change Specification
 * the unqualified case would mean deprecating both entities as it does now.
 
 Although, ``pattern`` seems like a weird choice, we are using it deliberately to be consistent
-with other language features(for example, `PatternSynonyms<https://downloads.haskell.org/~ghc/master/users-guide/glasgow_exts.html#patsyn-impexp>`_).
+with other language features(for example, `PatternSynonyms <https://downloads.haskell.org/~ghc/master/users-guide/glasgow_exts.html#patsyn-impexp>`_).
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -76,7 +76,7 @@ This will work - warn when these types are used(but not their constructors): ::
 
 This will not work (parse error): ::
 
-    {-# DEPRECATED type Qux, constructor Quux "Don't use this" #-}
+    {-# DEPRECATED type Qux, data Quux "Don't use this" #-}
 
 This feature does not work on ``module`` level.
 Module level deprecation already implies the entity - the module itself.

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -5,9 +5,7 @@ Deprecated Entities
 .. trac-ticket:: 3427
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/167>`_.
 .. sectnum::
 .. contents::
 
@@ -99,8 +97,8 @@ Unresolved Questions
 `Initial feature request <https://ghc.haskell.org/trac/ghc/ticket/3427>`_ suggested to use `constructor` but
 using `specifiers from disambiguation in export list proposal <https://ghc.haskell.org/trac/ghc/wiki/Design/TypeNaming>`_
 seems better since it does not require new keywords to be introduced. Another disadvantage of using `constructor`
-is that it is quite a widely used identifier which is bad for backward compatibility
-(for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ )
+is that it is quite a widely used identifier so making it a keyword is bad for backward compatibility
+(for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ ).
 
 Implementation Plan
 -------------------

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -25,8 +25,8 @@ Proposed Change Specification
 -----------------------------
 
 * extend ``DEPRECATED`` pragma with a disambiguating specifiers:
-** ``value`` for value-level things;
-** ``type`` for types;
+  ``value`` - for value-level things,
+  ``type`` - for types.
 * the unqualified case would mean deprecating both entities as it does now.
 
 

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -87,25 +87,36 @@ There are currently no known drawbacks to this feature.
 
 Alternatives
 ------------
-The usual workaround would be to have a module that imports one but not the other.
+* The usual workaround would be to have a module that imports one but not the other.
 Unfortunately this workaround is limited as it would only work for types, but not for data constructors.
 Another option would be to refactor data constructor names, which is not backward compatible and inefficient.
+* Another alternative would be to try to utilize Haddock annotations. Example: ::
+
+    -- | DEPRECATE: This type is deprecated
+    data Foo =
+        -- | DEPRECATE: This constructor is deprecated
+        Foo x
 
 Unresolved Questions
 --------------------
 1) What specifier should be used for data constructors?
-`Initial feature request <https://ghc.haskell.org/trac/ghc/ticket/3427>`_ suggested to use `constructor` but
+`Initial feature request <https://ghc.haskell.org/trac/ghc/ticket/3427>`_ suggested to use ``constructor`` but
 using `specifiers from disambiguation in export list proposal <https://ghc.haskell.org/trac/ghc/wiki/Design/TypeNaming>`_
-seems better since it does not require new keywords to be introduced. Another disadvantage of using `constructor`
+seems better since it does not require new keywords to be introduced. Another disadvantage of using ``constructor``
 is that it is quite a widely used identifier so making it a keyword is bad for backward compatibility
 (for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ ).
+2) Although `DEPRECATED` pragma isn't often used with multiple entities specified,
+would it be nicer to have ``type``/``data`` qualifier specified for each entity,
+such that the following example is accepted? ::
+
+    {-# DEPRECATED type Qux, data Quux "Don't use this" #-}
 
 Implementation Plan
 -------------------
 * add new reserved keyword for disambiguating data constructors (?)
 * add new datatype to distinguish between different deprecated entities - ``DeprEntity``
 * extend ``WarningTxt`` type, namely ``DeprecatedTxt`` constructor with a field of type ``DeprEntity``
-* during the renaming phase, in `warnIfDeprecated` do extra check for the deprecated entity
+* during the renaming phase, in ``warnIfDeprecated`` do extra check for the deprecated entity
 * perform check against ``DeprEntity`` and ``Namespace``
 
 If accepted, I (`@nineonine <https://github.com/nineonine>`_) volunteer to implement this change.

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -96,9 +96,28 @@ Alternatives
         -- | DEPRECATE: This constructor is deprecated
         Foo x
 
+* Another idea is to make ``DEPRECATED`` positional. One says ::
+
+    module M {-# DEPRECATED "blah" #-} where ...
+
+  One could do the same for data constructors, thus ::
+
+    data Baz = Baz {-# DEPRECATED "blah" #-}
+             | Boo
+             | Bim {-# DEPRECATED "blah" #-} Int
+
+  Or in GADT syntax ::
+
+    data Baz where
+      Baz :: Int -> Baz
+      Boo :: Baz
+      Bim :: Baz
+      {-# DEPRECATED Bim, Baz "blah" #-}
+
+  This positional story works well when the deprecation is attached to the definition of the thing. If you want to import something, deprecate it, and re-export it, it would not work so well. But (SPJ thinks) it is not possible to do that anyway today.
+
 Unresolved Questions
 --------------------
-
 
 Implementation Plan
 -------------------

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -1,0 +1,113 @@
+Deprecated Entities
+==============
+
+.. proposal-number::
+.. trac-ticket:: 3427
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+This feature would allow to control what sort of entity a DEPRECATED pragma applies to.
+
+Motivation
+------------
+It is a very common idiom to have a type and an identically named data constructor.
+Sometimes one would want to deprecate the use of constructor
+(for example, when using smart constructors) with a help of ``DEPRECATED`` pragma.
+However, according to the user guide, there is currently no way to deprecate one thing without the other.
+The usual workaround would be to have a module that imports one but not the other,
+however while that's possible for the type it's not possible for the constructor.
+
+Proposed Change Specification
+-----------------------------
+
+* extend DEPRECATED pragma with a disambiguating specifier: ``data`` for data constructors and ``type`` for types.
+* the unqualified case would mean deprecating both entities as it does now.
+
+
+Effect and Interactions
+-----------------------
+An example of a use case for this is the following. Given the following module:
+
+    module A where
+
+    data Foo = Foo
+    {-# DEPRECATED Foo "Don't use type and data constructor Foo" #-}
+
+    data Bar = Bar
+    {-# DEPRECATED type Bar "Don't use type Bar" #-}
+
+    data Baz = Baz
+    {-# DEPRECATED data Baz "Don't use data constructor Baz" #-}
+
+When compiling the code which happens to use data constructor or type ``Foo``, we will see the following warnings:
+
+    Main.hs:5:8: warning: [-Wdeprecations (in -Wdefault)]
+        In the use of type constructor or class ‘Foo’ (imported from A):
+        Deprecated: "Don't use type and data constructor Foo"
+
+    Main.hs:6:7: warning: [-Wdeprecations (in -Wdefault)]
+        In the use of data constructor ‘Foo’ (imported from A):
+        Deprecated: "Don't use type and data constructor Foo"
+
+In the same vein, if we use data constructor or type ``Bar``,
+we will be warned only when we use the type, but not constructor,
+since we specified which entity we want to deprecate in above mentioned module ``A``:
+
+    Main.hs:8:8: warning: [-Wdeprecations (in -Wdefault)]
+        In the use of type constructor or class ‘Bar’ (imported from A):
+        Deprecated: "Don't use type Bar"
+
+Same logic applies to ``Baz``, we will be warned only when its data constructor is used:
+
+    Main.hs:12:7: warning: [-Wdeprecations (in -Wdefault)]
+        In the use of data constructor ‘Baz’ (imported from A):
+        Deprecated: "Don't use data constructor Baz"
+
+
+When specifying several entities in one pragma,
+the sort of deprecated entity we've specified will apply to all listed entities.
+This will work - warn when these types are used(but not their constructors):
+
+    {-# DEPRECATED type Qux, Quux "Don't use this" #-}
+
+This will not work (parse error):
+
+    {-# DEPRECATED type Qux, constructor Quux "Don't use this" #-}
+
+This feature does not work on ``module`` level since it does not make sense.
+Module level deprecation already implies the entity - the module itself.
+
+Costs and Drawbacks
+-------------------
+There are currently no known drawbacks to this feature.
+
+Alternatives
+------------
+The usual workaround would be to have a module that imports one but not the other.
+Unfortunately this workaround is limited as it would only work for types, but not for data constructors.
+Another option would be to refactor data constructor names, which is not backward compatible and inefficient.
+
+Unresolved Questions
+--------------------
+1) What specifier should be used for data constructors?
+`Initial feature request <https://ghc.haskell.org/trac/ghc/ticket/3427>`_ suggested to use `constructor` but
+using `specifiers from disambiguation in export list proposal <https://ghc.haskell.org/trac/ghc/wiki/Design/TypeNaming>`_
+seems better since it does not require new keywords to be introduced. Another disadvantage of using `constructor` is
+is that it is quite a widely used identifier which is bad for bakward compatibility
+(for example, `hsc2hs uses it <https://github.com/haskell/hsc2hs/blob/master/CrossCodegen.hs#L470>`_ )
+
+Implementation Plan
+-------------------
+* add new reserved keyword for disambiguating data constructors (?)
+* add new datatype to distinguish between different deprecated entities - ``DeprEntity``
+* extend ``WarningTxt`` type, namely ``DeprecatedTxt`` constructor with a field of type ``DeprEntity``
+* during the renaming phase, in `warnIfDeprecated` do extra check for the deprecated entity
+* perform check against ``DeprEntity`` and ``Namespace``
+
+If accepted, I (`@nineonine <https://github.com/ninonine>`_) volunteer to implement this change.
+`Phab Diff <https://phabricator.haskell.org/D5126>`_

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -25,10 +25,12 @@ Proposed Change Specification
 -----------------------------
 
 * extend ``DEPRECATED`` pragma with a disambiguating specifiers:
-  ``value`` - for value-level things,
+  ``pattern`` - for value-level things,
   ``type`` - for types.
 * the unqualified case would mean deprecating both entities as it does now.
 
+Although, ``pattern`` seems like a weird choice, we are using it deliberately to be consistent
+with other language features(for example, `PatternSynonyms<https://downloads.haskell.org/~ghc/master/users-guide/glasgow_exts.html#patsyn-impexp>`_).
 
 Effect and Interactions
 -----------------------
@@ -43,7 +45,7 @@ An example of a use case for this is the following. Given the following module: 
     {-# DEPRECATED type Bar "Don't use type Bar" #-}
 
     data Baz = Baz
-    {-# DEPRECATED value Baz "Don't use data constructor Baz" #-}
+    {-# DEPRECATED pattern Baz "Don't use data constructor Baz" #-}
 
 When compiling the code which happens to use data constructor or type ``Foo``, we will see the following warnings: ::
 
@@ -69,16 +71,10 @@ Same logic applies to ``Baz``, we will be warned **only when its data constructo
         In the use of data constructor ‘Baz’ (imported from A):
         Deprecated: "Don't use data constructor Baz"
 
+When having several entities in one pragma, specifiers can be supplied per entity.
+This will work: ::
 
-When specifying several entities in one pragma,
-the sort of deprecated entity we've specified will apply to all listed entities.
-This will work - warn when these types are used(but not their constructors): ::
-
-    {-# DEPRECATED type Qux, Quux "Don't use this" #-}
-
-This will not work (parse error): ::
-
-    {-# DEPRECATED type Qux, value Quux "Don't use this" #-}
+    {-# DEPRECATED type Qux, pattern Quux "Don't use this" #-}
 
 This feature does not work on ``module`` level.
 Module level deprecation already implies the entity - the module itself.
@@ -103,19 +99,9 @@ Another option would be to refactor data constructor names, which is not backwar
 Unresolved Questions
 --------------------
 
-1) Although `DEPRECATED` pragma isn't often used with multiple entities specified,
-would it be nicer to have ``type``/``value`` qualifier specified for each entity,
-such that the following example is accepted? ::
-
-    {-# DEPRECATED type Qux, value Quux "Don't use this" #-}
 
 Implementation Plan
 -------------------
-* add new reserved keyword (``value``)
-* add new datatype to distinguish between different deprecated entities - ``DeprEntity``
-* extend ``WarningTxt`` type, namely ``DeprecatedTxt`` constructor with a field of type ``DeprEntity``
-* during the renaming phase, in ``warnIfDeprecated`` do extra check for the deprecated entity
-* perform check against ``DeprEntity`` and ``Namespace``
 
 If accepted, I (`@nineonine <https://github.com/nineonine>`_) volunteer to implement this change.
 `Phab Diff <https://phabricator.haskell.org/D5126>`_

--- a/proposals/0000-deprecated-entities.rst
+++ b/proposals/0000-deprecated-entities.rst
@@ -118,6 +118,8 @@ Alternatives
 
 Unresolved Questions
 --------------------
+* Would it be useful to be able to deprecate class instances too?
+  https://ghc.haskell.org/trac/ghc/ticket/12014
 
 Implementation Plan
 -------------------


### PR DESCRIPTION
This proposal would allow to specify which entity (type or data constructor) you want to deprecate.


[rendered](https://github.com/nineonine/ghc-proposals/blob/depr-entities/proposals/0000-deprecated-entities.rst)
[gitlab issue](https://gitlab.haskell.org/ghc/ghc/issues/3427)