### PR TITLE
Introduce -XTypeAbstractions, limiting -XScopedTypeVariables

### DIFF
--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -424,12 +424,33 @@ Effect and Interactions
   
 Costs and Drawbacks
 -------------------
-* The new small zoo of flags is yet more flags to be aware of. It is possible to do away
-  with this part of the proposal of the cost appears to outweigh the benefit. (Earlier
-  versions of this proposal had ``-XTypeAbstractions`` imply ``-XNoScopedForAlls``, but
-  that does not work with *inferred* variables. In any case, this historical fact is why
-  these two ideas are bundled in one proposal. They could be separated, but I want both
-  parts, so I've kept them both here.)
+* The new small zoo of flags is yet more flags to be aware of. It is possible
+  to do away with this part of the proposal if the cost appears to outweigh
+  the benefit. (Earlier versions of this proposal had ``-XTypeAbstractions``
+  imply ``-XNoScopedForAlls``. In any case, this historical fact is why these
+  two ideas are bundled in one proposal. They could be separated, but I want
+  both parts, so I've kept them both here.)
+
+* Note that the second part of this proposal (introducing ``-XTypeAbstractions``)
+  is *not* backward-compatible, because it rejects expressions like ::
+
+    ((\x -> (x :: a)) :: forall a. a -> a)
+
+  which are accepted today. No migration period is proposed, because it is
+  very hard to imagine how ``-XTypeAbstractions`` and ``-XScopedForAlls`` should
+  co-exist peacefully here. Instead, we can issue a specific error message telling
+  users how to migrate their code in this case.
+
+  My hope is that constructs such as this one are rare and would not impact many
+  users.
+
+  If necessary, we could imagine taking the expression ``expr :: forall ... . ty``
+  and looking proactively to see whether ``expr`` ever uses a type variable
+  pattern from this proposal. If not, ``-XScopedForAlls`` could trigger (and we
+  issue a warning with ``-Wcompat``). But, if a type argument appears anywhere
+  in ``expr``, then ``-XScopedForAlls`` is disabled. This would be backward-compatible,
+  but unfortunately non-local and annoying. I prefer just to skip this
+  migration step.
 
 * ``-XTypeAbstractions`` is another feature to specify and maintain, and
   that's always a burden. It will take some creative thought about how to do

--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -14,6 +14,7 @@ Binding type variables in lambda-expressions
 .. _`#128`: https://github.com/ghc-proposals/ghc-proposals/pull/128
 .. _`#119`: https://github.com/ghc-proposals/ghc-proposals/pull/119
 .. _`Haskell 2010 Report`: https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-18000010.5
+.. _`#285`: https://github.com/ghc-proposals/ghc-proposals/pull/285
 
 Proposal `#126`_ allows us to bind scoped type variables in patterns using an ``@a`` syntax.
 However, the new syntax is allowed only in *constructor* patterns ``K @a @b x y``. This proposal
@@ -95,13 +96,16 @@ Proposed Change Specification
 -----------------------------
 
 1. Introduce ``-XPatternSignatures``. With ``-XPatternSignatures``, we would
-   allow type signatures in patterns. These signatures could mention type
-   variables, but their scope would be limited to only that very signature.
+   allow type signatures in patterns. These signatures could mention in-scope
+   type variables as variable occurrences, but could not bind type variables.
 
-2. Introduce ``-XPatternTypeVariables``. With ``-XPatternTypeVariables``, any
-   type variables bound in a pattern signature would remain in scope over the
+2. Introduce ``-XPatternSignatureBinds``. With ``-XPatternSignatureBinds``, any
+   out-of-scope type variables written in a pattern signature would be bound there
+   and would remain in scope over the
    same region of code that term-level variables introduced in a pattern scope
-   over. This implies ``-XPatternSignatures``.
+   over. This extension is on by default (but is useless without ``-XPatternSignatures``).
+   (This point is actually not a change, but is a part of accepted proposal
+   `#285`_.)
 
 3. Introduce ``-XMethodTypeVariables``. With ``-XMethodTypeVariables``, type
    variables introduced in an instance head would scope over the bodies of

--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -492,8 +492,7 @@ Effect and Interactions
   concerned).
 
   Accepting the ``@(..)`` syntax does *not* entail accepting this new, separate
-  ``(..)`` syntax, though it is good to know that the idea is forward compatible
-  with.
+  ``(..)`` syntax, though it is good to know that the idea is forward compatible.
 
   A ``@(..)`` argument counts as a type argument when asking whether ``-XScopedForAlls``
   affects a function equation.

--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -501,6 +501,12 @@ Effect and Interactions
   lambda-expressions, or anywhere other than a function binding with a type
   signature. This is because doing so would require propagating type
   information into scoping, which is problematic.
+
+  Some have argued on GitHub that it may be best to hold off the ``@(..)`` until
+  we gain more experience here: adding new features is easier than removing them.
+  While I agree that this could be done, the ``@(..)`` construct makes for a very
+  easy migration from today's ``-XScopedTypeVariables`` and is thus tempting to
+  be around from the start. I don't feel strongly.
   
 Costs and Drawbacks
 -------------------

--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -394,7 +394,8 @@ Effect and Interactions
 
 * The optional extra ``@(..)`` notation seems like a convenient middle ground,
   allowing for an easy transition from the old-style ``-XScopedTypeVariables``
-  to the newer ``-XTypeAbstractions``. It brings inferred variables into
+  to the newer ``-XTypeAbstractions``. It brings the *inferred* variables (from `#99`_)
+  into
   scope, quite conveniently. This new notation also allows type variables to
   be brought into scope without the ``forall`` keyword in the type, in case
   the user does not want to trigger ``forall``\ -or-nothing behavior.


### PR DESCRIPTION
Recent discussion (on only [tangentially related features](https://gitlab.haskell.org/ghc/ghc/issues/16734#note_203412)) has brought to light that the accepted proposal for binding type variables does not fly. I have amended the proposal to fix the problem. Basically, we cannot have both `\ @a -> ...` and the scoping behavior of `forall`. This new version introduces a new extension `-XTypeAbstractions` that will control the new syntax, as well as disable the feature of `-XScopedTypeVariables` that brings `forall`d variables into scope.

[Original, accepted proposal](https://github.com/ghc-proposals/ghc-proposals/blob/79f48248ae31b1a490deb1b019c206efa0be89da/proposals/0155-type-lambda.rst)
[Discussion on original proposal](https://github.com/ghc-proposals/ghc-proposals/pull/155)
[Rendered new proposal](https://github.com/goldfirere/ghc-proposals/blob/type-abstractions/proposals/0050-type-lambda.rst)

<!-- probot = {"1313345":{"who":"goldfirere","what":"submit if conversation has died down.","when":"2021-04-27T09:00:00.000Z"}} -->