### PR TITLE
Module qualified syntax

### DIFF
--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -27,9 +27,6 @@ To import a qualified module you must specify ``qualified`` in prepositive posit
  import           B
  import           C
 
-
-
-
 We propose to also allow ``qualified`` to appear in postpositive position : ``import M qualified``. In that case, one could write:
 
 ::

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -43,7 +43,7 @@ The ``importdecl`` production is updated like so:
    importdecl :: { LImportDecl GhcPs }
         : 'import' maybe_src maybe_safe optqualified maybe_pkg modid optqualified maybeas maybeimpspec
 
-A new warning ``-Wprepositive-qualified-module`` is introduced that when set, warns on prepositive syntax:
+A new language extension `QualifiedImportsPostpositive` is introduced. When enabled, `qualified` will be accepted in postpositive positition and a new warning ``-Wprepositive-qualified-module`` introduced that when set, warns on prepositive syntax:
 
 ::
 

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -19,7 +19,7 @@ We propose to allow the syntax ``import M qualified`` to solve hanging indents i
 
 Motivation
 ----------
-To import a qualified module you must specify ``qualified`` in prepositive position : ``import qualified M``. This often leads to a "hanging indent" (which is automatically inserted by `some autoformatters <https://github.com/commercialhaskell/hindent/blob/master/src/HIndent.hs>`_ and `common <https://github.com/owickstrom/gi-gtk-declarative/blob/master/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Class.hs>`_ `in <https://github.com/commercialhaskell/intero/blob/master/src/GhciFind.hs>`_ `many <https://github.com/aristidb/aws/blob/master/Aws/Iam/Core.hs>`_  `code <https://github.com/input-output-hk/cardano-sl/blob/develop/explorer/src/Pos/Explorer/DB.hs>`_ `bases <https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/Error.hs>`_). For example:
+To import a qualified module you must specify ``qualified`` in prepositive position : ``import qualified M``. This often leads to a "hanging indent" (which is automatically inserted by some `autoformatters <https://github.com/commercialhaskell/hindent/blob/master/src/HIndent.hs>`_ and `common <https://github.com/owickstrom/gi-gtk-declarative/blob/master/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Class.hs>`_ `in <https://github.com/commercialhaskell/intero/blob/master/src/GhciFind.hs>`_ `many <https://github.com/aristidb/aws/blob/master/Aws/Iam/Core.hs>`_  `code <https://github.com/input-output-hk/cardano-sl/blob/develop/explorer/src/Pos/Explorer/DB.hs>`_ `bases <https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/Error.hs>`_). For example:
 
 ::
 

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -43,7 +43,7 @@ The ``importdecl`` production is updated like so:
    importdecl :: { LImportDecl GhcPs }
         : 'import' maybe_src maybe_safe optqualified maybe_pkg modid optqualified maybeas maybeimpspec
 
-A new language extension `QualifiedImportsPostpositive` is introduced. When enabled, `qualified` will be accepted in postpositive positition and a new warning ``-Wprepositive-qualified-module`` introduced that when set, warns on prepositive syntax:
+A new language extension ``QualifiedImportsPostpositive`` is introduced. When enabled, ``qualified`` will be accepted in postpositive positition and a new warning ``-Wprepositive-qualified-module`` introduced that when set, warns on prepositive syntax:
 
 ::
 

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -77,6 +77,7 @@ The second alternative solves the motivating hanging indent issue but in our opi
 Unresolved Questions
 --------------------
 (1) Perhaps the proposed warning is uneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
+(2) What precisely should happen if under ``QualifiedImportsPostpositive``, ``qualified`` is encountered in both pre- and post-positive position? For example, ``import qualified Data.Map qualified as M`?
 
 Implementation Plan
 -------------------

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -19,13 +19,16 @@ We propose to allow the syntax ``import M qualified`` to solve hanging indents i
 
 Motivation
 ----------
-To import a qualified module you must specify ``qualified`` in prepositive position : ``import qualified M``. This often leads to a "hanging indent". For example:
+To import a qualified module you must specify ``qualified`` in prepositive position : ``import qualified M``. This often leads to a "hanging indent" (which is automatically inserted by `some autoformatters <https://github.com/commercialhaskell/hindent/blob/master/src/HIndent.hs>`_ and `common <https://github.com/owickstrom/gi-gtk-declarative/blob/master/gi-gtk-declarative/src/GI/Gtk/Declarative/Container/Class.hs>`_ `in <https://github.com/commercialhaskell/intero/blob/master/src/GhciFind.hs>`_ `many <https://github.com/aristidb/aws/blob/master/Aws/Iam/Core.hs>`_  `code <https://github.com/input-output-hk/cardano-sl/blob/develop/explorer/src/Pos/Explorer/DB.hs>`_ `bases <https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/Error.hs>`_). For example:
 
 ::
 
  import qualified A
  import           B
  import           C
