### PR TITLE
Process tweak: Involve authors in a possible rejection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,11 +269,11 @@ mailing list. All interested parties are invited to follow the discussion.
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
    decides whether the proposal ought to be accepted or rejected or returned for
    revision.
-   
+
 -  If the shephard thinks the proposal ought to be rejected, they post their
    justifications on the GitHub thread, and invite the authors to respond with
    a rebuttal and/or refine the proposal. This continues until either
-    
+
    * the shepherd changes their mind and supports the proposal now,
    * the authors withdraw their proposal,
    * the authors indicate that they will revise the proposal to address the shepherds
@@ -283,19 +283,19 @@ mailing list. All interested parties are invited to follow the discussion.
      positions, even if they disagree on the conclusion.
 
 -  Now the shepherd proposes acceptance or rejectance, by email to the mailing
-   list. Discussion among the committee ensues on the mailing list, and 
+   list. Discussion among the committee ensues on the mailing list, and
    silence is understood as agreement with the shepherd's recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
--  The decision is announced, by the shepherd to the mailing.
+-  The decision is announced, by the shepherd to the mailing list.
 
 -  The secretary tags the pull request accordingly, and either merges or closes it.
    In particular
-  
-   *  **If we say no:** 
+
+   *  **If we say no:**
       The pull request will be closed and labeled
       `Rejected <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3Arejected>`_.
 
@@ -306,9 +306,9 @@ mailing list. All interested parties are invited to follow the discussion.
       GHC, it will be reverted.
 
    *  **If we say yes:**
-       The pull request will be merged, numbered and labeled
+      The pull request will be merged, numbered and labeled
       `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3AAccepted>`_.
-      
+
       At this point, the proposal process is technically
       complete. It is outside the purview of the committee to implement,
       oversee implementation, attract implementors, etc.

--- a/README.rst
+++ b/README.rst
@@ -271,8 +271,8 @@ mailing list. All interested parties are invited to follow the discussion.
    revision.
    
 -  If the shephard thinks the proposal ought to be rejected, they post their
-   justifications on the GitHub thread, and invites the authors to respond with
-   a rebuttal and/or refine the proposal. This continues until the either
+   justifications on the GitHub thread, and invite the authors to respond with
+   a rebuttal and/or refine the proposal. This continues until either
     
    * the shepherd changes their mind and supports the proposal now,
    * the authors withdraw their proposal,
@@ -284,7 +284,7 @@ mailing list. All interested parties are invited to follow the discussion.
 
 -  Now the shepherd proposes acceptance or rejectance, by email to the mailing
    list. Discussion among the committee ensues on the mailing list, and 
-   silence is understood as agreement with the shepherds recommendation.
+   silence is understood as agreement with the shepherd's recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons

--- a/README.rst
+++ b/README.rst
@@ -267,23 +267,36 @@ mailing list. All interested parties are invited to follow the discussion.
    the discussion.
 
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
-   makes a recommendation as to whether the proposal ought to be accepted,
-   rejected or returned for revision.
+   decides whether the proposal ought to be accepted or rejected or returned for
+   revision.
+   
+-  If the shephard thinks the proposal ought to be rejected, they post their
+   justifications on the GitHub thread, and invites the authors to respond with
+   a rebuttal and/or refine the proposal. This continues until the either
+    
+   * the shepherd changes their mind and supports the proposal now,
+   * the authors withdraw their proposal,
+   * the authors indicate that they will revise the proposal to address the shepherds
+     point. The shepherd will label the pull request as
+     `Needs Revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A"Needs+revision">`_.
+   * the authors and the shepherd fully understand each other’s differing
+     positions, even if they disagree on the conclusion.
 
--  Discussion among the committee ensues on the mailing list.
-   Silence is understood as agreement with the shepherds recommendation.
+-  Now the shepherd proposes acceptance or rejectance, by email to the mailing
+   list. Discussion among the committee ensues on the mailing list, and 
+   silence is understood as agreement with the shepherds recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
-   the shepherd.  If consensus is elusive, then we vote, with the Simons
+   the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
--  The decision is announced, by the shepherd or the secretary, to the mailing
-   list and the pull request commentary. In particular:
+-  The decision is announced, by the shepherd to the mailing.
 
-   *  **If we say no:** The shepherd comments on the GitHub pull request with the
-      reasons for rejection.
-      The pull request will be closed, by the shepherd or the secretary, with
-      label
+-  The secretary tags the pull request accordingly, and either merges or closes it.
+   In particular
+  
+   *  **If we say no:** 
+      The pull request will be closed and labeled
       `Rejected <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3Arejected>`_.
 
       If the proposer wants to revise and try again, the new proposal should
@@ -292,19 +305,10 @@ mailing list. All interested parties are invited to follow the discussion.
       In the case that the proposed change has already been implemented in
       GHC, it will be reverted.
 
-   *  **If we return for revision:** If during the debate, the need for
-      substantial changes does arise, then the shepherd summarizes the
-      issues on the GitHub pull request and labels it
-      `Needs Revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A"Needs+revision">`_.
-      The author is encouraged to address the issues and re-submit.
-
    *  **If we say yes:**
-      The shepherd or the secretary announces this on the pull request
-      and labels it as
+       The pull request will be merged, numbered and labeled
       `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3AAccepted>`_.
-      The secretary merges the pull request and assigns the final proposal
-      number.
-
+      
       At this point, the proposal process is technically
       complete. It is outside the purview of the committee to implement,
       oversee implementation, attract implementors, etc.


### PR DESCRIPTION
Based on recent bad experiences, this is a proposal to tweak our process. The main idea is that if the shepherd intends to reject the proposal, they have to first discuss this with the authors, to give the authors a chance to respond, tweak, or point out misunderstandings in the shepherd’s perception. 

So the process of accepting proposals is unchanged, and still on the list, rejecting a proposal is now a two step process: the shepherd discusses it with the authors on GitHub (and anyone else interested, of course), and then there is a shorter discussion on the mailinglist, with hopefully all facts clarified.