### PR TITLE
Named type arguments

### DIFF
--- a/proposals/0042-named-type-args.rst
+++ b/proposals/0042-named-type-args.rst
@@ -9,7 +9,7 @@ Proposal title
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/196>`_.
             **After creating the pull request, edit this file again, update the
             number in the link, and delete this bold sentence.**
 .. sectnum::


### PR DESCRIPTION
This is a proposal extending type application syntax with the syntax of record field updates.

[Rendered](https://github.com/niobium0/ghc-proposals/blob/patch-1/proposals/0042-named-type-args.rst)