+
+
+
 
 We propose to also allow ``qualified`` to appear in postpositive position : ``import M qualified``. In that case, one could write:
 

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -37,8 +37,7 @@ While a small change, this annoyance is a significant issue in many large codeba
 
 Proposed Change Specification
 -----------------------------
-
-A new language extension ``QualifiedImportsPostpositive`` is introduced. When enabled, ``qualified`` will be accepted in postpositive position, by updating the ``importdecl`` production like so:
+A new language extension ``ImportQualifiedPost`` is introduced. When enabled, ``qualified`` will be accepted in postpositive position, by updating the ``importdecl`` production like so:
 
 ::
 
@@ -58,13 +57,15 @@ A new warning ``-Wprepositive-qualified-module`` (off by default) will be introd
 
 Effect and Interactions
 -----------------------
-The proposed change adds the ability to specify a qualified import by placing ``qualified`` either before or after the module name. The position of the ``qualified`` does not change the semantics, and is independent from any other import features (e.g. package imports or safe annotations).  As an example, both ``import qualified D as E`` and ``import D qualified as E`` are permitted and equivalent.
+The proposed change adds the ability to specify a qualified import by placing ``qualified`` either before or after the module name. Under ``ImportQualifiedPost``, ``qualified`` will be permitted in either pre- or post-positive positions (but not both). If in the future we decide to deprecate the pre-positive syntax, we would make an extension flag for that and allow it to be turned off.
+
+The position of the ``qualified`` does not change the semantics, and is independent from any other import features (e.g. package imports or safe annotations).  As an example, both ``import qualified D as E`` and ``import D qualified as E`` are permitted and equivalent.
 
 There should be no other interactions with any existing language or compiler features.
 
 Costs and Drawbacks
 -------------------
-The implementation of the change is but a few lines (``Parser.y`` for the grammar and ``RdrHsSyn.hs`` for the warning). The increased flexibility comes with no discernible drawbacks.
+The implementation of the change is but a few lines (``Parser.y`` for the grammar and ``RdrHsSyn.hs`` for warnings/errors). The increased flexibility comes with no discernible drawbacks.
 
 Alternatives
 ------------
@@ -76,8 +77,7 @@ The second alternative solves the motivating hanging indent issue but in our opi
 
 Unresolved Questions
 --------------------
-(1) Perhaps the proposed warning is unneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
-(2) What precisely should happen if under ``QualifiedImportsPostpositive``, ``qualified`` is encountered in both pre- and post-positive position? For example, ``import qualified Data.Map qualified as M``?
+There are no remaining unresolved questions.
 
 Implementation Plan
 -------------------

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -76,7 +76,7 @@ The second alternative solves the motivating hanging indent issue but in our opi
 
 Unresolved Questions
 --------------------
-(1) Perhaps the proposed warning is uneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
+(1) Perhaps the proposed warning is unneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
 (2) What precisely should happen if under ``QualifiedImportsPostpositive``, ``qualified`` is encountered in both pre- and post-positive position? For example, ``import qualified Data.Map qualified as M``?
 
 Implementation Plan

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -1,0 +1,81 @@
+Allow ``qualified`` to follow module name
+=========================================
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+We propose to allow the syntax ``import M qualified`` to solve hanging indents in module import lists.
+
+Motivation
+----------
+To import a qualified module you must specify ``qualified`` in prepositive position : ``import qualified M``. This often leads to a "hanging indent". For example:
+
+::
+
+ import qualified A
+ import           B
+ import           C
+
+We propose to also allow ``qualified`` to appear in postpositive position : ``import M qualified``. In that case, one could write:
+
+::
+
+   import A qualified
+   import B
+   import C
+
+Proposed Change Specification
+-----------------------------
+
+The ``importdecl`` production is updated like so:
+
+::
+
+   importdecl :: { LImportDecl GhcPs }
+        : 'import' maybe_src maybe_safe optqualified maybe_pkg modid optqualified maybeas maybeimpspec
+
+A new warning ``-Wprepositive-qualified-module`` is introduced that when set, warns on prepositive syntax:
+
+::
+
+  /Users/shaynefletcher/Preposition.hs:5:8: warning: [-Wprepositive-qualified-module]
+      Found ‘qualified’ in prepositive position
+      Suggested fix: place  ‘qualified’ after the module name instead.
+    |
+  5 | import qualified Data.List
+    |        ^^^^^^^^^
+
+Effect and Interactions
+-----------------------
+The proposed change adds the ability to specify a qualified import by placing ``qualified`` either before or after the module name (or both). A warning may be optionally enabled that alerts usages of ``qualified`` in prepositive position. There should be no other interactions with any existing language or compiler features.
+
+Costs and Drawbacks
+-------------------
+The implementation of the change is but a few lines (``Parser.y`` for the grammar and ``RdrHsSyn.hs`` for the warning). The increased flexibility comes with no discernible drawbacks.
+
+Alternatives
+------------
+The alternatives appear to be:
+(1) Keep the status-quo and do not allow the alternate syntax;
+(2) Mandate the alternative syntax and formulate a migration strategy.
+
+The second alternative solves the motivating hanging indent issue but in our opinion both alternatives seem needlessly strict when both conventions can be had cheaply with only upside.
+
+Unresolved Questions
+--------------------
+There are no unresolved questions at this time.
+
+Implementation Plan
+-------------------
+If accepted, the proposal authors will implement the change.

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -77,7 +77,7 @@ The second alternative solves the motivating hanging indent issue but in our opi
 Unresolved Questions
 --------------------
 (1) Perhaps the proposed warning is uneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
