### PR TITLE
Source plugins were implemented in GHC 8.6

### DIFF
--- a/proposals/0017-source-plugins.rst
+++ b/proposals/0017-source-plugins.rst
@@ -3,7 +3,7 @@ Source plugins
 
 .. proposal-number:: 17
 .. trac-ticket:: 14709
-.. implemented::
+.. implemented:: 8.6
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/107>`_.
 .. contents::


### PR DESCRIPTION
Specifically, in commit https://gitlab.haskell.org/ghc/ghc/commit/c2783ccf545faabd21a234a4dfc569cd856082b9, where it all started.