### PR TITLE
integer-openssl proposal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ What is the timeline of a proposal?
    `How to bring a proposal before the committee <#how-to-bring-a-proposal-before-the-committee>`_ •
    `Who is the committee? <#who-is-the-committee>`_
 
-5. One committee member steps up as a shephard, and generates consensus within the commitee within four or five weeks.
+5. One committee member steps up as a shepherd, and generates consensus within the committee within four or five weeks.
 
    `Committee process <#committee-process>`_ •
    `Review criteria <#review-criteria>`_ •
@@ -208,7 +208,7 @@ What is a dormant proposal
 
 In order to keep better track of actively discussed proposals, proposals that
 see no activity for an extended period of time (a month or two) might be marked
-as “``dormant``”. At any time the proposor, or someone else can revive the
+as “``dormant``”. At any time the proposer, or someone else can revive the
 proposal by picking up the discussion (and possibly asking `the secretary
 <#who-is-the-committee>`_ to remove the ``dormant`` tag).
 
@@ -217,7 +217,7 @@ You can see the `list of dormant proposals <https://github.com/ghc-proposals/ghc
 Who is the committee
 --------------------
 
-The current members of the GHC steering committe, who you can reach
+The current members of the GHC steering committee, who you can reach
 by email at ghc-steering-committee@haskell.org, are:
 
 ======================  ====================================================  =========
@@ -247,7 +247,7 @@ Committee process
 -----------------
 
 The committee process starts once the committee has been notified that a
-proposal is ready for decistion, and takes place on the
+proposal is ready for decision, and takes place on the
 `ghc-steering-committee <https://mail.haskell.org/cgi-bin/mailman/listinfo/>`_
 mailing list. All interested parties are invited to follow the discussion.
 
@@ -258,8 +258,8 @@ mailing list. All interested parties are invited to follow the discussion.
    makes a recommendation as to whether the proposal ought to be accepted,
    rejected or returned for revision.
 
--  Discussion among the committee ensues on the mailiing list.
-   Silence is undestood as agreement with the shepherds recommendation.
+-  Discussion among the committee ensues on the mailing list.
+   Silence is understood as agreement with the shepherds recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd.  If consensus is elusive, then we vote, with the Simons
@@ -288,7 +288,7 @@ mailing list. All interested parties are invited to follow the discussion.
 
    *  **If we say yes:**
       The shepherd or the secretary announces this on the pull request
-      and lables it as
+      and labels it as
       `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3AAccepted>`_.
       The secretary merges the pull request and assigns the final proposal
       number.
@@ -298,7 +298,7 @@ mailing list. All interested parties are invited to follow the discussion.
       oversee implementation, attract implementors, etc.
 
       The proposal authors or other implementors are encouraged to update the