-(2) What precisely should happen if under ``QualifiedImportsPostpositive``, ``qualified`` is encountered in both pre- and post-positive position? For example, ``import qualified Data.Map qualified as M`?
+(2) What precisely should happen if under ``QualifiedImportsPostpositive``, ``qualified`` is encountered in both pre- and post-positive position? For example, ``import qualified Data.Map qualified as M``?
 
 Implementation Plan
 -------------------

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -33,21 +33,23 @@ We propose to also allow ``qualified`` to appear in postpositive position : ``im
    import B
    import C
 
+While a small change, this annoyance is a significant issue in many large codebases, where programmers are forced to "pick a style" - chosing to add redundant whitespace to have modules align, or to make scanning import lists harder. Additionally, the location of `qualified` makes sorting imports harder.
+
 Proposed Change Specification
 -----------------------------
 
-The ``importdecl`` production is updated like so:
+A new language extension ``QualifiedImportsPostpositive`` is introduced. When enabled, ``qualified`` will be accepted in postpositive position, by updating the ``importdecl`` production like so:
 
 ::
 
    importdecl :: { LImportDecl GhcPs }
         : 'import' maybe_src maybe_safe optqualified maybe_pkg modid optqualified maybeas maybeimpspec
 
-A new language extension ``QualifiedImportsPostpositive`` is introduced. When enabled, ``qualified`` will be accepted in postpositive positition and a new warning ``-Wprepositive-qualified-module`` introduced that when set, warns on prepositive syntax:
+A new warning ``-Wprepositive-qualified-module`` (off by default) will be introduced that warns on prepositive syntax:
 
 ::
 
-  /Users/shaynefletcher/Preposition.hs:5:8: warning: [-Wprepositive-qualified-module]
+  Preposition.hs:5:8: warning: [-Wprepositive-qualified-module]
       Found ‘qualified’ in prepositive position
       Suggested fix: place  ‘qualified’ after the module name instead.
     |
@@ -56,7 +58,9 @@ A new language extension ``QualifiedImportsPostpositive`` is introduced. When en
 
 Effect and Interactions
 -----------------------
-The proposed change adds the ability to specify a qualified import by placing ``qualified`` either before or after the module name (or both). A warning may be optionally enabled that alerts usages of ``qualified`` in prepositive position. There should be no other interactions with any existing language or compiler features.
+The proposed change adds the ability to specify a qualified import by placing ``qualified`` either before or after the module name. The position of the ``qualified`` does not change the semantics, and is independent from any other import features (e.g. package imports or safe annotations).  As an example, both ``import qualified D as E`` and ``import D qualified as E`` are permitted and equivalent.
+
+There should be no other interactions with any existing language or compiler features.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -9,9 +9,7 @@ Allow ``qualified`` to follow module name
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/190>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-module-qualified-syntax.rst
+++ b/proposals/0000-module-qualified-syntax.rst
@@ -76,7 +76,7 @@ The second alternative solves the motivating hanging indent issue but in our opi
 
 Unresolved Questions
 --------------------
-There are no unresolved questions at this time.
+(1) Perhaps the proposed warning is uneccessary and under ``QualifiedImportsPostpositive`` the prepositive form should be a syntax error?
 
 Implementation Plan
 -------------------


### PR DESCRIPTION
A proposal for `import M qualified` syntax.

[Rendered](https://github.com/shayne-fletcher-da/ghc-proposals/blob/module-qualified-syntax/proposals/0000-module-qualified-syntax.rst)