### PR TITLE
Put associated-type kind sigs outside classes

### DIFF
--- a/proposals/0036-kind-signatures.rst
+++ b/proposals/0036-kind-signatures.rst
@@ -75,7 +75,7 @@ Proposed Change Specification
    is done before ever examining the full declaration, just like how GHC treats type
    signatures.
 
-   Associated types may be given kind signatures within their classes.
+   Associated types may be given kind signatures outside their classes.
 
    Unlike type signatures, the type variables brought into scope in a type-level kind
    signature do *not* scope over the type definition.
@@ -164,6 +164,9 @@ Alternatives
   made on the original), but it still means that types have a different treatment from
   terms, which is aesthetically displeasing to me.
 
+* Put associated-type signatures inside their classes. Doing so has unfortunate consequences
+  with respect to the scoping of class variables (do they scope over the kind signature or
+  not?).
 
 Unresolved questions
 --------------------


### PR DESCRIPTION
This is a small tweak to the [accepted proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0036-kind-signatures.rst) on top-level kind signatures. The only change is to move associated-type kind signatures outside their class declarations. This is for two reasons:

1. If the signature is within the class, we have some awkwardness around scoping. The kind signature is purportedly "top-level", but if the class variables are in scope there, what does that really mean? If the class variables are not in scope, then the scope of the class variables has a "hole", which is awkward.

2. I would like to see associated type families become more like methods. These would be [constrained](https://github.com/typedrat/ghc-proposals/blob/constrained-type-families/proposals/0000-simple-constrained-type-families.rst) and more tightly associated with their class. By putting signatures *outside* the class, we know that the signature is really the kind of the type family.

This tweak was, in part, fueled by challenges in implementation.