### PR TITLE
Process tweak: GitHub discussion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,11 +269,11 @@ mailing list. All interested parties are invited to follow the discussion.
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
    decides whether the proposal ought to be accepted or rejected or returned for
    revision.
-   
+
 -  If the shephard thinks the proposal ought to be rejected, they post their
    justifications on the GitHub thread, and invite the authors to respond with
    a rebuttal and/or refine the proposal. This continues until either
-    
+
    * the shepherd changes their mind and supports the proposal now,
    * the authors withdraw their proposal,
    * the authors indicate that they will revise the proposal to address the shepherds
@@ -283,19 +283,19 @@ mailing list. All interested parties are invited to follow the discussion.
      positions, even if they disagree on the conclusion.
 
 -  Now the shepherd proposes acceptance or rejectance, by email to the mailing
-   list. Discussion among the committee ensues on the mailing list, and 
+   list. Discussion among the committee ensues on the mailing list, and
    silence is understood as agreement with the shepherd's recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
--  The decision is announced, by the shepherd to the mailing.
+-  The decision is announced, by the shepherd to the mailing list.
 
 -  The secretary tags the pull request accordingly, and either merges or closes it.
    In particular
-  
-   *  **If we say no:** 
+
+   *  **If we say no:**
       The pull request will be closed and labeled
       `Rejected <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3Arejected>`_.
 
@@ -306,9 +306,9 @@ mailing list. All interested parties are invited to follow the discussion.
       GHC, it will be reverted.
 
    *  **If we say yes:**
-       The pull request will be merged, numbered and labeled
+      The pull request will be merged, numbered and labeled
       `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3AAccepted>`_.
-      
+
       At this point, the proposal process is technically
       complete. It is outside the purview of the committee to implement,
       oversee implementation, attract implementors, etc.

--- a/README.rst
+++ b/README.rst
@@ -271,8 +271,8 @@ mailing list. All interested parties are invited to follow the discussion.
    revision.
    
 -  If the shephard thinks the proposal ought to be rejected, they post their
-   justifications on the GitHub thread, and invites the authors to respond with
-   a rebuttal and/or refine the proposal. This continues until the either
+   justifications on the GitHub thread, and invite the authors to respond with
+   a rebuttal and/or refine the proposal. This continues until either
     
    * the shepherd changes their mind and supports the proposal now,
    * the authors withdraw their proposal,
@@ -284,7 +284,7 @@ mailing list. All interested parties are invited to follow the discussion.
 
 -  Now the shepherd proposes acceptance or rejectance, by email to the mailing
    list. Discussion among the committee ensues on the mailing list, and 
-   silence is understood as agreement with the shepherds recommendation.
+   silence is understood as agreement with the shepherd's recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons

--- a/README.rst
+++ b/README.rst
@@ -258,7 +258,7 @@ Roman Leshchinskiy      `@rleshchinskiy <https://github.com/rleshchinskiy>`_
 Committee process
 -----------------
 
-The committee process starts once the secretray has been notified that a
+The committee process starts once the secretary has been notified that a
 proposal is ready for decision.
 
 -  The secretary nominates a member of the committee, the *shepherd*, to oversee
@@ -273,7 +273,7 @@ proposal is ready for decision.
    decides whether the proposal ought to be accepted or rejected or returned for
    revision.
 
--  If the shephard thinks the proposal ought to be rejected, they post their
+-  If the shepherd thinks the proposal ought to be rejected, they post their
    justifications on the GitHub thread, and invite the authors to respond with
    a rebuttal and/or refine the proposal. This continues until either
 
@@ -289,8 +289,8 @@ proposal is ready for decision.
 
    * post their recommendation, with a rationale, on the GitHub discussion thread,
    * label the pull request as ``Pending committee review``,
-   * notify the committe by mentioning ``@ghc-proposals/ghc-steering-committee``,
-   * inlude the sentence “This proposal will now be discussed by the committee.
+   * notify the committee by mentioning ``@ghc-proposals/ghc-steering-committee``,
+   * include the sentence “This proposal will now be discussed by the committee.
      We welcome all authors to join the discussion, but kindly ask others to
      refrain from posting.” in the comment
    * drop a short mail to the mailing list informing the committee that

--- a/README.rst
+++ b/README.rst
@@ -209,9 +209,9 @@ When the discussion has ebbed down and the author thinks the proposal is ready, 
    ``@nomeata``).
 
 `The secretary <#who-is-the-committee>`_ will then label the pull request with
-``Pending committee review`` and start the `committee process <#committee-process>`_.
-(If this does not happen within a day or two, please ping the secretary or the
-committee.)
+``Pending shepherd recommendation`` and start the `committee process
+<#committee-process>`_.  (If this does not happen within a day or two, please
+ping the secretary or the committee.)
 
 What is a dormant proposal
 --------------------------
@@ -258,13 +258,16 @@ Roman Leshchinskiy      `@rleshchinskiy <https://github.com/rleshchinskiy>`_
 Committee process
 -----------------
 
-The committee process starts once the committee has been notified that a
-proposal is ready for decision, and takes place on the
-`ghc-steering-committee <https://mail.haskell.org/cgi-bin/mailman/listinfo/>`_
-mailing list. All interested parties are invited to follow the discussion.
+The committee process starts once the secretray has been notified that a
+proposal is ready for decision.
 
 -  The secretary nominates a member of the committee, the *shepherd*, to oversee
