### PR TITLE
Local do

### DIFF
--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -979,7 +979,7 @@ to be more flexible about how builders are used. For instance,
 
   (f builder).do { stmts }
 
-where ``f`` is some transformer on builders. It is no possible to be so
+where ``f`` is some transformer on builders. It is not possible to be so
 succint with ``TypeClass.do``.
 
 Related work

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -162,9 +162,9 @@ raise an error *even if there is a value for ``(>>=)`` in scope*.
 
 Enabling ``-XQualifiedDo`` doesn't change the meaning of existing do-expressions.
 
-When both ``QualifiedDo`` and ``RebindableSyntax`` are enabled, ``QualifiedDo`` only affects qualified ``do``'s and ``RebindableSyntax`` affects the unqualified ``do``'s.
+When both ``-XQualifiedDo`` and ``-XRebindableSyntax`` are enabled, ``-XQualifiedDo`` only affects qualified ``do``'s and ``-XRebindableSyntax`` affects the unqualified ``do``'s.
 
-In principle, `QualifiedDo` would not affect monad comprehensions, though we could
+In principle, ``-XQualifiedDo`` would not affect monad comprehensions, though we could
 imagine a similar mechanism to qualify the names in the desugared expressions
 given some suitable syntax to specify the qualifier.
 

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -530,11 +530,15 @@ This single record is easier to import, export and document.
 
 Another downside is that error messages are less specific. Compare
 
-* “Desugaring statement <stmt> requires <field name> but builder <builder expression> doesn't provide it”
+* “Desugaring statement <stmt> requires a ``fail`` field but builder <builder expression> doesn't provide it”
 
 with
 
