### PR TITLE
GRC: Improve language for Stack code of conduct

### DIFF
--- a/GRC.rst
+++ b/GRC.rst
@@ -85,7 +85,7 @@ Acknowledgements
 We'd like to thank the communities and projects that established code of
 conducts and diversity statements as our inspiration, including these:
 
-* One month before this document was first published, Michael Snoyman proposed
+* A month before this document was first published, Michael Snoyman proposed
   a `Stack code of conduct
   <https://www.snoyman.com/blog/2018/11/proposal-stack-coc>`_ with a
   motivation similar to ours.

--- a/GRC.rst
+++ b/GRC.rst
@@ -85,10 +85,10 @@ Acknowledgements
 We'd like to thank the communities and projects that established code of
 conducts and diversity statements as our inspiration, including these:
 
-* In our own community, Michael Snoyman has recently (2018) started a process
-  for a `Stack code of conduct
-  <https://www.snoyman.com/blog/2018/11/proposal-stack-coc>`_, with similar
-  motivations ours.
+* One month before this document was first published, Michael Snoyman proposed
+  a `Stack code of conduct
+  <https://www.snoyman.com/blog/2018/11/proposal-stack-coc>`_ with a
+  motivation similar to ours.
 * The `GNU Kind Communication Guidelines
   <https://www.gnu.org/philosophy/kind-communication.html>`_, published in
   October 2018, also express the positive tone we seek; `Stallman’s post


### PR DESCRIPTION
1. Change “similar motivations ours” to “a motivation similar to ours”
2. Use language that does not require knowing the time of publication