-   the discussion.
+   the discussion. The secretary
+
+   * labels the proposal as ``Pending shepherd recommendation``,
+   * assigns the proposal to the shepherd,
+   * drops a short mail on the mailing list, informing the committee about the
+     status change.
 
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
    decides whether the proposal ought to be accepted or rejected or returned for
@@ -282,17 +285,27 @@ mailing list. All interested parties are invited to follow the discussion.
    * the authors and the shepherd fully understand each other’s differing
      positions, even if they disagree on the conclusion.
 
--  Now the shepherd proposes acceptance or rejectance, by email to the mailing
-   list. Discussion among the committee ensues on the mailing list, and
-   silence is understood as agreement with the shepherd's recommendation.
+-  Now the shepherd proposes to accept or reject the proposal. To do so, they
 
--  Ideally, the committee reaches consensus, as determined by the secretary or
+   * post their recommendation, with a rationale, on the GitHub discussion thread,
+   * label the pull request as ``Pending committee review``,
+   * notify the committe by mentioning ``@ghc-proposals/ghc-steering-committee``,
+   * inlude the sentence “This proposal will now be discussed by the committee.
+     We welcome all authors to join the discussion, but kindly ask others to
+     refrain from posting.” in the comment
+   * drop a short mail to the mailing list informing the committee that
+     discussion has started.
+
+-  Discussion among the committee ensues on the discussion thread.
+   Silence is understood as agreement with the shepherd's recommendation.
+   Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
--  The decision is announced, by the shepherd to the mailing list.
+-  The decision is announced, by the shepherd or the secretary, on the Github
+   thread and the mailing list.
 
--  The secretary tags the pull request accordingly, and either merges or closes it.
+   The secretary tags the pull request accordingly, and either merges or closes it.
    In particular
 
    *  **If we say no:**

--- a/README.rst
+++ b/README.rst
@@ -267,23 +267,36 @@ mailing list. All interested parties are invited to follow the discussion.
    the discussion.
 
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
-   makes a recommendation as to whether the proposal ought to be accepted,
-   rejected or returned for revision.
+   decides whether the proposal ought to be accepted or rejected or returned for
+   revision.
+   
+-  If the shephard thinks the proposal ought to be rejected, they post their
+   justifications on the GitHub thread, and invites the authors to respond with
+   a rebuttal and/or refine the proposal. This continues until the either
+    
+   * the shepherd changes their mind and supports the proposal now,
+   * the authors withdraw their proposal,
+   * the authors indicate that they will revise the proposal to address the shepherds
+     point. The shepherd will label the pull request as
+     `Needs Revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A"Needs+revision">`_.
+   * the authors and the shepherd fully understand each other’s differing
+     positions, even if they disagree on the conclusion.
 
--  Discussion among the committee ensues on the mailing list.
-   Silence is understood as agreement with the shepherds recommendation.
+-  Now the shepherd proposes acceptance or rejectance, by email to the mailing
+   list. Discussion among the committee ensues on the mailing list, and 
+   silence is understood as agreement with the shepherds recommendation.
 
 -  Ideally, the committee reaches consensus, as determined by the secretary or
-   the shepherd.  If consensus is elusive, then we vote, with the Simons
+   the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
--  The decision is announced, by the shepherd or the secretary, to the mailing
-   list and the pull request commentary. In particular:
+-  The decision is announced, by the shepherd to the mailing.
 
-   *  **If we say no:** The shepherd comments on the GitHub pull request with the
-      reasons for rejection.
-      The pull request will be closed, by the shepherd or the secretary, with
-      label
+-  The secretary tags the pull request accordingly, and either merges or closes it.
+   In particular
+  
+   *  **If we say no:** 
+      The pull request will be closed and labeled
       `Rejected <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3Arejected>`_.
 
       If the proposer wants to revise and try again, the new proposal should
@@ -292,19 +305,10 @@ mailing list. All interested parties are invited to follow the discussion.
       In the case that the proposed change has already been implemented in
       GHC, it will be reverted.
 
-   *  **If we return for revision:** If during the debate, the need for
-      substantial changes does arise, then the shepherd summarizes the
-      issues on the GitHub pull request and labels it
-      `Needs Revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A"Needs+revision">`_.
-      The author is encouraged to address the issues and re-submit.
-
    *  **If we say yes:**
-      The shepherd or the secretary announces this on the pull request
-      and labels it as
+       The pull request will be merged, numbered and labeled
       `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3AAccepted>`_.
-      The secretary merges the pull request and assigns the final proposal
-      number.
-
+      
       At this point, the proposal process is technically
       complete. It is outside the purview of the committee to implement,
       oversee implementation, attract implementors, etc.


### PR DESCRIPTION
This is a variant of #221: It retains the extra step that the shepherd must confer with the author before proposing to reject a proposal, but it additionally moves GitHub discussion onto the mailing list.

A nice side-effect of this is that the committee mailing list will be mostly only status updates mails (new proposal, new recommendation, decision), and my status summary emails will be much less tedious to assemble :-)