### PR TITLE
Ambiguous Type per-signature pragma

### DIFF
--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -91,7 +91,7 @@ Proposed Change Specification
 
 4. The error reporting from the ambiguity check that currently suggests ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes`` must make clear this is likely to entail using ``TypeApplications`` at usage sites, and that there are several possible approaches to avoid ambiguous type variables.
 
- Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) Starting bikeshed::
+   Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) Starting bikeshed::
  
      The ambiguity might be resolvable through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
  

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -101,7 +101,13 @@ Proposed Change Specification
  
      The ambiguity might be resolvable through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
  
-5. There is to be a flag ``-Wambiguous-types`` controlling whether a warning is raised for ambiguous types -- as allowed by ``-XAllowAmbiguousTypes``. If the signature is also marked ``{-# AMBIGUOUS #-}``, then don't issue the warning (see "migration path" below). If a signature marked ``{-# AMBIGUOUS #-}`` is not in fact ambiguous, ignore.
+5. There is to be a flag ``-Wambiguous-types`` controlling whether a warning is raised for ambiguous types -- as allowed by ``-XAllowAmbiguousTypes``. That is:
+
+   - If ``-XAllowAmbiguousTypes`` is not set, reject ambiguous signatures/don't also warn.
+   - If ``-XAllowAmbiguousTypes`` is set and the signature is also marked ``{-# AMBIGUOUS #-}``, then don't issue the warning (see "migration path" below).
+   - If a signature marked ``{-# AMBIGUOUS #-}`` is not in fact ambiguous, ignore.
+
+   ``-Wambiguous-types`` is to be in bin-of-warnings ``-W`` "normal warnings", on grounds an ambiguous signature is outside Haskell 2010. (If some time in future, ``-XAllowAmbiguousTypes`` is to be deprecated in favour of per-signature pragmas, move ``-Wambiguous-types`` into the ``-Wcompat`` bin.)
 
 6. The pragma can only appear with an explicit ``::`` signature; not for terms where the inferred signature is ambiguous such as toplevel functions or instances::
 
@@ -120,7 +126,7 @@ By lifting the ambiguity check only for signatures deliberately flagged, this en
 
 The proposed behaviour affects only validation and error/warning messages, not type checking rules or type inference.
 
-Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguities are not checked. The migration path is:
+Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguities are not checked. The migration path away from the module-wide setting for modules with ambiguous signatures is:
 
 * Switch on ``-Wambiguous-types``; compile the module to examine signatures that are currently ambiguous.
 
@@ -128,7 +134,11 @@ Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguitie
 
 * Remove the ``LANGUAGE AllowAmbiguousTypes`` setting and recompile.
 
-* In due course (not within scope of this proposal), deprecate the ``AllowAmbiguousTypes`` extension. (Same idea as introducing the ``OVERLAPPABLE`` and friends pragmas; then deprecating ``OverlappingInstances``/``IncoherentInstances``.)
+After this proposal is in place, with experience of how onerous or intrusive is the per-signature ``{-# AMBIGUOUS #-}``, a possible future migration path away from module-wide ``AllowAmbiguousTypes`` for GHC is
+
+* In due course (not within scope of this proposal), deprecate the ``AllowAmbiguousTypes`` extension in GHC, and eventually remove it. (Same idea as introducing the ``OVERLAPPABLE`` and friends pragmas; then deprecating ``OverlappingInstances``/``IncoherentInstances``.)
+
+Also note
 
 * Discussion on this proposal is going on in parallel with #234 'Local Warning Pragmas'. Because ``{-# AMBIGUOUS #-}`` is a language extension (an alternative to ``-XAllowAmbiguousTypes``), not merely controlling warnings, I see this as outside the scope that #234 has evolved to. (The ``-Wambiguous-types`` point 5. warning might fall within the 'Local Warning' in the sense of #234, but note that ``{-# AMBIGUOUS #-}`` in effect is a local suppression of that warning.)
 
@@ -160,7 +170,7 @@ No contrary feedback received for these questions, so left here as visible for C
 
 * [Implementor's judgment:] Re pragmas that change semantics (such as the ``{-# OVERLAPPABLE #-}`` series), there has been comment they're difficult for source tooling utilities to observe. As well as the ``AMBIGUOUS`` pragma per signature, should there be a module-wide ``LANGUAGE`` setting? ``-XAmbiguousTypesPragma``.
 
-* [From discussion, decide against this:] For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NOAMBIGUOUS #-}`` that *does* apply the ambiguity check? That would prevent in future deprecating ``AllowAmbiguousTypes``.
+* [From discussion, decide against this:] For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NO[T_]AMBIGUOUS #-}`` that *does* apply the ambiguity check? That would prevent in future deprecating ``AllowAmbiguousTypes``.
 
 * [Implementor's judgment:] If a signature marked ``{-# AMBIGUOUS #-}`` is not in fact ambiguous ...? A comment suggested warning of the non-ambiguity. 
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -208,7 +208,7 @@ Appendix: BNF diff for appearences of ``{-# AMBIGUOUS #-}``
     exp     → infixexp :: [ {-# AMBIGUOUS #-} ] [context =>] type      (expression type signature)
             | infixexp
             
-    fexp    → [fexp] [@([ {-# AMBIGUOUS #-} ] type)] aexp	       (function application with type applicn)
+    fexp    → [fexp [@([ {-# AMBIGUOUS #-} ] type)] ] aexp	       (function application with type applicn)
 
     gendecl → vars :: [ {-# AMBIGUOUS #-} ] [context =>] type          (type signature)
             | fixity [integer] ops                                     (fixity declaration)
@@ -223,11 +223,11 @@ Appendix: BNF diff for appearences of ``{-# AMBIGUOUS #-}``
             
     topdecl → ...
             | data simpletype where [gconstrs] [deriving]              (GADT style data or newtype)
-            | newtype [context =>] simpletype where [newgconstrs] [deriving]
+            | newtype simpletype where [newgconstrs] [deriving]
             | ...
             
     gconstrs → gconstr1 | … | gconstrn	                               (n ≥ 1)
-    gconstr → con [{ fielddecl1 , … , fielddecln }] :: [ {-# AMBIGUOUS #-} ] [context =>] type  
+    gconstr → con :: [ {-# AMBIGUOUS #-} ] [{ fielddecl1 , … , fielddecln }] [context =>] type  
                                                    	               (n ≥ 0, GADT style constructor)
                                                                        (GADT style newtype constr likewise)
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -91,20 +91,20 @@ Proposed Change Specification
     
         data T :: {-# AMBIGUOUS #-} F a -> Type                   -- ambiguous kind signature
         
-   Also ``{-# AMBIGUOUS #-}`` can appear after ``::`` in a ``data`` or ``newtype`` declaration -- either for fields or GADT-style constructors; or in H2010-style immediately after the constructor::
+   Also ``{-# AMBIGUOUS #-}`` can appear after ``::`` in a ``data`` or ``newtype`` declaration -- either for fields or GADT-style constructors; or in H2010-style immediately ~after~ before the constructor (that is, after ``=`` or ``|``, because no ``::``)::
    
         data D a where                                            -- GADT style
           MkD :: {-# AMBIGUOUS #-} (forall b. C a b => a)
 
-        data D2 a = MkD2  {-# AMBIGUOUS #-} (forall b. C a b => a) (Show a => a) 
+        data D2 a = {-# AMBIGUOUS #-} MkD2  (forall b. C a b => a) (Show a => a) 
                                                -- H2010 style; note no ::; note the second arg is not ambiguous
                                                
-        newtype N a = MkN {-# AMBIGUOUS #-} { foo :: {-# AMBIGUOUS #-} (forall b. C a b => a) } 
+        newtype N a = {-# AMBIGUOUS #-} MkN { foo :: {-# AMBIGUOUS #-} (forall b. C a b => a) } 
                                                -- AMBIGUOUS not ambiguous, but one is redundant
 
-   ``{-# AMBIGUOUS #-}`` is also to be allowed in the body of a type application::
+   For type applications, see 7. <strike>``{-# AMBIGUOUS #-}`` is also to be allowed in the body of a type application::
 
-        x = foo @({-# AMBIGUOUS #-} forall b. C a b => a) bar
+        x = foo @({-# AMBIGUOUS #-} forall b. C a b => a) bar</strike>
    
    See Appendix giving a diff to the BNF for the language (wrt the Report, and affected extensions).
 
@@ -133,6 +133,8 @@ Proposed Change Specification
     instance C (F b) => C (Option a)
     
    For those cases, the user must contrive an explicit signature (with ``-XInstanceSigs`` if necessary).
+
+7. Type applications are to be allowed ambiguous signatures, no warning or error, without needing ``{-# AMBIGUOUS #-}`` (nor needing ``LANGUAGE AllowAmbiguousTypes``).
 
 
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -131,7 +131,7 @@ Proposed Change Specification
     
    For those cases, the user must contrive an explicit signature (with ``-XInstanceSigs`` if necessary).
 
-7. ``-XTypeApplications`` is to be changed, so that when enabled, ``f @t`` is valid regardless of whether ``t`` is ambiguous. That is, Type applications are to be allowed ambiguous signatures, no warning or error, without needing ``{-# AMBIGUOUS #-}`` (nor needing ``LANGUAGE AllowAmbiguousTypes``). For example, this is currently rejected without ``AllowAmbiguousTypes``:
+7. ``-XTypeApplications`` is to be changed, so that when enabled, ``f @t`` is valid regardless of whether ``t`` is ambiguous. That is, Type applications are to be allowed ambiguous signatures, no warning or error, without needing ``{-# AMBIGUOUS #-}`` (nor needing ``LANGUAGE AllowAmbiguousTypes``). For example, this is currently rejected without ``AllowAmbiguousTypes``::
 
         x = foo @(forall b. C a b => a) bar
 
@@ -178,7 +178,7 @@ Do nothing. That is, continue with the module-wide ``AllowAmbiguousTypes`` setti
     
 I would disagree with that "useless". I see the confusion they cause as harmful. Especially because that follows from the error message's misleading ``enable AllowAmbiguousTypes``.
 
-Re Type Applications [Section 2 Point 7.] possibly changing to silently accept ambiguous signatures might be considered too radical of a change. (Although this is the opposite of a breaking change: it will accept more programs, without needing ``LANGUAGE AllowAmbiguousTypes``.) Then Point 7. could require an ``{-# AMBIGUOUS #-}`` pragma after the ``@``, and syntactically would need the signature and pragma enclosed in parens, for example:
+Re Type Applications [Section 2 Point 7.] possibly changing to silently accept ambiguous signatures might be considered too radical of a change. (Although this is the opposite of a breaking change: it will accept more programs, without needing ``LANGUAGE AllowAmbiguousTypes``.) Then Point 7. could require an ``{-# AMBIGUOUS #-}`` pragma after the ``@``, and syntactically would need the signature and pragma enclosed in parens, for example::
 
     x = foo @({-# AMBIGUOUS #-} forall b. C a b => a) bar
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -30,29 +30,82 @@ Proposal title
 .. sectnum::
 .. contents::
 
-Text for pull request [move there when PR created].
+.. Text for pull request [move there when PR created]:
 
-Per-signature pragma ``{-# AMBIGUOUS #-}`` to allow that signature's type to be ambiguous; replacing the module-wide ``-XAllowAmbiguousTypes``, which dangerously lifts ambiguity checking on all signatures.
+Per-signature pragma ``{-# AMBIGUOUS #-}`` to allow that signature's type to be ambiguous; instead of the module-wide ``-XAllowAmbiguousTypes``, which dangerously lifts ambiguity checking on all signatures.
 
 Also tweak the error reporting to avoid recklessly suggesting users turn on ``-XAllowAmbiguousTypes``; and provide a flag ``-Wallowed-ambiguous-types`` that shows the ambiguity message as a warning.
 
-To do: Here you should write a short abstract motivating and briefly summarizing the proposed change.
+.. Here you should write a short abstract motivating and briefly summarizing the proposed change.
 
-This proposal was the residue from discussions around 'Top-level signatures' #148. Thank you to @goldfirere and @int-index.
+Provide a per-signature ``{-# AMBIGUOUS #-}`` pragma, to precision-control which signatures are allowed/intended to be ambiguous. This to be instead of the module-wide ``LANGUAGE AllowAmbiguousTypes`` setting. Because ambiguous signatures (at definition sites) for functions/methods are more likely to be an error than be intended -- even for code written to combine with ``-XTypeApplications`` at usage sites. Currently the ``-XAllowAmbiguousTypes`` lifts the ambiguity check indiscriminately for all signatures in a module.
+
+The likelihood of error is made worse by GHC's current error reporting that suggests a blanket ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes``. Naive (and not-so-naive) users tend to grab for this suggestion which a) will only move the ambiguity to the usage site where it is more difficult to diagnose; and b) is liable to allow through other ambiguous signatures that were not intended. So this proposal also tightens error reporting and wording.
+
+This proposal is a residue from discussions around 'Top-level signatures' #148. Thank you to @goldfirere and @int-index.
 
 Motivation
 ------------
-Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+.. Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
 
+Ambiguous types/signatures at definition sites combine powerfully with ``TypeApplications`` at usage sites for fancy type trickery. This is an 'advanced' feature that should be opt-in. Currently ``LANGUAGE AllowAmbiguousTypes`` is a module-wide setting that abandons checking for ambiguity, whether or not the user intends to use some function/method with ``TypeApplications``.
+
+Consider this code (a classic of its time)
+::
+
+    class Collects c e  where
+      insert :: e -> c -> c
+      empty :: c
+
+GHC correctly rejects this::
+
+    * Could not deduce (Collects c e0)
+      from the context: Collects c e
+        bound by the type signature for:
+                   empty :: forall c e. Collects c e => c
+      The type variable `e0' is ambiguous
+    * In the ambiguity check for `empty'
+
+So far so good. There are several possible approaches to avoiding this ambiguity
+
+* Use a (Associated) Type Family to derive ``e`` from ``c``, so ``e`` can be removed as a type parameter (or constrained by an ``~`` to the TF.)
+* Use a Functional Dependency.
+* Use method ``singleton :: e -> c`` instead of ``empty`` with its failure to ground ``e``.
+
+Any of those are better than what GHC suggests next::
+
+    To defer the ambiguity check to use sites, enable AllowAmbiguousTypes
+
+Novice users will switch on that option and get class ``Collects`` to compile. Great, thank you GHC. Except they are now in for a world of pain and confusion. At usage sites, they'll get a whole series of ``The type variable `e0' is ambiguous`` and ``Could not deduce (Collects [e1] e0)`` messages. If they persevere they might reach::
+
+    instance Collects [e] e  where
+      insert = (:)
+      empty = []
+
+    *> insert 'c' (empty :: [Char])
+
+    * Ambiguous type variable `e0' arising from a use of `empty'
+      prevents the constraint `(Collects [Char] e0)' from being solved.
+      Probable fix: use a type annotation to specify what `e0' should be.
+
+Grr. There *is* a type annotation on that ``empty``; and the ``insert 'c' ...`` is telling the type of ``e0``. Where/how on earth to specify ``e0`` otherwise? The answer (which they'll get on StackOverflow) is there's only one way: use a ``TypeApplications``. Why didn't GHC say that long ago? Why did GHC lead down the rabbit-hole of ``AllowAmbiguousTypes``? The User Guide is no help: for ``AllowAmbiguousTypes``, there's a series of examples where types at the usage site can be resolved by an annotation or a literal of specific type. There's brief mention of ``TypeApplications``. The patient helpers at StackOverflow are adept at winding users back to the definition site, and advising they probably didn't ever need to go down the rabbit-hole.
+
+Oh, and thanks to ``AllowAmbiguousTypes`` being a module-wide setting, there's probably several other definitions in the module that didn't get ambiguity-checked. So at usage sites there's piles of these ambiguities to be unwound.
+
+In an ideal world, that error message should probably say something long-winded to the effect: do you know what you're doing with ``TypeApplications``/is that what you intend at usage sites? Then you forgot to switch on ``AllowAmbiguousTypes`` in the definition module. (Oh, and watch out that any/all of your definitions might be ambiguous, I won't be checking them.) It should go on to say: if you don't understand what I'm talking about, probably there's a better way to avoid that ambiguity.
+
+Then this proposal firstly aims to avoid users blundering blindly into ambiguous signatures, by improving error messages and warnings; secondly avoids the dangers of module-wide abandoning ambiguity checking.
 
 Proposed Change Specification
 -----------------------------
 
-1. There is to be a pragma ``{-# AMBIGUOUS #-}``, to appear immediately after the ``::`` of a function or method definition's signature (so before the type). Not applicable for term type annotations beginning ``::``, nor for pattern signatures. Example
+1. There is to be a pragma ``{-# AMBIGUOUS #-}``, to appear immediately after the ``::`` of a function or method definition's signature (so before the type). Not applicable for term type annotations beginning ``::``, nor for pattern signatures. Examples
 ::
 
- class Sized a  where
-   sizeOf :: {-# AMBIGUOUS #-} Integer
+    f :: {-# AMBIGUOUS #-} C a => Int
+
+    class Sized a  where
+      sizeOf :: {-# AMBIGUOUS #-} Integer
 
 2. Types marked ``AMBIGUOUS`` are to be validated as if ``-XAllowAmbiguousTypes`` is set, for that signature only. (If that is already set module-wide, the pragma has no further effect.)
 
@@ -60,9 +113,11 @@ Proposed Change Specification
 
 4. The error reporting from the ambiguity check that currently suggests ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes`` must make clear this is likely to entail using ``TypeApplications`` at usage sites, and that there are several possible approaches to avoid ambiguous type variables.
 
- Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.)
+ Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) Starting bikeshed::
  
- 5. There is to be a flag ``-Wallowed-ambiguous-types`` controlling whether a warning is raised for ambiguous types -- allowed either from the ``AMBIGUOUS`` pragma or ``-XAllowAmbiguousTypes``.
+     The ambiguity might be resolved through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
+ 
+5. There is to be a flag ``-Wallowed-ambiguous-types`` controlling whether a warning is raised for ambiguous types -- allowed either from the ``AMBIGUOUS`` pragma or ``-XAllowAmbiguousTypes``.
 
 
 
@@ -71,7 +126,7 @@ Effect and Interactions
 -----------------------
 By lifting the ambiguity check only for signatures deliberately flagged, this ensures ambiguity checking does apply for the bulk of the signatures in the program *at the definition site*. Then ambiguity is less likely to manifest at *usage* sites, where it is more difficult to diagnose -- particularly if that is in a separate module.
 
-The proposed behaviour affects only validate and error/warning messages, not type checking rules or type inference.
+The proposed behaviour affects only validation and error/warning messages, not type checking rules or type inference.
 
 Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguities are not checked. The migration path is:
 
@@ -84,7 +139,13 @@ Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguitie
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+.. Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+
+The proposal is for superficial tweaks to error reporting/warnings. There is no deep impact on type checking or inference.
+
+For code intending to make heavy use of ``TypeApplications`` at usage sites, there may be many ambiguous signatures, needing many pragmas at definition sites that might be onerous to code. Against that, the per-signature pragma means that other definitions in the module do get properly checked against ambiguity.
+
+GHC's suggestion ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes`` is currently costing a great deal of perplexity and frustration for novice and not-so-novice users. Evidence: StackOverflow questions anon. Switching on the option in the definition module is not likely to help anything compile, unless the user is consciously intending to use ``TypeApplications`` at the usage site/module. That may not be the best approach for the coding requirements (see Motivation section), but GHC's message does not suggest other options. Novice and not-so-novice users are likely to attach too much weight to that suggestion.
 
 
 Alternatives
@@ -102,7 +163,7 @@ Unresolved questions
 
 * Re pragmas that change semantics (such as the ``{-# OVERLAPPABLE #-}`` series), there has been comment they're difficult for source tooling utilities to observe. As well as the ``AMBIGUOUS`` pragma per signature, should there be a module-wide ``LANGUAGE`` setting? ``-XAllowAmbiguousTypesPragma``.
 
-* For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NOAMBIGUOUS#-}`` that *does* apply the ambiguity check?
+* For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NOAMBIGUOUS #-}`` that *does* apply the ambiguity check?
 
 
 Implementation Plan

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -1,0 +1,84 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Proposal title
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Text for pull request [move there when PR created].
+
+Per-signature pragma `{-# AMBIGUOUS #-}` allows that signature's type to be ambiguous; replacing the whole-module `-XAllowAmbiguousTypes`, which dangerously lifts ambiguity checking on all signatures.
+
+Also tweak the error reporting to avoid recklessly suggesting users turn on `-XAllowAmbiguousTypes`; and provide a flag `-Wallowed-ambiguous-types` that shows the ambiguity message as a warning.
+
+To do: Here you should write a short abstract motivating and briefly summarizing the proposed change.
+
+
+Motivation
+------------
+Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
+
+* grammar and semantics of any new syntactic constructs
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
+
+Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+
+
+Effect and Interactions
+-----------------------
+Detail how the proposed change addresses the original problem raised in the motivation.
+
+Discuss possibly contentious interactions with existing language or compiler features. 
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+
+
+Unresolved questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -11,19 +11,10 @@ Ambiguous Type per-signature pragma
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/232>`_.
 .. sectnum::
 .. contents::
 
-.. Text for pull request [move there when PR created]:
-
-Per-signature pragma ``{-# AMBIGUOUS #-}`` to allow that signature's type to be ambiguous; instead of the module-wide ``-XAllowAmbiguousTypes``, which dangerously lifts ambiguity checking on all signatures.
-
-Also tweak the error reporting to avoid recklessly suggesting users turn on ``-XAllowAmbiguousTypes``; and provide a flag ``-Wallowed-ambiguous-types`` that shows the ambiguity message as a warning.
-
-.. Here you should write a short abstract motivating and briefly summarizing the proposed change.
 
 Provide a per-signature ``{-# AMBIGUOUS #-}`` pragma, to precision-control which signatures are allowed/intended to be ambiguous. This to be instead of the module-wide ``LANGUAGE AllowAmbiguousTypes`` setting. Because ambiguous signatures (at definition sites) for functions/methods are more likely to be an error than be intended -- even for code written to combine with ``-XTypeApplications`` at usage sites. Currently the ``-XAllowAmbiguousTypes`` lifts the ambiguity check indiscriminately for all signatures in a module.
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -102,9 +102,6 @@ Proposed Change Specification
         newtype N a = {-# AMBIGUOUS #-} MkN { foo :: {-# AMBIGUOUS #-} (forall b. C a b => a) } 
                                                -- AMBIGUOUS not ambiguous, but one is redundant
 
-   For type applications, see 7. <strike>``{-# AMBIGUOUS #-}`` is also to be allowed in the body of a type application::
-
-        x = foo @({-# AMBIGUOUS #-} forall b. C a b => a) bar</strike>
    
    See Appendix giving a diff to the BNF for the language (wrt the Report, and affected extensions).
 
@@ -134,8 +131,9 @@ Proposed Change Specification
     
    For those cases, the user must contrive an explicit signature (with ``-XInstanceSigs`` if necessary).
 
-7. Type applications are to be allowed ambiguous signatures, no warning or error, without needing ``{-# AMBIGUOUS #-}`` (nor needing ``LANGUAGE AllowAmbiguousTypes``).
+7. ``-XTypeApplications`` is to be changed, so that when enabled, ``f @t`` is valid regardless of whether ``t`` is ambiguous. That is, Type applications are to be allowed ambiguous signatures, no warning or error, without needing ``{-# AMBIGUOUS #-}`` (nor needing ``LANGUAGE AllowAmbiguousTypes``). For example, this is currently rejected without ``AllowAmbiguousTypes``:
 
+        x = foo @(forall b. C a b => a) bar
 
 
 Effect and Interactions
@@ -180,6 +178,10 @@ Do nothing. That is, continue with the module-wide ``AllowAmbiguousTypes`` setti
     
 I would disagree with that "useless". I see the confusion they cause as harmful. Especially because that follows from the error message's misleading ``enable AllowAmbiguousTypes``.
 
+Re Type Applications [Section 2 Point 7.] possibly changing to silently accept ambiguous signatures might be considered too radical of a change. (Although this is the opposite of a breaking change: it will accept more programs, without needing ``LANGUAGE AllowAmbiguousTypes``.) Then Point 7. could require an ``{-# AMBIGUOUS #-}`` pragma after the ``@``, and syntactically would need the signature and pragma enclosed in parens, for example:
+
+    x = foo @({-# AMBIGUOUS #-} forall b. C a b => a) bar
+
 Unresolved questions
 --------------------
 
@@ -208,7 +210,7 @@ Appendix: BNF diff for appearences of ``{-# AMBIGUOUS #-}``
     exp     → infixexp :: [ {-# AMBIGUOUS #-} ] [context =>] type      (expression type signature)
             | infixexp
             
-    fexp    → [fexp [@([ {-# AMBIGUOUS #-} ] type)] ] aexp	       (function application with type applicn)
+    fexp    → [fexp [@([ {-# AMBIGUOUS #-} ] type)] ] aexp	       (function application with type applicn, see Alternatives)
 
     gendecl → vars :: [ {-# AMBIGUOUS #-} ] [context =>] type          (type signature)
             | fixity [integer] ops                                     (fixity declaration)

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -109,11 +109,9 @@ Proposed Change Specification
 
 3. This does not change the validation for ambiguous types/type variables at usage sites.
 
-4. The error reporting from the ambiguity check that currently suggests ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes`` must make clear this is likely to entail using ``TypeApplications`` at usage sites, and that there are several possible approaches to avoid ambiguous type variables.
-
-   Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) Starting bikeshed::
+4. The error reporting from the ambiguity check that currently suggests ``To defer the ambiguity check to use sites, enable AllowAmbiguousTypes`` must make clear this is likely to entail using ``TypeApplications`` at usage sites, and that there are several possible approaches to avoid ambiguous types. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) ::
  
-     The ambiguity might be resolvable through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
+     If you intend to resolve the ambiguity at each use site (typically via TypeApplications), prefix this signature with the AMBIGUOUS pragma.
  
 5. There is to be a flag ``-Wambiguous-types`` controlling whether a warning is raised for ambiguous types -- as allowed by ``-XAllowAmbiguousTypes``. That is:
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -1,20 +1,7 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
-
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
 
 
-Proposal title
-==============
+Ambiguous Type per-signature pragma
+===================================
 
 .. proposal-number:: Leave blank. This will be filled in when the proposal is
                      accepted.
@@ -46,7 +33,7 @@ This proposal is a residue from discussions around 'Top-level signatures' #148. 
 
 Motivation
 ------------
-.. Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+
 
 Ambiguous types/signatures at definition sites combine powerfully with ``TypeApplications`` at usage sites for fancy type trickery. This is an 'advanced' feature that should be opt-in. Currently ``LANGUAGE AllowAmbiguousTypes`` is a module-wide setting that abandons checking for ambiguity, whether or not the user intends to use some function/method with ``TypeApplications``.
 
@@ -107,7 +94,7 @@ Proposed Change Specification
     class Sized a  where
       sizeOf :: {-# AMBIGUOUS #-} Integer
 
-2. Types marked ``AMBIGUOUS`` are to be validated as if ``-XAllowAmbiguousTypes`` is set, for that signature only. (If that is already set module-wide, the pragma has no further effect.)
+2. Signatures marked ``AMBIGUOUS`` are to be validated as if ``-XAllowAmbiguousTypes`` is set, for that signature only. (If that is already set module-wide, the pragma has no further effect.)
 
 3. This does not change the validation for ambiguous types/type variables at usage sites.
 
@@ -115,7 +102,7 @@ Proposed Change Specification
 
  Precise wording to be arrived at in discussion of this PR. (Prefer not mentioning ``AllowAmbiguousTypes`` at all.) Starting bikeshed::
  
-     The ambiguity might be resolved through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
+     The ambiguity might be resolvable through TypeApplications at use sites. Then mark this signature as AMBIGUOUS
  
 5. There is to be a flag ``-Wallowed-ambiguous-types`` controlling whether a warning is raised for ambiguous types -- allowed either from the ``AMBIGUOUS`` pragma or ``-XAllowAmbiguousTypes``.
 
@@ -139,7 +126,6 @@ Existing code using ``AllowAmbiguousTypes`` is not affected. That is, ambiguitie
 
 Costs and Drawbacks
 -------------------
-.. Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
 
 The proposal is for superficial tweaks to error reporting/warnings. There is no deep impact on type checking or inference.
 

--- a/proposals/AmbiguousType-pragma.rst
+++ b/proposals/AmbiguousType-pragma.rst
@@ -77,20 +77,19 @@ Then this proposal firstly aims to avoid users blundering blindly into ambiguous
 Proposed Change Specification
 -----------------------------
 
-1. There is to be a pragma ``{-# AMBIGUOUS #-}``, to appear immediately after the ``::`` (so before the type), in principle wherever ``::`` can appear. That is a function or method definition's signature; term type annotations beginning ``::``; pattern signatures (and pattern synonyms). The "in principle" would also include ``::`` introducing kind signatures (type of types); and possibly places ready for not-yet-developed usages of type ``@`` applications. Examples
-::
+1. There is to be a pragma ``{-# AMBIGUOUS #-}``, to appear immediately after the ``::`` (so before the type), in principle wherever ``::`` can appear. That is a function or method definition's signature; term type annotations beginning ``::``; pattern signatures (and pattern synonyms). The "in principle" would also include ``::`` introducing kind signatures (type of types); and possibly places ready for not-yet-developed usages of type ``@`` applications. Examples::
 
-    f :: {-# AMBIGUOUS #-} C a => Int
+        f :: {-# AMBIGUOUS #-} C a => Int
 
-    class Sized a  where
-      sizeOf :: {-# AMBIGUOUS #-} Integer
+        class Sized a  where
+          sizeOf :: {-# AMBIGUOUS #-} Integer
       
-    apply (x :: {-# AMBIGUOUS #-} forall a. (Read a, Show a) => String -> String) = x @Int "01"
+        apply (x :: {-# AMBIGUOUS #-} forall a. (Read a, Show a) => String -> String) = x @Int "01"
     
-    norm :: {-# AMBIGUOUS #-} forall a. (Read a, Show a) => String -> String
-    norm = show @a . read                                     -- needs type-lambda #155
+        norm :: {-# AMBIGUOUS #-} forall a. (Read a, Show a) => String -> String
+        norm = show @a . read                                     -- needs type-lambda #155
     
-    data T :: {-# AMBIGUOUS #-} F a -> Type                   -- ambiguous kind signature
+        data T :: {-# AMBIGUOUS #-} F a -> Type                   -- ambiguous kind signature
 
 2. Signatures marked ``AMBIGUOUS`` are to be validated as if ``-XAllowAmbiguousTypes`` is set, for that signature only. (If that is already set module-wide, the pragma has the effect of suppressing the ``-Wambiguous-type`` warning, see 5.)
 
@@ -155,13 +154,15 @@ I would disagree with that "useless". I see the confusion they cause as harmful.
 Unresolved questions
 --------------------
 
-* Precise wording to be discussed for the rejection message that currently suggests enabling ``AllowAmbiguousTypes``.
+No contrary feedback received for these questions, so left here as visible for Committee discussion.
 
-* Re pragmas that change semantics (such as the ``{-# OVERLAPPABLE #-}`` series), there has been comment they're difficult for source tooling utilities to observe. As well as the ``AMBIGUOUS`` pragma per signature, should there be a module-wide ``LANGUAGE`` setting? ``-XAllowAmbiguousTypesPragma``.
+* [No objection to:] Precise wording proposed for the rejection message that currently suggests enabling ``AllowAmbiguousTypes``.
 
-* From discussion, decide against this: For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NOAMBIGUOUS #-}`` that *does* apply the ambiguity check? That would prevent in future deprecating ``AllowAmbiguousTypes``.
+* [Implementor's judgment:] Re pragmas that change semantics (such as the ``{-# OVERLAPPABLE #-}`` series), there has been comment they're difficult for source tooling utilities to observe. As well as the ``AMBIGUOUS`` pragma per signature, should there be a module-wide ``LANGUAGE`` setting? ``-XAmbiguousTypesPragma``.
 
-* If a signature marked ``{-# AMBIGUOUS #-}`` is not in fact ambiguous ...? A comment suggested warning of the non-ambiguity. Leave that to the implementer's judgment.
+* [From discussion, decide against this:] For modules containing more ambiguous types than not, so with ``AllowAmbiguousTypes`` switched on, should there be a per-signature pragma ``{-# NOAMBIGUOUS #-}`` that *does* apply the ambiguity check? That would prevent in future deprecating ``AllowAmbiguousTypes``.
+
+* [Implementor's judgment:] If a signature marked ``{-# AMBIGUOUS #-}`` is not in fact ambiguous ...? A comment suggested warning of the non-ambiguity. 
 
 
 Implementation Plan


### PR DESCRIPTION
Per-signature pragma ``{-# AMBIGUOUS #-}`` to allow that signature's type to be ambiguous; instead of the module-wide ``-XAllowAmbiguousTypes``, which dangerously lifts ambiguity checking on all signatures.

Also tweak the error reporting to avoid recklessly suggesting users turn on ``-XAllowAmbiguousTypes``; and provide a flag ``-Wallowed-ambiguous-types`` that shows the ambiguity message as a warning.

[Rendered](https://github.com/AntC2/ghc-proposals/blob/patch-2/proposals/AmbiguousType-pragma.rst)

<!-- probot = {"1313345":{"who":"goldfirere","what":"accept this","when":"2019-08-09T09:00:00.000Z"}} -->