-* “Desugaring statement <stmt> requires ``M.>>`` which is not in scope”
+* “Desugaring statement <stmt> requires ``M.fail`` which is not in scope”
+
+In the later case, ``M.fail`` may need a new import statement, or maybe there is
+a typo in an import statement, or maybe ``fail`` is just not supported for this
+particular use of ``do`` notation.
 
 
 Qualified do with parameters

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -96,7 +96,7 @@ The semantics of ``do`` notation statements is given as follows (using
 
   ::
 
-    M.do { (x1 <- u1 | … | xn <- un); return e }  =
+    M.do { (x1 <- u1 | … | xn <- un); M.return e }  =
       (\x1 … xn -> e) M.<$> u1 M.<*> … M.<*> un
 
     M.do { (x1 <- u1 | … | xn <- un); stmts }  =

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -9,9 +9,7 @@ Local do
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/216>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -106,7 +106,7 @@ The semantics of ``do`` notation statements is given as follows (using
 
 It is, crucially, not required that the record projections be in scope unqualified (otherwise projections of various builders would shadow one-another).
 
-If a field is required by the desugaring process (and only if it's required!) but the builder's type doesn't have such a type, an error message is produced:
+If a field is required by the desugaring process (and only if it's required!) but the builder's type doesn't have such a field, an error message is produced:
 
 * “Desugaring statement <stmt> requires <field name> but builder <builder name> doesn't provide it”
 

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -1,0 +1,155 @@
+Proposal title
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+This proposal introduces a new extension ``-XLocalDo`` which makes it possible to overload the meaning of a do-notation expression *on a case-by-case basis* (as opposed to the global effect of ``-XRebindableSyntax``), by writing ``do @builder``. The design is inspired by F#'s [computational expressions](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions).
+
+
+Motivation
+------------
+
+There are many kinds of monad-like things out there:
+
+* monads
+* indexed monads
+* graded monads
+* relative monads
+* linear variants of all the above once `linear types <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_
+* …
+
+All of these are theoretically compatible with the do-notation. And, in fact, really want the do-notation to work for them. After all, the entire existence of the do-notation can be ascribed to: “it's really annoying to program with ``(>>=)`` all the time”.
+
+The prescribed solution to use ``-XRebindableSyntax``. But ``-XRebindableSyntax`` is a very blunt instrument:
+
+* It affects many syntactic constructs (numerical literals, the ``if then else`` syntax, … (see the `full list <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-RebindableSyntax>`_)).
+* It implies ``-XNoImplicitPrelude``
+* It uses the same rebinding for all the do-expression in an entire file.
+
+You may not want all this. For instance, with linear types ``if then else`` syntax cannot be meaningfully rebound to a function. And there is no reason why a file wouldn't have a piece code referring to a monad, one to a graded monad, and one to a linear relative monad.
+
+Proposed Change Specification
+-----------------------------
+
+This proposal creates a new language extension ``-XLocalDo``.
+
+When ``-XLocalDo`` is activated, the syntax of the ``do`` notation is changed to
+
+::
+  <lexp> ⟶ do [@<aexp>]
+
+(``aexp`` means that the notation after the ``@`` is parsed as a variable, unless there are parentheses)
+
+The additional expression is called the *builder* of the do-expression. A builder's type must be a record, other than that the type is immaterial.
+
+Desugaring is then performed as follows:
+
+* Desugaring a ``x <- u`` statement uses the ``(>>=)`` field of the builder
+* Desugaring a ``u`` statement uses ``(>>)`` field of the builder
+* Desugaring a ``pat <- u`` statement uses ``fail`` field of the builder
+* ``-XApplicativeDo`` uses the ``(<*>)`` field of the builder
+
+It is, crucially, not required that the record projections be in scope unqualified (otherwise projections of various builders would shadow one-another).
+
+If a field is required by the desugaring process (and only if it's required!) but the builder's type doesn't have such a type, an error message is produced:
+
+* “Desugaring statement <stmt> requires <field name> but builder <builder name> doesn't provide it”
+
+The fields of a builder are subject to the same type restrictions as their counterparts with ``-XRebindableSyntax``.
+
+When the ``@<aexp>`` annotation is omitted, the builder is taken to be whatever is named ``builder`` in scope.
+
+A standard builder is added to ``Control.Monad`` and re-exported in the ``Prelude``:
+
+::
+
+  -- For simplicity, this ignores the namespacing issues
+
+  data StandardBuilder = StandardBuilder
+    { (>>=) :: Monad m => m a -> (a -> m b) -> m b
+    , (>>) :: Monad m => m a -> m b -> m b
+    , fail :: MonadFail m => m a
+    , (<*>) :: Applicative f => f (a -> b) -> f a -> f b
+    }
+
+  builder :: StandardBuilder
+  builder = StandardBuilder (>>=) (>>) fail (<*>)
+
+Effect and Interactions
+-----------------------
+
+``-XLocalDo`` make it possible to choose, for each individual do-expressions, what kind of monad-like notion they are about. Even if the monad-like notion doesn't support all the range of desugaring (for instance it doesn't have a ``fail``), this will still work, as long as the do-expression doesn't use the corresponding feature (in our example: pattern-binders).
+
+For instance we could make a builder for monoids:
+
+::
+
+  module Data.Monoid.Builder where
+    data MonoidBuilder = MonoidBuilder
+      { (>>) :: Monoid a => a -> a -> a
+      }
+
+    builder :: MonoidBuilder
+    builder = MonoidBuilder (<>)
+
+  module X where
+    import qualified Data.Monoid.Builder as Monoid
+
+    f = do @Monoid.builder
+      Sum 2
+      Sum 3
+      Sum 5
+      Sum 8
+
+If one would try to use ``x <- u`` with ``Monoid.builder``, GHC would
+raise an error *even if there is a value for ``(>>=)`` in scope*.
+
+Importing ``-XLocalDo`` doesn't change the meaning of existing do-expressions: they will pick up the ``builder`` from the ``Prelude``, which has the same meaning as current default.
+
+``LocalDo`` interferes with ``RebindableSyntax``. We propose that ``LocalDo`` take precedence when both are enabled.
+
+The syntax was chosen to resemble that of visible type applications (as it also makes visible arguments which were previously hidden). There is no syntax conflicts, as ``do`` is not actually a function, therefore the notation ``@<expr>`` cannot occur at this site currently. This is still true after `Type applications in patterns <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0031-type-applications-in-patterns.rst>`_, even if one chooses to use the whitespace syntax *and* writes the first statement on the same line as the ``do``: no pattern can start with an ``@``.
+
+Costs and Drawbacks
+-------------------
+
+The do-expression store, during type-checking, which expression they will use for ``(>>=)``, etc… So the core infrastructure is actually already there. We anticipate the cost of implementation and maintenance of this feature to be very low.
+
+Alternatives
+------------
+
+* One could use ``-XRebindableSyntax`` and use a very general type class which encompasses all monads
+
+  * This was the essence of the `OverloadedDo proposal <https://github.com/ghc-proposals/ghc-proposals/pull/78>`_, though type inference was never solved for this
+  * A more recent idea is `supermonads <http://www.cs.nott.ac.uk/~psznhn/Publications/jfp2018.pdf>`_, which solves the type inference issue using a plugin
+
+  It requires somewhat less work (“only” a plugin, rather than a change in GHC's compiler, at least it's more modular), and is more automatic, as the correct functions are picked automatically from the type. But there is no way that this will capture all the desired notion: some restrictions need be imposed for the sake of type inference. Note as well that this proposal doesn't preclude an automatic approach when appropriate: simply import your very automatic builder in scope, and all the do-expressions without an explicit builder will use this.
+
+* There is a way to emulate ``-XLocalDo`` in current GHC using ``-XRecordWildcards``: have no ``(>>=)`` and such in scope, and import a builder with ``Builder {..} = builder``. It is used in `linear-base <https://github.com/tweag/linear-base/blob/0d6165fbd8ad84dd1574a36071f00a6137351637/src/System/IO/Resource.hs#L119-L120>`_. This is not a very good solution: it is rather a impenetrable idiom, and, if a single function uses several builders, it yields syntactic contortion (which is why shadowing warnings are deactivated `here <https://github.com/tweag/linear-base/blob/0d6165fbd8ad84dd1574a36071f00a6137351637/src/System/IO/Resource.hs#L1>`_)
+
+* Instead of changing the ``Prelude``, the standard builder could be
+  hosted in a separate module (such as ``Ghc.LocalDo``), and the
+  programmer could ``import Ghc.LocalDo`` when they use ``-XLocalDo``.
+
+* An alternative to the ``@<aexpr>`` notation would be to use implicit parameters, somehow. But it's unclear how exactly it would look.
+
+Unresolved Questions
+--------------------
+
+None.
+
+
+Implementation Plan
+-------------------

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -210,7 +210,7 @@ An example of linear ``do`` blocks follows, mixed with non-linear
 
   {-# LANGUAGE LinearTypes #-}
   {-# LANGUAGE NoImplicitPrelude #-}
-  module Control.Monad.Linear.Internal (Monad(..), linear) where
+  module Control.Monad.Linear.Internal (Monad(..)) where
 
   class Monad m where
     return :: a #-> m a
@@ -474,7 +474,7 @@ This is an example with the linear monad
 
   {-# LANGUAGE LinearTypes #-}
   {-# LANGUAGE NoImplicitPrelude #-}
-  module Control.Monad.Linear (Monad(..), linear) where
+  module Control.Monad.Linear (Monad(..)) where
 
   class Monad m where
     return :: a #-> m a

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -127,7 +127,7 @@ The semantics of ``do`` notation statements is given as follows (using
        ; stmts
        }
 
-If a name ``M.op`` is required by the desugaring process (and only if it's required!) but the name is not in scope, an error message is produced:
+If a name ``M.op`` is required by the desugaring process (and only if it's required!) but the name is not in scope, an error message like the following is produced:
 
 * “Desugaring statement <stmt> requires <M.op> which is not in scope”
 

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -15,7 +15,7 @@ Proposal title
 .. sectnum::
 .. contents::
 
-This proposal introduces a new extension ``-XLocalDo`` which makes it possible to overload the meaning of a do-notation expression *on a case-by-case basis* (as opposed to the global effect of ``-XRebindableSyntax``), by writing ``do @builder``. The design is inspired by F#'s [computational expressions](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions).
+This proposal introduces a new extension ``-XLocalDo`` which makes it possible to overload the meaning of a do-notation expression *on a case-by-case basis* (as opposed to the global effect of ``-XRebindableSyntax``), by writing ``do @builder``. The design is inspired by F#'s  `computational expressions <https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions>`_.
 
 
 Motivation
@@ -48,6 +48,7 @@ This proposal creates a new language extension ``-XLocalDo``.
 When ``-XLocalDo`` is activated, the syntax of the ``do`` notation is changed to
 
 ::
+
   <lexp> ⟶ do [@<aexp>]
 
 (``aexp`` means that the notation after the ``@`` is parsed as a variable, unless there are parentheses)
@@ -153,3 +154,5 @@ None.
 
 Implementation Plan
 -------------------
+
+The implementation shouldn't require too much effort. Matthías Páll (`@tritlo <https://github.com/Tritlo>`_) volunteers himself for the attempt, in collaboration with Arnaud (`@aspiwack <https://github.com/aspiwack>`_).

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -67,10 +67,12 @@ The additional expression is called the *builder* of the do-expression. The foll
 * ``K`` must be a record constructor, defining fields with any of the following names:
   ``(>>=)``, ``(>>)``, ``fail``, ``return``, ``<*>``, and ``<$>``.
 
-We say that an expression **has a fully settled type** when
+We say that an expression **has the fully settled type** ``T`` when
 
-* it is an identifier imported from another module, or
-* it is of the form ``expr @ty`` where `expr` **has a fully settled type**.
+* it is of the form ``e :: T``, or
+* it is an identifier imported from another module with type ``T``, or
+* it is of the form ``expr @ty`` where `expr` **has a fully settled type**
+  ``forall a. T``.
 
 The semantics of ``do`` notation statements is given as follows (using
 ``-XLambdaCase`` notation and fresh variables ``v, v1, …, vn``):

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -1,5 +1,5 @@
-Proposal title
-==============
+Local do
+========
 
 .. proposal-number:: Leave blank. This will be filled in when the proposal is
                      accepted.

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -26,7 +26,8 @@ There are many kinds of monad-like things out there:
 * graded monads
 * relative monads
 * linear variants of all the above once `linear types
-  <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_
+  <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_ are
+  implemented
   * in particular, the linear IO monad from the `Linear Haskell paper
     <https://arxiv.org/abs/1710.09756>`_ is an example of a linear
     graded monad

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -100,7 +100,7 @@ The semantics of ``do`` notation statements is given as follows (using
       (\x1 … xn -> e) M.<$> u1 M.<*> … M.<*> un
 
     M.do { (x1 <- u1 | … | xn <- un); stmts }  =
-      M.join (\x1 … xn -> M.do { stmts }) M.<$> u1 M.<*> … M.<*> un
+      M.join ((\x1 … xn -> M.do { stmts }) M.<$> u1 M.<*> … M.<*> un)
 
 
   Note that ``M.join`` is only needed if the final expression is

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -195,6 +195,30 @@ The do-expression store, during type-checking, which expression they will use fo
 Alternatives
 ------------
 
+Syntax variations
+~~~~~~~~~~~~~~~~~
+
+In the pull request discussion some concerns were raised about the use of the syntax ``do @builder``, as ``builder`` is not a type (``@`` is typically followed by a type) and because a competing idea would be to have ``do @MonadType`` be the regular ``do`` on monads, but with the monad specified.
+
+Both points can be addressed
+
+- ``@`` is better understood as something which makes an *invisible* argument visible. As it happens, invisible arguments in current Haskell are always types, but it may be best to consider it a coincidence. Especially as Haskell is moving towards more type dependency and more control over the visibility of arguments.
+- It is possible, within the changes of this proposal, to specify the monad type:
+
+  ::
+
+    do @(builder @MonadType)
+      <do block>
+
+  where ``builder`` is the default builder from ``Control.Monad`` (in the discussion of the pull request, this ``builder`` was also referred to as ``withMonad``).
+
+Nevertheless an alternative syntax has been proposed:
+
+- ``do via <aexpr>``. It is modelled after the ``deriving via`` construction. The implications on the parser are less clear then ``@<aexpr>``, however.
+
+Related work
+~~~~~~~~~~~~
+
 * One could use ``-XRebindableSyntax`` and use a very general type class which encompasses all monads
 
   * This was the essence of the `OverloadedDo proposal <https://github.com/ghc-proposals/ghc-proposals/pull/78>`_, though type inference was never solved for this

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -25,7 +25,11 @@ There are many kinds of monad-like things out there:
 * indexed monads
 * graded monads
 * relative monads
-* linear variants of all the above once `linear types <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_
+* linear variants of all the above once `linear types
+  <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_
+  * in particular, the linear IO monad from the `Linear Haskell paper
+    <https://arxiv.org/abs/1710.09756>`_ is an example of a linear
+    graded monad
 * …
 
 All of these are theoretically compatible with the do-notation. And, in fact, really want the do-notation to work for them. After all, the entire existence of the do-notation can be ascribed to: “it's really annoying to program with ``(>>=)`` all the time”.

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -362,7 +362,8 @@ We say that an expression **has the fully settled type** ``T`` when
 * it is of the form ``e :: T``, or
 * it is an identifier imported from another module with type ``T``, or
 * it is of the form ``expr @ty`` where `expr` **has a fully settled type**
-  ``forall a. T``.
+  ``forall a. T``, or
+* it is of the form ``expr1 expr2`` where ``expr1`` **has a fully settled type** ``T1 -> T``.
 
 The semantics of ``do`` notation statements is given as follows (using
 ``-XLambdaCase`` notation and fresh variables ``v, v1, …, vn``):

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -516,12 +516,26 @@ from different modules if they are imported with the same qualifier:
         g
         return x
 
-Despite of its verbosity when compared to the ``M.do`` approach, the
-``builder.do`` approach is preferred because it groups in a single record
-the operations that work together when desugaring a ``builder.do`` block.
-This single record is easier to import, export and document. In contrast,
-when using ``M.do``, one has to make sure to bring all the needed
-operations into scope.
+The advantages of this approach are that it doesn't need the programmer
+to understand a new notion of expressions having fully settled types.
+Moreover, no type information is necessary to desugar the do notation.
+And lastly, there is no need to write builders: the monadic and applicative
+operations can be brought into scope right from the places where they
+are defined or exported.
+
+A downside of ``M.do`` is that it requires to bring into scope all the
+operations that a ``do`` block needs. In contrast, the builder approach
+only requires to bring a single entity into scope: the builder.
+This single record is easier to import, export and document.
+
+Another downside is that error messages are less specific. Compare
+
+* “Desugaring statement <stmt> requires <field name> but builder <builder expression> doesn't provide it”
+
+with
+
+* “Desugaring statement <stmt> requires ``M.>>`` which is not in scope”
+
 
 Qualified do with parameters
 ++++++++++++++++++++++++++++

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -60,9 +60,10 @@ When ``-XQualifiedDo`` is activated, the syntax of the ``do`` notation is change
 
 The additional expression is called the *builder* of the do-expression. The following restrictions apply to the builder and its type.
 
-* expr must **have a fully settled type** ``T``.
-* ``T`` must be a subtype of a type ``R t0 … tn``.
-* ``R`` must be a datatype, with precisely one constructor ``K``.
+* expr must **have the fully settled type** ``T``.
+* There is a type ``R`` such that normalizing ``T`` with respect to type
+  families yields a type of the form ``R T0 … Tn``.
+* ``R`` must be a datatype with precisely one constructor ``K``.
 * ``K`` must be a record constructor, defining fields with any of the following names:
   ``(>>=)``, ``(>>)``, ``fail``, ``return``, ``<*>``, and ``<$>``.
 
@@ -356,12 +357,12 @@ An example of super monad follows.
 
   import qualified Control.Monad.Super as Super
 
-  data SuperMonadBuilder m n p = SuperMonadBuilder
-    { (>>=) :: forall a b. BindCts m n p => m a -> (a -> n b) -> p b
-    , (>>) :: forall a b. BindCts m n p => m a -> n b -> p b
+  data SuperMonadBuilder = SuperMonadBuilder
+    { (>>=) :: forall m n p a b. (Bind m n p, BindCts m n p) => m a -> (a -> n b) -> p b
+    , (>>) :: forall m n p a b. (Bind m n p, BindCts m n p) => m a -> n b -> p b
     }
 
-  super :: Bind m n p => SuperMonadBuilder m n p
+  super :: SuperMonadBuilder
   super = SuperMonadBuilder (Super.>>=) (\a b -> a Super.>>= const b)
 
   -----------------
@@ -381,7 +382,7 @@ An example of super monad follows.
   import Control.Monad.Linear (linear)
   import qualified Control.Monad.Linear as Linear
 
-  g :: Bind SomeM SomeN SomeP => a -> SomeP b
+  g :: a -> SomeSuperMonad b
   g a = super.do
     b <- someSuperFunction a Super.>>= someOtherSuperFunction
     c <- anotherSuperFunction b

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -103,7 +103,7 @@ The semantics of ``do`` notation statements is given as follows (using
   Note that a ``join`` field is only needed if the final expression is
   not identifiably a ``return``.
 
-  When the applicative statements contain nested statement (see the
+  When the applicative statements contain nested statements (see the
   `wiki page
   <https://gitlab.haskell.org/ghc/ghc/wikis/applicative-do>`_ for a
   complete description of applicative-do statements), we also need a

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -132,9 +132,12 @@ If a field is required by the desugaring process (and only if it's required!) bu
 
 The fields of a builder are subject to the same type restrictions as their counterparts with ``-XRebindableSyntax``.
 
-When the ``@<aexp>`` annotation is omitted, the builder is taken to be whatever is named ``builder`` in scope.
+When the ``@<aexp>`` annotation is omitted, then
 
-A standard builder is added to ``Control.Monad`` and re-exported in the ``Prelude``:
+- If ``-XRebindableSyntax`` is *not* set, then ``do { … }`` has the default behaviour of using methods of the monad type classes from the prelude.
+- If ``-XRebindableSyntax`` is set, the builder is taken to be whatever is named ``builder`` in scope.
+
+A standard builder is added to ``Control.Monad``:
 
 ::
 
@@ -210,11 +213,20 @@ Both points can be addressed
     do @(builder @MonadType)
       <do block>
 
-  where ``builder`` is the default builder from ``Control.Monad`` (in the discussion of the pull request, this ``builder`` was also referred to as ``withMonad``).
+  where ``builder`` is the standard builder from ``Control.Monad`` (in the discussion of the pull request, this ``builder`` was also referred to as ``withMonad``).
 
 Nevertheless an alternative syntax has been proposed:
 
 - ``do via <aexpr>``. It is modelled after the ``deriving via`` construction. The implications on the parser are less clear then ``@<aexpr>``, however.
+
+Semantics variations
+~~~~~~~~~~~~~~~~~~~~
+
+A previous version of the proposal made it so that ``do {…}``, without an ``@…`` notation, would always use, as its builder, the variable named ``builder`` in scope. This had the dual advantage of being uniform (with ``-XLocalDo``, the ``do`` notation always uses a builder), and to let programmers affect the behaviour of their ``do`` block for a whole module without having to resort to ``-XRebindableSyntax``. For instance, with the future ``-XLinearTypes``, ``-XRebindableSyntax`` makes it impossible to write linear expressions.
+
+On the other hand, a number of commenters pointed out that this would be a very surprising behaviour, as this sort of rebinding is exceptional without ``-XRebindableSyntax``. This is a fatal flaw.
+
+This also required that the standard builder for monads be exported in the ``Prelude``, which could be dropped without remorse in this version.
 
 Related work
 ~~~~~~~~~~~~

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -29,6 +29,7 @@ There are many kinds of monad-like things out there:
 * linear variants of all the above once `linear types
   <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_ are
   implemented
+
   * in particular, the linear IO monad from the `Linear Haskell paper
     <https://arxiv.org/abs/1710.09756>`_ is an example of a linear
     graded monad
@@ -55,8 +56,7 @@ When ``-XQualifiedDo`` is activated, the syntax of the ``do`` notation is change
 
   <lexp> ⟶ [<aexp>.]do
 
-``aexp`` means that the notation before the ``.`` is parsed as a variable, unless there are paren
-theses.
+``aexp`` means that the notation before the ``.`` is parsed as a variable, unless there are parentheses.
 
 The additional expression is called the *builder* of the do-expression. The following restrictions apply to the builder and its type.
 
@@ -67,6 +67,7 @@ The additional expression is called the *builder* of the do-expression. The foll
   ``(>>=)``, ``(>>)``, ``fail``, ``return``, ``<*>``, and ``<$>``.
 
 We say that an expression **has a fully settled type** when
+
 * it is an identifier imported from another module, or
 * it is of the form ``expr @ty`` where `expr` **has a fully settled type**.
 
@@ -138,14 +139,14 @@ The semantics of ``do`` notation statements is given as follows (using
 * With ``-XRecursiveDo``, ``rec`` blocks use the ``mfix`` and ``return``
   fields of the builder:
 
-   ::
+  ::
 
-     b.do { rec { x1 <- u1; … ; xn <- un }; stmts }  =
-       case b of K { mfix = v1, return = v2 } ->
-         b.do
-         { (x1, …, xn) <- v1 (\~(x1, …, xn) -> b.do { x1 <- u1; …; xn <- un; v2 (x1, …, xn)})
-         ; stmts
-         }
+    b.do { rec { x1 <- u1; … ; xn <- un }; stmts }  =
+      case b of K { mfix = v1, return = v2 } ->
+        b.do
+        { (x1, …, xn) <- v1 (\~(x1, …, xn) -> b.do { x1 <- u1; …; xn <- un; v2 (x1, …, xn)})
+        ; stmts
+        }
 
 It is, crucially, not required that the record projections be in scope unqualified (otherwise projections of various builders would shadow one-another).
 
@@ -381,9 +382,9 @@ An example of super monad follows.
   import qualified Control.Monad.Linear as Linear
 
   g :: Bind SomeM SomeN SomeP => a -> SomeP b
-  g a = graded.do
-    b <- someGradedFunction a Super.>>= someOtherGradedFunction
-    c <- anotherGradedFunction b
+  g a = super.do
+    b <- someSuperFunction a Super.>>= someOtherSuperFunction
+    c <- anotherSuperFunction b
     Super.return c
 
   f :: Linear.Monad m => a #-> m b
@@ -429,7 +430,7 @@ When both ``-XQualifiedDo`` and ``-XRebindableSyntax`` are enabled, ``-XQualifie
 ``-XQualifiedDo`` doesn't affect monad comprehensions. But given some suitable syntax,
 it would be possible to extend ``-XQualifiedDo`` to support them.
 
-``-XQualifiedDo`` doesn't affect the `do notation for arrow commands <https://downloads.haskell.org/~ghc/8.8.2/docs/html/users_guide/glasgow_exts.html#do-notation-for-commands>` either. We defer analysis and handling of this case for the future.
+``-XQualifiedDo`` doesn't affect the `do notation for arrow commands <https://downloads.haskell.org/~ghc/8.8.2/docs/html/users_guide/glasgow_exts.html#do-notation-for-commands>`_ either. We defer analysis and handling of this case for the future.
 
 Costs and Drawbacks
 -------------------
@@ -736,10 +737,6 @@ be considered to have a fully settled type:
 It has been suggested that the predicate could have other uses as well.
 For instance, to identify expressions whose type can be reified in Template
 Haskell.
-
-In a way similar to the monadic case, it would be possible to use builders to
-use the ``do`` notation for arrow-like things.
-* It affects many syntactic constructs (numerical literals, the ``if then else`` syntax, … (see the `full list <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-RebindableSyntax>`_)).
 
 
 Unresolved Questions

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -234,6 +234,29 @@ Related work
 
 * An alternative to the ``@<aexpr>`` notation would be to use implicit parameters, somehow. But it's unclear how exactly it would look.
 
+Extensions
+~~~~~~~~~~
+
+Comprehension
++++++++++++++
+
+A possible extension which has been floated but not fully explored is to extend the same idea to list comprehension, in which case we can (and should!) extend the proposal to handle parallel list comprehension.
+
+The following syntax has been proposed
+
+- ``[ @builder x | x <- xs, isEven x ]``
+
+It seems that GHC uses a custom-crafter n-ary ``zip`` function in list comprehension, which would be impossible to replicate in a builder, but in monad comprehension desugaring, an iterated binary ``zip`` function is used
+
+::
+
+  mzip :: MonadZip m => m a -> m b -> m (a, b)
+  munzip :: MonadZip m => m (a, b) -> (m a, m b)
+
+So builders could contain an ``mzip`` and an ``munzip`` field for parallel comprehension. The default builder would include ``mzip`` and ``munzip`` fields for ``MonadZip``.
+
+We could set ``-XLocalDo`` to affect comprehension whenever ``-XMonadComprehensions`` is also set.
+
 Unresolved Questions
 --------------------
 

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -114,7 +114,7 @@ The semantics of ``do`` notation statements is given as follows (using
 
   ::
 
-    M.do { ({stmt1; …; stmtn} {x1; …; xn} | y <- u) ; return e }  =
+    M.do { ({stmt1; …; stmtn} {x1; …; xn} | y <- u) ; M.return e }  =
       (\(x1,…,xn) y -> e) <$> (M.do { stmt1; …; stmtn; M.return (x1, …, xn)}) <*> u
 
 *  With ``-XRecursiveDo``, ``rec`` blocks use ``M.mfix`` and ``M.return``:

--- a/proposals/0000-local-do.rst
+++ b/proposals/0000-local-do.rst
@@ -13,7 +13,9 @@ Qualified do
 .. sectnum::
 .. contents::
 
-This proposal introduces a new extension ``-XQualifiedDo`` which makes it possible to overload the meaning of a do-notation expression *on a case-by-case basis* (as opposed to the global effect of ``-XRebindableSyntax``), by writing ``modid.do``.
+This proposal introduces a new extension ``-XQualifiedDo`` which makes it possible to overload the meaning of a do-notation expression *on a case-by-case basis* (as opposed to the global effect of ``-XRebindableSyntax``), by writing ``builder.do``. The design is inspired by F#'s  `computational
+expressions <https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-express
+ions>`_.
 
 Motivation
 ------------
@@ -34,7 +36,7 @@ There are many kinds of monad-like things out there:
 
 All of these are theoretically compatible with the do-notation. And, in fact, really want the do-notation to work for them. After all, the entire existence of the do-notation can be ascribed to: “it's really annoying to program with ``(>>=)`` all the time”.
 
-The prescribed solution to use ``-XRebindableSyntax``. But ``-XRebindableSyntax`` is a very blunt instrument:
+The prescribed solution is to use ``-XRebindableSyntax``. But ``-XRebindableSyntax`` is a very blunt instrument:
 
 * It affects many syntactic constructs (numerical literals, the ``if then else`` syntax, … (see the `full list <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-RebindableSyntax>`_)).
 * It implies ``-XNoImplicitPrelude``
@@ -51,85 +53,107 @@ When ``-XQualifiedDo`` is activated, the syntax of the ``do`` notation is change
 
 ::
 
-  <lexp> ⟶ [modid.]do
+  <lexp> ⟶ [<aexp>.]do
 
-where ``modid`` stands for some module name.
+``aexp`` means that the notation before the ``.`` is parsed as a variable, unless there are paren
+theses.
 
-The additional module name is called the qualifier of the do-expression.
+The additional expression is called the *builder* of the do-expression. The following restrictions apply to the builder and its type.
+
+* expr must **have a fully settled type** ``T``.
+* ``T`` must be a subtype of a type ``R t0 … tn``.
+* ``R`` must be a datatype, with precisely one constructor ``K``.
+* ``K`` must be a record constructor, defining fields with any of the following names:
+  ``(>>=)``, ``(>>)``, ``fail``, ``return``, ``<*>``, and ``<$>``.
+
+We say that an expression **has a fully settled type** when
+* it is an identifier imported from another module, or
+* it is of the form ``expr @ty`` where `expr` **has a fully settled type**.
 
 The semantics of ``do`` notation statements is given as follows (using
-``-XLambdaCase`` notation):
+``-XLambdaCase`` notation and fresh variables ``v, v1, …, vn``):
 
-* The ``x <- u`` statement uses ``(modid.>>=)``
-
-  ::
-
-    M.do { x <- u; stmts }  =  (M.>>=) u $ \x -> M.do { stmts }
-* The ``u`` statement uses ``modid.(>>)``
+* The ``x <- u`` statement uses the ``(>>=)`` field of the builder
 
   ::
 
-    M.do { u; stmts }  =  (M.>>) u $ M.do { stmts }
-
-* The a ``pat <- u`` statement uses ``M.fail`` for the failing case,
-  if such a case is needed
-
-  ::
-
-    M.do { pat <- u; stmts }  =  (M.>>=) u $ \case
-      { pat -> M.do { stmts }
-      ; _ -> M.fail "…"
-      }
-
-  If the pattern cannot fail, then we don't need to use ``M.fail``.
+    b.do { x <- u; stmts }  =  case b of K { (>>=) = v } ->
+                                 v u (\x -> b.do { stmts })
+* The ``u`` statement uses the ``(>>)`` field of the builder
 
   ::
 
-    M.do { pat <- u; stmts }  =  (M.>>=) u $ \case pat -> M.do { stmts }
+    b.do { u; stmts }  =  case b of K { (>>) = v } ->
+      v u (b.do { stmts })
 
-* ``-XApplicativeDo`` uses ``(M.<$>)``, ``(M.<*>)`` and ``M.join`` (this
-  assumes that the applicative-do grouping has been performed)
+* The a ``pat <- u`` statement uses the ``fail`` field of the builder for the
+  failing case, if such a case is needed
 
   ::
 
-    M.do { (x1 <- u1 | … | xn <- un); return e }  =
-      (\x1 … xn -> e) M.<$> u1 M.<*> … M.<*> un
+    b.do { pat <- u; stmts }  =  case b of K { (>>=) = v1, fail = v2 } ->
+                                   v1 u (\case
+                                     { pat -> b.do { stmts }
+                                     ; _ -> v2 "…"
+                                     })
 
-    M.do { (x1 <- u1 | … | xn <- un); stmts }  =
-      M.join (\x1 … xn -> M.do { stmts }) M.<$> u1 M.<*> … M.<*> un
+  If the pattern cannot fail, then we don't need to use ``fail`` field in the
+  builder.
+
+  ::
+
+    b.do { pat <- u; stmts }  =  case b of K { (>>=) = v } ->
+                                   v u (\case pat -> b.do { stmts })
+
+* ``-XApplicativeDo`` uses the ``(<$>)``, ``(<*>)`` and ``join`` fields
+  of the builder (this assumes that the applicative-do grouping has been
+  performed)
+
+  ::
+
+    b.do { (x1 <- u1 | … | xn <- un); return e }  =
+      case b of K { (<*>) = v1, (<$>) = v2 } ->
+        (\x1 … xn -> e) `v2` u1 `v1` … `v1` un
+
+    b.do { (x1 <- u1 | … | xn <- un); stmts }  =
+      case b of K { (<*>) = v1, (<$>) = v2, join = v3 } ->
+        v3 (\x1 … xn -> b.do { stmts }) `v2` u1 `v1` … `v1` un
 
 
-  Note that ``M.join`` is only needed if the final expression is
+  Note that a ``join`` field is only needed if the final expression is
   not identifiably a ``return``.
 
   When the applicative statements contain nested statements (see the
   `wiki page
   <https://gitlab.haskell.org/ghc/ghc/wikis/applicative-do>`_ for a
   complete description of applicative-do statements), we also need a
-  ``M.return``. *e.g.*
+  ``return`` field. *e.g.*
 
   ::
 
-    M.do { ({stmt1; …; stmtn} {x1; …; xn} | y <- u) ; return e }  =
-      (\(x1,…,xn) y -> e) <$> (M.do { stmt1; …; stmtn; M.return (x1, …, xn)}) <*> u
+    b.do { ({stmt1; …; stmtn} {x1; …; xn} | y <- u) ; return e }  =
+      case b of K { (<*>) = v1, return = v2 } ->
+        (\(x1,…,xn) y -> e) <$> (b.do { stmt1; …; stmtn; v2 (x1, …, xn)}) `v1` u
 
-*  With ``-XRecursiveDo``, ``rec`` blocks use ``M.mfix`` and ``M.return``:
+* With ``-XRecursiveDo``, ``rec`` blocks use the ``mfix`` and ``return``
+  fields of the builder:
 
    ::
 
-     M.do { rec { x1 <- u1; … ; xn <- un }; stmts }  =
-       M.do
-       { (x1, …, xn) <- M.mfix (\~(x1, …, xn) -> M.do { x1 <- u1; …; xn <- un; M.return (x1, …, xn)})
-       ; stmts
-       }
+     b.do { rec { x1 <- u1; … ; xn <- un }; stmts }  =
+       case b of K { mfix = v1, return = v2 } ->
+         b.do
+         { (x1, …, xn) <- v1 (\~(x1, …, xn) -> b.do { x1 <- u1; …; xn <- un; v2 (x1, …, xn)})
+         ; stmts
+         }
 
-If a name ``M.op`` is required by the desugaring process (and only if it's required!) but the name is not in scope, an error message is produced:
+It is, crucially, not required that the record projections be in scope unqualified (otherwise projections of various builders would shadow one-another).
 
-* “Desugaring statement <stmt> requires <M.op> which is not in scope”
+If a field is required by the desugaring process (and only if it's required!) but the builder's type doesn't have such a field, an error message is produced:
 
-The qualified operations are subject to the same type restrictions as their counterparts with ``-XRebindableSyntax``.
+* “Desugaring statement <stmt> requires <field name> but builder <builder expression> doesn't provide it”
 
-When the qualifier ``modid.`` is omitted, the meaning of ``do { … }`` is the
+When the qualifier ``<aexp>.`` is omitted, the meaning of ``do { … }`` is the
 same as if ``-XQualifiedDo`` is *not* in effect.
 
 Examples
@@ -142,7 +166,7 @@ Examples
   import qualified Some.Monad.M as M
 
   boolM :: (a -> M.M Bool) -> b -> b -> a -> M.M b
-  boolM p a b x = M.do
+  boolM p a b x = M.builder.do
       px <- p x     -- M.>>=
       if px then
         return b    -- Prelude.return
@@ -157,24 +181,215 @@ Examples
   import Data.Bool (bool)
 
   boolMM :: (a -> M.M Bool) -> M b -> M b -> a -> M.M b
-  boolMM p ma mb x = M.do
+  boolMM p ma mb x = M.builder.do
       p x >>= bool ma mb   -- Prelude.>>=
 
-Linear ``do`` blocks would look as follows.
+Nested ``do`` blocks do not affect each other meanings.
 
 ::
 
+  import qualified Some.Monad.M as M
+
+  f :: M.M SomeType
+  f = M.builder.do
+      x <- f1                 -- case M.builder of K { (>>=) } -> (>>=)
+      f2 (do y <- g1          -- Prelude.>>=
+             g2 x y
+         )
+    where
+      f1 = ...
+      f2 m = ...
+      g1 = ...
+      g2 x y = ...
+
+An example of linear ``do`` blocks follows, mixed with non-linear
+``do`` to show what the imports would look like.
+
+::
+
+  {-# LANGUAGE LinearTypes #-}
+  {-# LANGUAGE NoImplicitPrelude #-}
+  module Control.Monad.Linear.Internal (Monad(..), linear) where
+
+  class Monad m where
+    return :: a #-> m a
+    (>>=) :: m a #-> (a #-> m b) #-> mb
+
+  -----------------
+
+  {-# LANGUAGE LinearTypes #-}
+  {-# LANGUAGE NoImplicitPrelude #-}
+  {-# LANGUAGE RankNTypes #-}
+  module Control.Monad.Linear.Builder (linear, LinearBuilder) where
+
+  import qualified Control.Monad.Linear as Linear
+
+  data LinearBuilder m = LinearBuilder
+    { (>>=) :: forall a b. m a #-> (a #-> m b) #-> mb
+    , return :: forall a. a #-> m a
+    }
+
+  linear :: Monad m => LinearBuilder m
+  linear = Builder (Linear.>>=) Linear.return
+
+  -----------------
+
+  module Control.Monad.Linear (module X) where
+
+  import Control.Monad.Linear.Builder as X
+  import Control.Monad.Linear.Internal as X
+
+  -----------------
+
+  module M where
+
+  import Control.Monad.Linear (linear)
   import qualified Control.Monad.Linear as Linear
 
   f :: Linear.Monad m => a #-> m b
-  f a = Linear.do
-    b <- someLinearFunction a         -- Linear.>>=
-    anotherLinearFunction b
+  f a = linear.do
+    b <- someLinearFunction a Linear.>>= someOtherLinearFunction
+    c <- anotherLinearFunction b
+    Linear.return c
 
-  g :: Linear.Monad m => a #-> m b
-  g a = Linear.do
-    b <- someLinearFunction a         -- Linear.>>=
-    c <- anotherLinearFunction b      -- Linear.>>=
+  g :: Monad m => a -> m b
+  g a = do
+    b <- someNonLinearFunction a >>= someOtherNonLinearFunction
+    c <- anotherNonLinearFunction b
+    return c
+
+  -- fixing the type to Maybe
+  h a = (linear @Maybe).do
+    b <- someLinearFunction a Linear.>>= someOtherLinearFunction
+    c <- anotherLinearFunction b
+    Linear.return c
+
+An example of graded monads follows, mixed with linear monads
+to show what the imports would look like.
+
+::
+
+  {-# LANGUAGE ConstraintKinds #-}
+  {-# LANGUAGE PolyKinds #-}
+  {-# LANGUAGE TypeFamilies #-}
+  module Control.Monad.Graded.Internal (GradedMonad(..)) where
+
+  import Data.Kind (Constraint)
+
+  class GradedMonad (m :: k -> * -> *) where
+    type Unit m :: k
+    type Plus m (i :: k) (j :: k) :: k
+    type Inv  m (i :: k) (j :: k) :: Constraint
+    (>>=) :: Inv m i j => m i a -> (a -> m j b) -> m (Plus m i j) b
+    return :: a -> m (Unit m) a
+
+  -----------------
+
+  {-# LANGUAGE RankNTypes #-}
+  module Control.Monad.Graded.Builder (graded, GradedMonadBuilder) where
+
+  import qualified Control.Monad.Graded as Graded
+
+  data GradedMonadBuilder m = GradedMonadBuilder
+    { (>>=) :: forall i j a b. Inv m i j => m i a -> (a -> m j b) -> m (Plus m i j) b
+    , (>>) :: forall i j a b. Inv m i j => m i a -> m j b -> m (Plus m i j) b
+    }
+
+  graded :: GradedMonad m => GradedMonadBuilder m
+  graded = GradedMonadBuilder (Graded.>>=) (\a b -> a Graded.>>= const b)
+
+  -----------------
+
+  module Control.Monad.Graded (module X) where
+
+  import Control.Monad.Graded.Builder as X
+  import Control.Monad.Graded.Internal as X
+
+  -----------------
+
+  module M where
+
+  import Control.Monad.Graded (graded)
+  import qualified Control.Monad.Graded as Graded
+
+  import Control.Monad.Linear (linear)
+  import qualified Control.Monad.Linear as Linear
+
+  g :: GradedMonad m => a -> m SomeTypeIndex b
+  g a = graded.do
+    b <- someGradedFunction a Graded.>>= someOtherGradedFunction
+    c <- anotherGradedFunction b
+    Graded.return c
+
+  f :: Linear.Monad m => a #-> m b
+  f a = linear.do
+    b <- someLinearFunction a Linear.>>= someOtherLinearFunction
+    c <- anotherLinearFunction b
+    Linear.return c
+
+An example of super monad follows.
+
+::
+
+  {-# LANGUAGE ConstraintKinds #-}
+  {-# LANGUAGE PolyKinds #-}
+  {-# LANGUAGE TypeFamilies #-}
+  module Control.Monad.Super.Internal (Bind(..), Return(..)) where
+
+  import Data.Kind (Constraint)
+
+  class (Functor m, Functor n, Functor p) => Bind m n p where
+    type BindCts m n p :: Constraint
+    type BindCts m n p = ()
+    (>>=) :: (BindCts m n p) => m a -> (a -> n b) -> p b
+
+  class Functor m => Return m where
+    type ReturnCts m :: Constraint
+    type ReturnCts m = ()
+    return :: (ReturnCts m) => a -> m a
+
+  -----------------
+
+  {-# LANGUAGE RankNTypes #-}
+  module Control.Monad.Super.Builder (super, SuperMonadBuilder) where
+
+  import qualified Control.Monad.Super as Super
+
+  data SuperMonadBuilder m n p = SuperMonadBuilder
+    { (>>=) :: forall a b. BindCts m n p => m a -> (a -> n b) -> p b
+    , (>>) :: forall a b. BindCts m n p => m a -> n b -> p b
+    }
+
+  super :: Bind m n p => SuperMonadBuilder m n p
+  super = SuperMonadBuilder (Super.>>=) (\a b -> a Super.>>= const b)
+
+  -----------------
+
+  module Control.Monad.Super (module X) where
+
+  import Control.Monad.Super.Builder as X
+  import Control.Monad.Super.Internal as X
+
+  -----------------
+
+  module M where
+
+  import Control.Monad.Super (super)
+  import qualified Control.Monad.Super as Super
+
+  import Control.Monad.Linear (linear)
+  import qualified Control.Monad.Linear as Linear
+
+  g :: Bind SomeM SomeN SomeP => a -> SomeP b
+  g a = graded.do
+    b <- someGradedFunction a Super.>>= someOtherGradedFunction
+    c <- anotherGradedFunction b
+    Super.return c
+
+  f :: Linear.Monad m => a #-> m b
+  f a = linear.do
+    b <- someLinearFunction a Linear.>>= someOtherLinearFunction
+    c <- anotherLinearFunction b
     Linear.return c
 
 
@@ -187,188 +402,169 @@ For instance we could write operations for monoids:
 
 ::
 
-  module Data.Monoid.QualifiedDo where
-    import Prelude hiding ((>>))
+  module Data.Monoid.Builder where
+    data MonoidBuilder = MonoidBuilder
+      { (>>) :: Monoid a => a -> a -> a
+      }
 
-    (>>) :: Monoid a => a -> a -> a
-    (>>) = (<>)
+    builder :: MonoidBuilder
+    builder = MonoidBuilder (<>)
 
   module X where
-    import qualified Data.Monoid.QualifiedDo as Monoid
+    import Data.Monoid.Builder
 
-    f = Monoid.do
+    f = builder.do
       Sum 2
       Sum 3
       Sum 5
       Sum 8
 
-If one would try to use ``x <- u`` with ``Monoid.do``, GHC would
+If one would try to use ``x <- u`` with ``Monoid.builder``, GHC would
 raise an error *even if there is a value for ``(>>=)`` in scope*.
 
 Enabling ``-XQualifiedDo`` doesn't change the meaning of existing do-expressions.
 
 When both ``-XQualifiedDo`` and ``-XRebindableSyntax`` are enabled, ``-XQualifiedDo`` only affects qualified ``do``'s and ``-XRebindableSyntax`` affects the unqualified ``do``'s.
 
-In principle, ``-XQualifiedDo`` would not affect monad comprehensions, though we could
-imagine a similar mechanism to qualify the names in the desugared expressions
-given some suitable syntax to specify the qualifier.
+``-XQualifiedDo`` doesn't affect monad comprehensions. But given some suitable syntax,
+it would be possible to extend ``-XQualifiedDo`` to support them.
+
+``-XQualifiedDo`` doesn't affect the `do notation for arrow commands <https://downloads.haskell.org/~ghc/8.8.2/docs/html/users_guide/glasgow_exts.html#do-notation-for-commands>` either. We defer analysis and handling of this case for the future.
 
 Costs and Drawbacks
 -------------------
 
-The do-expression store, during type-checking, which expression they will use for ``(>>=)``, etc… So the core infrastructure is actually already there. We anticipate the cost of implementation and maintenance of this feature to be very low.
+The do-expression stores, during type-checking, which expression they will use for ``(>>=)``, etc… So the core infrastructure is actually already there. We anticipate the cost of implementation and maintenance of this feature to be very low.
 
 Alternatives
 ------------
 
-Do with builders
-~~~~~~~~~~~~~~~~
+Do with a module name
+~~~~~~~~~~~~~~~~~~~~~
 
-The initial version of the proposal was inspired by F#'s `computational expressions <https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions>`_.
-
-Instead of qualifying ``do``, it would attach an expression to it:
-
-::
-
-  <lexp> ⟶ do [@aexp] { stmts }
-
-The optional expression should evaluate to a record containing the operations to use
-when desugaring.
+An earlier version of the proposal used an ``<modid>.do`` syntax, where
+``<modid>`` stands for some module name.
 
 ::
 
-  module Control.Monad.Linear.Builder where
+  <lexp> ⟶ [<modid>.]do { stmts }
 
-    data BuilderType = Builder
-      { (>>=) :: forall m a b. Linear.Monad m => m a #-> (a #-> m b) #-> m b
-      , (>>) :: forall m b. Linear.Monad m => m () #-> m b #-> m b
-      , fail :: forall m a. Linear.MonadFail m => String -> m a
-      , return :: forall m a. Linear.Monad m => a #-> m a
-      }
+The additional module name is called the qualifier of the do-expression.
 
-    monadBuilder :: BuilderType
-    monadBuilder = Builder
-      { (>>=) = (Linear.>>=)
-      , (>>) = (Linear.>>)
-      , fail = Linear.fail
-      , return = Linear.return }
+The semantics of ``do`` notation statements is given schematically as follows.
 
+* The ``x <- u`` statement uses ``(modid.>>=)``
 
-  module X where
+  ::
 
-    import qualified Control.Monad.Linear as Linear
-    import qualified Control.Monad.Linear.Builder as Linear
+    M.do { x <- u; stmts }  =  u M.>>= \x -> M.do { stmts }
 
-    f :: Linear.Monad m => a #-> m a
-    f x = do @Linear.builder
-      y <- someLinearFunction x
-      Linear.return y
+* The ``u`` statement uses ``modid.(>>)``
 
-The main obstacle with this approach was that it was difficult to express the
-desugaring of the do notation without knowing the type of the builder. And all
-attempts to characterize the type ended up requiring impredicative types.
+  ::
 
-It was later suggested that the optional expression could be constrained to
-a qualified variable.
+    M.do { u; stmts }  =  u M.>> M.do { stmts }
+
+and so on ...
+
+This is an example with the linear monad
 
 ::
 
-  <lexp> ⟶ do @qvarid { stmts }
+  {-# LANGUAGE LinearTypes #-}
+  {-# LANGUAGE NoImplicitPrelude #-}
+  module Control.Monad.Linear (Monad(..), linear) where
 
-With this constraint, the desugaring could use the qualifier to qualify the
-monad operations.
+  class Monad m where
+    return :: a #-> m a
+    (>>=) :: m a #-> (a #-> m b) #-> mb
 
-::
+  -----------------
 
-  f :: Linear.Monad m => a #-> m a
-  f x = do @Linear.builder
-    y <- someLinearFunction x
-    Linear.return y
+  module M where
 
-would desugar to
+  import qualified Control.Monad.Linear as Linear
 
-::
+  f :: Linear.Monad m => a #-> m b
+  f a = Linear.do
+    b <- someLinearFunction a Linear.>>= someOtherLinearFunction
+    c <- anotherLinearFunction b
+    Linear.return c
 
-  f :: Linear.Monad m => a #-> m a
-  f x =
-    (Linear.>>=) Linear.builder (someLinearFunction x) (\y -> Linear.return y)
+  g :: Monad m => a -> m b
+  g a = do
+    b <- someNonLinearFunction a
+    c <- anotherNonLinearFunction b
+    return c
 
-This effectively avoids the need to find the type of the builder for desugaring.
-We haven't opted for this approach though, because it requires defining builders
-while the qualified do requires no extra definitions.
-
-Exclusive names
-~~~~~~~~~~~~~~~
-
-It has been noted during discussion of the proposal that using the usual names
-when desugaring (``(>>=)``, ``return``, ``(>>)``, ``fail``, etc) could cause
-undesired ambiguity when trying to resolve names in some cases. For instance,
-
-::
-
-  import Data.Monoid
-
-  f = Data.Monoid.do
-    Sum 2
-    Sum 3
-
-  main = putStr "Hello" >> putStrLn "World" -- (Data.Monoid.>>) or (Prelude.>>)?
-
-One would have to write instead
+The major difference with the ``builder.do`` approach, is that no record
+of operations needs to be defined. The ``(M.>>=)`` is taken to be whatever
+such operation is in scope. For instance ``(M.>>=)`` and ``(M.>>)`` can come
+from different modules if they are imported with the same qualifier:
 
 ::
 
-  import qualified Data.Monoid.QualifiedDo as Data.Monoid
-  import Data.Monoid -- Changed to not export (>>)
+  import Some.Module.Defining.Bind as M ((>>=), return)
+  import Some.Module.Defining.Then as M ((>>))
 
-  f = Data.Monoid.do
-    Sum 2
-    Sum 3
+  f = M.do
+        x <- f
+        g
+        return x
 
-  main = putStr "Hello" >> putStrLn "World"
+Despite of its verbosity when compared to the ``M.do`` approach, the
+``builder.do`` approach is preferred because it groups in a single record
+the operations that work together when desugaring a ``builder.do`` block.
+This single record is easier to import, export and document. In contrast,
+when using ``M.do``, one has to make sure to bring all the needed
+operations into scope.
 
-Fiddling with the imports like this would not be necessary if ``-XQualifiedDo``
-used different names like ``qualifiedBind``, ``qualifiedThen``,
-``qualifiedReturn``, etc.
+Qualified do with parameters
+++++++++++++++++++++++++++++
 
-Although the solution is effective for the case of monoids, it has a couple
-of drawbacks that make unclear whether it would be a net win.
-
-Firstly, using exclusive names would make errors about out-of-scope names
-harder to understand. Compare
-
-::
-
-  /tmp/test.hs:4:5: error:
-      • Variable not in scope: Data.Monoid.qualifiedThen
-    |
-  4 | f = Data.Monoid.do
-    |   Sum 2
-    |   Sum 3
-    |
-
-with
+``M.do`` can be extended (or complemented with another language extension)
+to pass parameters to the operations during desugaring.
 
 ::
 
-  /tmp/test.hs:4:5: error:
-      • Variable not in scope: Data.Monoid.>>
-    |
-  4 | f = Data.Monoid.do
-    |   Sum 2
-    |   Sum 3
-    |
+  <lexp> ⟶ [<modid>.]do @aexp … @aexp { stmts }
 
-The reader can figure out that the do notation requires ``qualifiedThen``
-only if she knows that ``-XQualifiedDo`` desugars to ``qualifiedThen`` when
-regular ``do`` notation would desugar to ``(>>)``.
+This would allow a user to fix the type of the monad like so
 
-Secondly, the motivating examples of ``-XQualifiedDo`` are monad-like concepts
-that can define ``(>>=)`` and ``return`` for explicit use without the ``do``
-notation. Asking to define aliases like ``qualifiedBind`` and
-``qualifiedReturn`` is additional work that would not solve the name ambiguities
-when all of ``(>>=)``, ``return``, ``qualifiedBind`` and ``qualifiedReturn`` are
-exported.
+::
+
+  M.do @(@Maybe)
+    x <- m
+    M.return (x + 1)
+
+which would be equivalent to
+
+::
+
+  (M.>>=) @Maybe m (\x -> M.return @Maybe (x + 1))
+
+Or it could be used to pass information which is available locally
+
+::
+
+  f =
+    M.do @x1 @x2
+      x <- m
+      M.return (x + 1)
+    where
+      x1 = …
+      x2 = …
+
+which would be equivalent to
+
+::
+
+  f =
+    (M.>>=) x1 x2 m (\x -> M.return x1 x2 (x + 1))
+    where
+      x1 = …
+      x2 = …
+
 
 Desugar unqualified returns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -378,10 +574,11 @@ with an unqualified ``return``.
 
 ::
 
-  import qualified Control.Monad.Linear as Linear
+  import Control.Monad.Linear (linear)
+  import Control.Monad.Linear as Linear
 
   g :: Linear.Monad m => a #-> m b
-  g a = Linear.do
+  g a = linear.do
     b <- someLinearFunction a         -- Linear.>>=
     c <- anotherLinearFunction b      -- Linear.>>=
     return c                          -- Desugared to Linear.return
@@ -394,7 +591,7 @@ return should be desugared or left alone. For instance
   import qualified Some.Monad.M as M
 
   boolM :: (a -> M.M Bool) -> b -> b -> a -> M.M b
-  boolM p a b x = M.do
+  boolM p a b x = M.builder.do
       px <- p x
       y <- if px then
              return b   -- Prelude.return or M.return ?
@@ -409,11 +606,12 @@ different monad.
 
 ::
 
-  import qualified Control.Monad.Linear as Linear
-  import qualified System.IO.Linear (fromSystemIO)
+  import Control.Monad.Linear (linear)
+  import System.IO.Linear (fromSystemIO)
+  import qualified System.IO.Linear as Linear
 
-  g :: Linear.Monad m => a #-> m b
-  g a = Linear.do
+  g :: a #-> Linear.IO b
+  g a = linear.do
     b <- fromSystemIO (print () >> return b)   -- Control.Monad.return ?
     return b                                   -- Linear.return
 
@@ -425,17 +623,89 @@ Also, scoping rules would need to be added to deal with nested ``do`` blocks.
   import qualified Some.Monad.N as N
 
   condMM :: (a -> M.M Bool) -> M b -> M b -> a -> M.M b
-  condMM p ma mb x = M.do
+  condMM p ma mb x = M.builder.do
       px <- p x
-      if px then N.do
+      if px then N.builder.do
         a <- ma
         return a        -- N.return ?
       else do
         b <- mb
-        return b        -- Prelude.return ?
+        return b        -- M.return ?
 
 This alternative is feasible. But on balance, it is not clear whether it is
 worth the cost of working with whatever scoping rules are chosen.
+
+Qualify do with a type class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It was suggested during the discussion of this proposal, that the ``do``
+keyword could be qualified with a type class name like so:
+
+::
+
+  <lexp> ⟶ [<typeclass name>.]do { stmts }
+
+For instance,
+
+::
+
+  f :: [Int] -> m ()
+  f xs = MonadFail.do
+    [_] <- return xs
+    return ()
+
+desugars to
+
+::
+
+  f :: [Int] -> m ()
+  f xs = return xs GHC.Base.>>= \case
+    [_] -> return ()
+    _ -> Control.Monad.Fail.fail "..."
+
+During desugaring of ``TC.do``, the operations ``(>>=)`` and ``fail`` are
+looked in ``TC`` and all of its superclasses. In the example,
+``Control.Monad.Fail.fail`` is found at ``Control.Monad.Fail.MonadFail``
+and ``(GHC.Base.>>=)`` is found at ``GHC.Base.Monad``.
+
+Only the typeclass ``TC`` needs to be in scope. None of its methods, and
+none of its superclasses need to be in scope for desugaring to work.
+
+This approach allows to reuse existing type classes for a qualified ``do``,
+while still grouping the needed operations in a type class hierarchy.
+
+However, restrictions need to be imposed in the class hierarchies that are
+permitted to qualify a ``do``. Otherwise, looking up methods in superclasses
+becomes a challenge if ``-XConstraintKinds`` is enabled:
+
+::
+
+  class c => C c where
+
+These restrictions would complicate using the extension.
+
+Another inconvenience of this approach is that when type hierarchies are
+not readily available, it would encourage the introduction of type
+classes with a single instance only for the sake of qualifying ``do``
+blocks. For instance,
+
+::
+
+  class MonoidBuilder m where
+    (>>) :: m -> m -> m
+
+  instance Monoid m => MonadBuilder m where
+    (>>) = (<>)
+
+Lastly, there is speculation that at some point it could be desirable
+to be more flexible about how builders are used. For instance,
+
+::
+
+  (f builder).do { stmts }
+
+where ``f`` is some transformer on builders. It is no possible to be so
+succint with ``TypeClass.do``.
 
 Related work
 ~~~~~~~~~~~~
@@ -452,53 +722,24 @@ Related work
 Extensions
 ~~~~~~~~~~
 
-Qualified do with parameters
-++++++++++++++++++++++++++++
+More expressions with a fully settled type
+++++++++++++++++++++++++++++++++++++++++++
 
-At some point, this language extension could be modified to allow passing
-parameters to the operations during desugaring.
+**Having a fully settled type** is a predicate that could be modified
+to accept more expressions over time. In particular, the following expressions could
+be considered to have a fully settled type:
 
-::
+* Identifiers from before a top-level Template Haskell splice
+* Top-level identifiers from previous mutually-recursive groups when there is no monomorphism restriction
+* Variables bound with a type signature or arguments to functions defined with a type signature
 
-  <lexp> ⟶ do @aexp … @aexp { stmts }
+It has been suggested that the predicate could have other uses as well.
+For instance, to identify expressions whose type can be reified in Template
+Haskell.
 
-This would allow a user to fix the type of the monad like so
-
-::
-
-  do @(@Maybe)
-    x <- (+1) <$> m
-    return x
-
-which would be equivalent to
-
-::
-
-  (>>=) @Maybe ((+1) <$> m) (\x -> return @Maybe x)
-
-Or it could be used to pass information which is available locally
-
-::
-  f =
-    M.do @x1 @x2
-      x <- (+1) <$> m
-      M.return x
-    where
-      x1 = …
-      x2 = …
-
-which would be equivalent to
-
-::
-
-  f =
-    (M.>>=) x1 x2 ((+1) <$> m) (\x -> M.return x1 x2 x)
-    where
-      x1 = …
-      x2 = …
-
-Some commenters have expressed interest in these cases, which fall beyond
-the scope of the current proposal.
+In a way similar to the monadic case, it would be possible to use builders to
+use the ``do`` notation for arrow-like things.
+* It affects many syntactic constructs (numerical literals, the ``if then else`` syntax, … (see the `full list <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-RebindableSyntax>`_)).
 
 
 Unresolved Questions

--- a/proposals/0007-instance-foralls.rst
+++ b/proposals/0007-instance-foralls.rst
@@ -1,8 +1,6 @@
 .. proposal-number:: 0007
 
-.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
-                 ticket number which will track the progress of the
-                 implementation of the feature.
+.. trac-ticket:: 14268
 
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.

--- a/proposals/0007-instance-foralls.rst
+++ b/proposals/0007-instance-foralls.rst
@@ -1,0 +1,170 @@
+.. proposal-number:: 0007
+
+.. trac-ticket:: Leave blank. This will eventually be filled with the Trac
+                 ticket number which will track the progress of the
+                 implementation of the feature.
+
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+
+.. highlight:: haskell
+
+This proposal was `discussed at this pull requst <https://github.com/ghc-proposals/ghc-proposals/pull/55>`_.
+
+.. contents::
+
+More explicit ``forall``\s
+=========================
+
+On type signatures, users can write ``forall ...`` to explicitly bind type/kind variables.
+This allows users to give the type variables explicit kinds. However, not all constructs that
+bind type variables allow the user to write them explicitly. This proposal seeks to remedy this
+by enhancing GHC's concrete syntax to permit ``forall ...`` expressions wherever type variables
+may be bound.
+
+Specifically, this proposal adds the ability to write a ``forall ...`` clause on the following
+constructs:
+
+* data/newtype instances (including associated types)
+* type instances (including associated types)
+* closed type family equations
+* ``RULES``
+
+In contrast, the following constructs already allow user-written kinds for type variables:
+
+* type/data families (including associated ones): The type variables listed are type variable
+  binders, not occurrences.
+* type synonyms: The type variables listed are binders.
+* data/newtypes: The type variables listed are binders, in both Haskell98 and GADT notation.
+* classes: The type variables listed are binders.
+* class instances: The user can write an optional ``forall ...`` after the word ``instance``.
+* standalone-deriving instances: Ditto.
+* values: The user can bring scoped type variables into scope via a type signature.
+* type signatures: The user can write an optional ``forall ...``.
+* pattern signatures: The user can write separate optional ``forall ...``\s for both universal
+  and existential type variables.
+* ``SPECIALIZE`` pragmas: The user can write an optional ``forall ...`` in the type.
+* ``SPECIALIZE instance`` pragmas: The user can write an optional ``forall ...`` after the word ``instance``.
+
+I believe the list above is a full accounting of places in the GHC concrete syntax where
+type variables may appear. Do comment if I've missed anything.
+
+Motivation
+------------
+Given the evolution in GHC's kind system (``TypeInType`` in particular),
+it is no longer possible always to *infer* the kind
+of a type variable. For example, a type variable ``a`` might be used only in a place where it is expected
+to have kind ``F b`` for some non-injective type family ``F``. We cannot confidently choose ``a`` to
+have kind ``F b`` in this circumstance. Similarly, GHC now supports *higher-rank kinds*, where a type
+variable's kind might be a polytype. These, too, cannot be inferred.
+
+Note that a use of a type variable in a kind signature ``(a :: F b)`` does not necessarily give
+the declared kind for ``a``.
+
+Due to the inability to always infer kinds, the user may need to specify a kind manually. This proposal
+allows the user to do this in all syntactic scenarios.
+
+Proposed Change Specification
+-----------------------------
+
+1. Permit ``forall ...`` to bind type variables after the word ``instance`` in a ``data``,
+   ``newtype``, or ``type`` instance. For an associated type, the ``forall`` would appear after the word
+   ``data``, ``newtype``, or ``type``.
+
+2. Permit ``forall ...`` to bind type variables at the beginning of a closed type family equation.
+
+3. Permit ``forall ...`` to bind type variables in equations in a ``RULES`` declaration. It would
+   appear after the (optional) phase specifier and before the ``forall`` that introduces term-level
+   variables. For an equation that introduces both type-level and term-level variables, there would
+   appear two ``forall``\s. If only one ``forall`` appears in an equation, it binds *term-level* variables.
+   In the case where a user wants type-level variables but no term-level variables, the second ``forall``
+   would have to be written but would be empty.
+
+In all cases, the new ``forall`` construct binds type variables with any given kinds. In all cases,
+if the users has written a type-level ``forall``, that construct must bind *all* type variables used
+in the construct, much like the all-or-nothing behavior of value-level type signatures.
+
+These new extensions would be enabled with the old extension ``ExplicitForAll``, as they are backward-compatible
+with that extension.
+
+Examples
+--------
+
+1. ::
+
+     data family F a
+     data instance forall (x :: Bool). F (Proxy x) = MkF
+
+     class C a where
+       type F a b
+
+     instance forall a. C [a] where
+       type forall b. F [a] b = Int
+
+2. ::
+
+     type family G a b where
+       forall x y. G [x] (Proxy y) = Double
+       forall z.   G z   z         = Bool
+
+3. ::
+
+     {-# RULES
+     "example"  forall a b. forall. map @a @b id = id
+     "example2" forall a. forall (x :: a). id x = x
+       #-}
+
+Effect and Interactions
+-----------------------
+Class instances have permitted a ``forall`` for some time. This just extends the idea to other, similar
+constructs.
+
+With this change, a user can choose never to have a type variable be brought into scope implicitly.
+A particularly defensive programmer may enjoy this level of control. Similarly, no kind inference is
+ever necessary for type variables if the user wishes to avoid it.
+
+Given that ``forall`` is a keyword in types with ``ExplicitForAll``, this change is fully backward-compatible.
+Note that any new ``forall`` in a ``RULES`` equation would require two ``forall``\s, something not currently
+permitted.
+
+This proposal will fix long-standing ticket `#2600 <https://ghc.haskell.org/trac/ghc/ticket/2600>`_.
+
+Costs and Drawbacks
+-------------------
+This complicates the concrete and abstract syntax of Haskell, adding a maintenance burden. The new
+syntax on ``RULES`` might be counter-intuitive, but it should be very easy to understand in other
+places.
+
+
+Alternatives
+------------
+
+I argue that maintaining the status quo is not a viable alternative, as the inability to specify
+the kinds of variables in these places inhibits the use of ``TypeInType`` features.
+
+There is no strict need for the all-or-nothing behavior of these new ``forall``\s; that requirement
+can be dropped.
+
+Resolved questions
+------------------
+
+1. **Why have two** ``forall``\ **s in a** ``RULES`` **declaration?** Because otherwise users would have a hard
+   time telling type variables from term variables. A syntactic analysis could sort this out, but that
+   seems more confusing than having two ``forall``\s.
+
+2. **How will the two** ``forall``\ **s work with Dependent Haskell?** Dependent Haskell would need to generalize
+   the syntax of ``RULES`` to allow an arbitrary number of uses of the ``forall`` keyword to be backward
+   compatible with this proposal. This is in keeping with the use of ``forall`` in type signatures, where
+   ``forall a b c. ...`` is an abbreviation for ``forall a. forall b. forall c. ...``. In short, I don't
+   see problems here.
+
+
+Unresolved questions
+--------------------
+
+None at this time.
+
+Implementation Plan
+-------------------
+
+Implementation shouldn't be hard. I volunteer either myself or a close collaborator.


### PR DESCRIPTION
This proposal introduces a mechanism to override the meaning of a do-notation block (a bit like with `-XRebindableSyntax`, but on individual `do`-s).

```haskell
do @IndexedMonad.builder
x <- someIndexMonadExpression
…
```

It superseeds a previous attempt ( #78 ).

This proposal was authored by @Tritlo and @aspiwack .

[rendered](https://github.com/tweag/ghc-proposals/blob/local-do/proposals/0000-local-do.rst)

#### Todos

- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477164098 : sum up arguments for either using the default behaviour without do or using the ambiant `builder` binding.
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477168538 : “Worth examining carefully what methods are allowed in F#'s computation expressions.”
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477168538 : consider support for list comprehension (in which case a field for parallel list comprehension would be warranted).
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477524138 : add alternative syntax: `do via builder`.
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477646013 : explain the reasoning behind the `@` syntax.
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477168538 : be more explicit that we are considering linear-IO example from the paper.
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477168538 : be more precise on the semantics
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477168538 : add support for recursive do expressions (by way of an `mfix` field in builders)
- [x] See https://github.com/ghc-proposals/ghc-proposals/pull/216#issuecomment-477173618 : add link to F# computational expressions doc.


<!-- probot = {"1313345":{"who":"nomeata","what":"check if discussion has ebbed down.","when":"2020-04-09T09:00:00.000Z"}} -->