### PR TITLE
Replace "explicit code of conduct" with "set of guidelines for respec…

### DIFF
--- a/GRC.rst
+++ b/GRC.rst
@@ -15,7 +15,8 @@ standard, in the hope that others may voluntarily follow suit.
 Motivation
 ----------
 
-We are motivated to adopt an explicit code of conduct for several reasons
+We are motivated to adopt a set of guidelines for respectful communication for 
+several reasons
 
 * Diversity and inclusion.  We recognize that the Haskell community, echoing
   the technology industry more generally, skews white and male. We see it as our


### PR DESCRIPTION
As per Simon Peyton Jones' email sent out to the "GHC-Devs" mailing list on December 6, he says that he wants to avoid calling this a "Code of Conduct" and prefers to refer to it as "guidelines for respectful communication" because "[he wants] to encourage good communication, rather than focus on bad behaviour".
Therefore, I propose updating this file to replace "explicit code of conduct" with "set of guidelines for respectful communication".