### PR TITLE
Update the 'implemented' fields of some proposals

### DIFF
--- a/proposals/0024-no-kind-vars.rst
+++ b/proposals/0024-no-kind-vars.rst
@@ -3,7 +3,7 @@ Treat kind variables and type variables identically in ``forall``
 
 .. proposal-number:: 24
 .. trac-ticket:: #15264
-.. implemented::
+.. implemented:: 8.10
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/103>`_.
 .. sectnum::

--- a/proposals/0035-forall-arrow.rst
+++ b/proposals/0035-forall-arrow.rst
@@ -2,8 +2,8 @@ A syntax for visible dependent quantification
 =============================================
 
 .. proposal-number:: 35
-.. trac-ticket::
-.. implemented::
+.. trac-ticket:: #16326
+.. implemented:: 8.10
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/81>`_.
 .. sectnum::

--- a/proposals/0039-dot-type-operator.rst
+++ b/proposals/0039-dot-type-operator.rst
@@ -3,7 +3,7 @@ The dot type operator
 
 .. proposal-number:: 39
 .. trac-ticket::
-.. implemented::
+.. implemented:: 8.8
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/173>`_.
 .. sectnum::

--- a/proposals/0043-forall-keyword.rst
+++ b/proposals/0043-forall-keyword.rst
@@ -3,7 +3,7 @@ Make ``forall`` a keyword
 
 .. proposal-number:: 43
 .. trac-ticket:: !363
-.. implemented::
+.. implemented:: 8.8
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/193>`_.
 .. sectnum::
@@ -44,7 +44,7 @@ What do they mean? It depends on what extensions are in force.
 What's troublesome here is that a user might write one of these signatures, intending for quantification,
 but forgetting to enable ``-XExplicitForAll``. Instead of getting a helpful error message asking that
 they enable ``-XExplicitForAll``, they would get obscure type errors.
-  
+
 Proposed Change Specification
 -----------------------------
 The lexeme ``forall`` is understood to be a keyword in types, always. Similarly, the unicode variant


### PR DESCRIPTION
Four GHC proposals were recently implemented:

* Treat kind variables and type variables identically in `forall` (in [5bc195b1](https://gitlab.haskell.org/ghc/ghc/commit/5bc195b1fe788e9a900a15fbe473967850517c3e))
* A syntax for visible dependent quantification (in [c26d299d](https://gitlab.haskell.org/ghc/ghc/commit/c26d299dc422f43b8c37da4b26da2067eedcbae8))
* The dot type operator (in [887454d8](https://gitlab.haskell.org/ghc/ghc/commit/887454d8889ca5dbba70425de41d97939cb9ac60))
* Make `forall` a keyword (in [887454d8](https://gitlab.haskell.org/ghc/ghc/commit/887454d8889ca5dbba70425de41d97939cb9ac60))