-      propsoal with the implementation status (i.e. trac ticket number and the
+      proposal with the implementation status (i.e. trac ticket number and the
       first version of GHC implementing it.)
 
 
@@ -317,7 +317,7 @@ and any other relevant considerations appropriately.
    ideally offer evidence of some form.
 
 -  *Elegant and principled*. Haskell is a beautiful and principled
-   langauge. It is tempting to pile feature upon feature (and GHC
+   language. It is tempting to pile feature upon feature (and GHC
    Haskell has quite a bit of that), but we should constantly and
    consciously strive for simplicity and elegance.
 

--- a/proposals/0000-integer-openssl.rst
+++ b/proposals/0000-integer-openssl.rst
@@ -39,16 +39,16 @@ implementation of the ``GHC.Integer`` interface and is `BSD3
 slow and infeasible for contexts where big integer multiplication / division are
 in fact required, e.g. public key cryptography.
 
-So, the goal is to have a fast (enough), BSD3-licensed alternative for the
+So, the **goal** is to have a fast (enough), BSD3-licensed alternative for the
 ``Integer`` data type available in GHC.
 
 After looking for a BSD-licensed library, ``openssl`` came to mind, which
 implements arbitrary size integer arithmetic in it's `BIGNUM
-<https://github.com/openssl/openssl/tree/master/crypto/bn`_ library incorporated
+<https://github.com/openssl/openssl/tree/master/crypto/bn>`_ library incorporated
 into ``libcrypto``. It seems to ticks all boxes:
 
 * BSD-licensed: The OpenSSL license is a `BSD-style license
-  <https://tldrlegal.com/license/openssl-license-(openssl)`_.
+  <https://tldrlegal.com/license/openssl-license-(openssl)>`_.
 
 * Complete / correct: Documentation and source seems to cover all major
   operations on big integers - so only a thin layer / wrapper is suitable.
@@ -114,6 +114,8 @@ past and were discussed or prototypically implemented so far.
   `https://github.com/erikd/haskell-big-integer-experiment`
 * Wiki page about replacing GMP
   `https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes`
+* Performance Measurements of other Multi-Precision Libraries
+  `https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes/PerformanceMeasurements`
 
 
 Unresolved questions
@@ -125,7 +127,6 @@ and even ``GHC.Integer.Logarithms.Internals``.
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?
 
 1) Implement the "portable" ``GHC.Integer`` interface for 32bit and 64bit in a
    library, where implementation is tested and benchmarked against the builtin

--- a/proposals/0000-integer-openssl.rst
+++ b/proposals/0000-integer-openssl.rst
@@ -1,0 +1,122 @@
+Add integer-openssl as BSD-licensed alternative for integer-gmp
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Proposal to add a fast, BSD-licensed alternative for GHC's ``Integer`` type,
+next to currently available ``integer-gmp`` (default, fast and LPGL3-licensed)
+and ``integer-simple`` (slow, but pure and BSD3-licensed) implementations.
+Concretely, this would use OpenSSLs "BIGNUM" arbitrary size integer library
+contained in ``libcrypto``.
+ 
+Motivation
+------------
+
+By default, GHC uses ``integer-gmp`` as implementation for the ``GHC.Integer``
+interface. The GNU MP Bignum Library is distributed dual licensed under `LGPLv3
+<https://www.gnu.org/licenses/lgpl.html>` and `GPLv2
+<https://www.gnu.org/licenses/gpl-2.0.html>`. Although being fast and available
+on many platforms, these licenses are sometimes undesirable:
+
+* when statically linking (e.g. on Windows)
+* when "Convey the object code in, or embodied in, a physical product" (LGPLv3 -> GPLv3)
+
+The only available alternative is ``integer-simple``, which is a pure haskell
+implementation of the ``GHC.Integer`` interface and is `BSD3
+<https://opensource.org/licenses/BSD-3-Clause>` licensed. However, it is quite
+slow and infeasible for contexts where big integer multiplication / division are
+in fact required, e.g. public key cryptography.
+
+So, the goal is to have a fast (enough), BSD3-licensed alternative for the
+``Integer`` data type available in GHC.
+
+Proposed Change Specification
+-----------------------------
+
+A new integer library ``integer-openssl`` is added to GHC source tree as
+submodule and selectable via both (Makefile and hadrian) build systems.
+``integer-gmp`` should remain the default integer library, but instructions and
+documentation is updated to allow GHC users to build the compiler using
+``integer-openssl``.
+
+``integer-openssl`` will implement the portable interface of ``GHC.Integer``
+(and ``GHC.Integer.Logarithms`` and ``GHC.Integer.Logarithms.Internals`` if
+required - see open questions).
+
+Libraries depending on GMP internals will be updated to work with
+``integer-openssl`` like they do with work currently with ``integer-simple``.
+
+Effect and Interactions
+-----------------------
+
+By having an alternative integer library, users of GHC can switch the
+``Integer`` backend to ``integer-openssl`` and get a ``ghc`` which is not linked
+against ``libgmp`` but instead ``libcrypto``.
+
+Haskell packages using ``integer-gmp`` internals, and thus depending on
+``integer-gmp``, usually have flags to switch between ``integer-gmp`` and
+``integer-simple``, where the latter typically conforms to the "portable"
+interface. Corresponding flags need to be set by users of those packages when
+they use a GHC compiled against ``integer-openssl``.
+
+In summary, ``integer-openssl`` would be completely opt-in and if packages were
+properly switching between GMP-specific and the standard ``GHC.Integer``
+interface before, they will be able to do as well with ``integer-openssl``.
+
+
+Costs and Drawbacks
+-------------------
+
+Cost for maintaining another integer library is of course existing, as it is now
+with ``integer-simple``. It depends on how stable the ``GHC.Integer`` interface
+is (feedback on any planned changes welcome!).
+
+Alternatives
+------------
+
+Similar efforts for having a permissive licensed integer library existed in the
+past and were discussed or prototypically implemented so far.
+
+* a faster than ``integer-simple``, pure haskell implementation:
+  `https://github.com/erikd/haskell-big-integer-experiment`
+* Wiki page about replacing GMP
+  `https://ghc.haskell.org/trac/ghc/wiki/ReplacingGMPNotes`
+
+
+Unresolved questions
+--------------------
+
+What's the "portable" interface including? Right now there is code in ``base``
+which does not only include ``GHC.Integer`` but also ``GHC.Integer.Logarithms``
+and even ``GHC.Integer.Logarithms.Internals``.
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?
+
+1) Implement the "portable" ``GHC.Integer`` interface for 32bit and 64bit in a
+   library, where implementation is tested and benchmarked against the builtin
+   one.
+
+   Currently, about half of the interface are implemented in
+   `https://github.com/ch1bo/integer-openssl`.
+
+2) Make ``integer-openssl`` a build option for both, Makefile and Hadrian based
+   build of GHC.
+
+   This involves small modifications in ``ghc``, ``base``, ``bytestring`` and
+   ``text`` (mostly ``.cabal`` files in libraries).
+
+   A working in progress is available on `https://github.com/ch1bo/ghc`

