### PR TITLE
Proposal 0007 has been implemented

### DIFF
--- a/proposals/0007-instance-foralls.rst
+++ b/proposals/0007-instance-foralls.rst
@@ -2,8 +2,8 @@ More explicit ``forall``\s
 ==========================
 
 .. proposal-number:: 0007
-.. trac-ticket:: 14268
-.. implemented::
+.. trac-ticket:: 2600, 14268
+.. implemented:: 8.8
 .. sectnum::
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull requst <https://github.com/ghc-proposals/ghc-proposals/pull/55>`_.


### PR DESCRIPTION
As of commit [512eeb9bb9a81e915bfab25ca16bc87c62252064](https://git.haskell.org/ghc.git/commitdiff/512eeb9bb9a81e915bfab25ca16bc87c62252064), which will debut in GHC 8.8.

This also adds [Trac #2600](https://ghc.haskell.org/trac/ghc/ticket/2600) to the list of Trac tickets that this proposal addresses (since it was mistakenly omitted).