--- a/proposals/0000-integer-openssl.rst
+++ b/proposals/0000-integer-openssl.rst
@@ -9,7 +9,9 @@ Add integer-openssl as BSD-licensed alternative for integer-gmp
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/183>`_.
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`__.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
 .. sectnum::
 .. contents::
 
@@ -24,8 +26,8 @@ Motivation
 
 By default, GHC uses ``integer-gmp`` as implementation for the ``GHC.Integer``
 interface. The GNU MP Bignum Library is distributed dual licensed under `LGPLv3
-<https://www.gnu.org/licenses/lgpl.html>` and `GPLv2
-<https://www.gnu.org/licenses/gpl-2.0.html>`. Although being fast and available
+<https://www.gnu.org/licenses/lgpl.html>`_ and `GPLv2
+<https://www.gnu.org/licenses/gpl-2.0.html>`_. Although being fast and available
 on many platforms, these licenses are sometimes undesirable:
 
 * when statically linking (e.g. on Windows)
@@ -33,21 +35,41 @@ on many platforms, these licenses are sometimes undesirable:
 
 The only available alternative is ``integer-simple``, which is a pure haskell
 implementation of the ``GHC.Integer`` interface and is `BSD3
-<https://opensource.org/licenses/BSD-3-Clause>` licensed. However, it is quite
+<https://opensource.org/licenses/BSD-3-Clause>`_ licensed. However, it is quite
 slow and infeasible for contexts where big integer multiplication / division are
 in fact required, e.g. public key cryptography.
 
 So, the goal is to have a fast (enough), BSD3-licensed alternative for the
 ``Integer`` data type available in GHC.
 
+After looking for a BSD-licensed library, ``openssl`` came to mind, which
+implements arbitrary size integer arithmetic in it's `BIGNUM
+<https://github.com/openssl/openssl/tree/master/crypto/bn`_ library incorporated
+into ``libcrypto``. It seems to ticks all boxes:
+
+* BSD-licensed: The OpenSSL license is a `BSD-style license
+  <https://tldrlegal.com/license/openssl-license-(openssl)`_.
+
+* Complete / correct: Documentation and source seems to cover all major
+  operations on big integers - so only a thin layer / wrapper is suitable.
+
+* Fast enough (tm): Early results show a 10-20% worse than `integer-gmp
+  <https://ch1bo.github.io/integer-openssl/openssl-vs-gmp.html>`_ but up to
+  1000% better than `integer-simple
+  <https://ch1bo.github.io/integer-openssl/openssl-vs-simple.html>`_
+  performance.
+
+* Available: ``libcrypto`` is already installed on a lot of systems. Static
+  linking it should be also possiblen and allowed, as with any BSD licensed
+  library.
+
 Proposed Change Specification
 -----------------------------
 
-A new integer library ``integer-openssl`` is added to GHC source tree as
-submodule and selectable via both (Makefile and hadrian) build systems.
-``integer-gmp`` should remain the default integer library, but instructions and
-documentation is updated to allow GHC users to build the compiler using
-``integer-openssl``.
+New integer library ``integer-openssl`` is added to GHC source tree as submodule
+and selectable via both (Makefile and hadrian) build systems. ``integer-gmp``
+should remain the default integer library, but instructions and documentation is
+updated to allow GHC users to build the compiler using ``integer-openssl``.
 
 ``integer-openssl`` will implement the portable interface of ``GHC.Integer``
 (and ``GHC.Integer.Logarithms`` and ``GHC.Integer.Logarithms.Internals`` if
@@ -77,9 +99,10 @@ interface before, they will be able to do as well with ``integer-openssl``.
 Costs and Drawbacks
 -------------------
 
-Cost for maintaining another integer library is of course existing, as it is now
-with ``integer-simple``. It depends on how stable the ``GHC.Integer`` interface
-is (feedback on any planned changes welcome!).
+Cost for maintaining another integer library do of course exist, as it is now
+with ``integer-simple``. It depends however on how stable the ``GHC.Integer``
+interface is. Interface changes of relevant ``openssl`` / ``libcrypto``
+functions is unlikely as the library is very stable and in wide use.
 
 Alternatives
 ------------

--- a/proposals/0000-integer-openssl.rst
+++ b/proposals/0000-integer-openssl.rst
@@ -9,9 +9,7 @@ Add integer-openssl as BSD-licensed alternative for integer-gmp
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/183>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-integer-openssl.rst
+++ b/proposals/0000-integer-openssl.rst
@@ -9,9 +9,7 @@ Add integer-openssl as BSD-licensed alternative for integer-gmp
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`__.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/183>`__.
 .. sectnum::
 .. contents::
 


### PR DESCRIPTION
Proposal to add a fast, BSD-licensed alternative for GHC's Integer type, next to currently available `integer-gmp` (default, fast and LPGL3-licensed) and `integer-simple` (slow, but pure and BSD3-licensed) implementations. Concretely, this would use OpenSSLs "BIGNUM" arbitrary size integer library contained in `libcrypto`.

[Rendered](https://github.com/ch1bo/ghc-proposals/blob/patch-1/proposals/0000-integer-openssl.rst)