### PR TITLE
Compile with threaded RTS by default

### DIFF
--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -19,18 +19,24 @@ Parallel hardware is here. The overwhelming majority of GHC users probably has a
 
 * Blocking FFI calls do not yield to other threads. Common use cases:
 
-  * ``System.Process.waitForProcess`` blocks other threads.
+  * ``System.Process.waitForProcess`` blocks other threads. 
+  
+  This becomes especially hard to debug when used transitevly trough some library (e.g. for `conduit-extra <https://github.com/nh2/sourceProcessWithStreams-nonthreaded-problem>`_).
 
 * Foreign export and foreign import wrapper cannot be called by other threads.
 
 * The IO Manager only exists with ``-threaded``, which means that:
 
-  * Control.Concurrent.STM.registerDelay aborts compilation without ``-threaded``.
+  * ``Control.Concurrent.STM.registerDelay`` aborts compilation without ``-threaded``.
   * Other uses of the event manager, such as ``getSystemEventManager`` fail.
   * ``System.Timeout`` falls back to an inefficient implementation.
   * Parallelism (``+RTS -N`) doesn't work.
-    
-* Not a problem per se, but a matter of consistency: GHCi is built with ``-threaded`` by default, so using the same for binaries by default seems more consistent.
+
+Here is a couple of more points, which cannot be classified as problems per se but still suggest going for the switch:
+
+* GHCi is built with ``-threaded`` by default, so using the same for binaries by default seems more consistent.
+
+* The new I/O manager for Windows (`!1224 <https://gitlab.haskell.org/ghc/ghc/merge_requests/1224>`_) explicitly states that it is meant to be used with the threaded RTS.
 
 The proposal suggests avoiding these subtle problems by defaulting on the threaded RTS, and provide a way to fallback for users in need of single-threaded RTS mode for certain reasons (determinism, debugging, limited hardware, etc.). The latter can be done by the means of the new ``-single-threaded`` flag.
 
@@ -44,9 +50,9 @@ The GHC compiler should start in ``-threaded`` mode by default. To fallback to t
 Effect and Interactions
 -----------------------
 
-The users of GHC will get their programs compiled with the threaded RTS by default. This follows principle of the least surprise: many programs implicitly depending on tools such as `forkIO` can deadlock or crush with no good explanation with the single-threaded RTS. As surprising as it may sound, the threaded RTS comes closer to the principle of the least surprise than the single-threaded RTS.
+The users of GHC will get their programs compiled with the threaded RTS by default. As unexpected as it may sound, the threaded RTS comes closer to the principle of the least surprise than the single-threaded RTS: many programs implicitly depending on tools such as ``forkIO`` can deadlock or crush with no good explanation with the single-threaded RTS. 
 
-One of the main concerns with regards to the threaded RTS is parallel GC, which, anecdotally, almost certainly brings performance losses when not tuned carefully (cf., e.g. `#9221 <https://gitlab.haskell.org/ghc/ghc/issues/9221>`_). It is important to understand that parallel GC **is not implied** by ``-threaded``. The threaded mode still starts the program with one capability by default (unless ``-N`` is explicitly provided by the user), and GC runs sequential.
+One of the main concerns with regards to the threaded RTS is parallel GC, which, anecdotally, almost certainly brings performance losses when not tuned carefully (cf., e.g. `#9221 <https://gitlab.haskell.org/ghc/ghc/issues/9221>`_). It is important to understand that parallel GC **is not implied** by ``-threaded``. The threaded mode still starts the program with one capability by default (unless ``-N`` is *explicitly* provided by the user), and GC runs sequential.
 
 Those who passed ``-threaded`` before will get a new warning, which might be painful (e.g. in the ``-Werror`` setting).
 
@@ -56,7 +62,7 @@ Costs and Drawbacks
 
 The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain cases it may degrade, i.e. programs with no concurrent IO or programs running on single-threaded architectures might observe performance degradation upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via ``-single-threaded``) in the release notes. Changes in performance shouldn't be significant on a typical architecture given that parallel GC is not implied by ``-threaded``.
 
-Implementation has a very low cost and mostly concern with figuring out necessary adaptations in the GHC test suite.
+Implementation has a very low cost and mostly concerns with figuring out necessary adaptations in the GHC test suite.
 
 
 Alternatives
@@ -64,11 +70,11 @@ Alternatives
 
 One alternative is status quo: default to the non-threaded RTS. This is a plausible option but feels outdated as of now.
 
-Another alternative suggested by Cris Done:
+Another alternative suggested by Chris Done:
 
     GHC could determine at the Core/STG phase whether in the call graph from main, directly or transitively, there was a reference to ``fork#`` and other primops related to threading, and if neither ``-threaded`` nor ``-single-threaded`` was specified, it could warn "Your program may use multi-threaded code, please specify a mode by either: ``-threaded`` or ``-single-threaded``".
 
-This, in fact, does not exclude the option to switch the deafult.
+This, in fact, is orthogonal to switching the deafult, as well as, requiring sugnificant implementation effort, allegedly.
 
 There is also a minor concern about the fallback flag name. Possible options that have been suggested so far are ``-single-threaded`` and ``-non-threaded``.
 

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -1,0 +1,78 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Make RTS threaded by default
+==============
+
+.. proposal-number:: <blank>
+.. trac-ticket:: 16126
+.. implemented:: <blank>
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Today, in order to use the threaded variant of the runtime, one have to pass the `-threaded` flag. The proposal suggests making `-threaded` the default: in order to get the threaded RTS one would not have to do anything, while to fallback to the current, single-threaded mode, one would use the new ``-single-threaded`` flag.
+
+
+Motivation
+------------
+Parallel hardware is here. It is hard to imagine a setting without an access to multiple cores. Defaulting to single-threaded RTS seems to be a legacy these days, and the one we should cleanup at some point. The proposal suggest exactly this. We should default on the common case, which is parallel hardware today, and provide a way to fallback for users with special needs. The latter can be done by the means of the new ``-single-threaded`` flag.
+
+
+
+Proposed Change Specification
+-----------------------------
+
+***** below is still the template *****
+
+Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
+
+* grammar and semantics of any new syntactic constructs
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
+
+Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+
+
+Effect and Interactions
+-----------------------
+Detail how the proposed change addresses the original problem raised in the motivation.
+
+Discuss possibly contentious interactions with existing language or compiler features. 
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -1,24 +1,9 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
-
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
-Make RTS threaded by default
+Compile with the threaded RTS by default
 ==============
 
 .. proposal-number:: <blank>
 .. trac-ticket:: 16126
-.. implemented:: <blank>
+.. implemented::
 .. highlight:: haskell
 .. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
             **After creating the pull request, edit this file again, update the
@@ -31,48 +16,37 @@ Today, in order to use the threaded variant of the runtime, one have to pass the
 
 Motivation
 ------------
-Parallel hardware is here. It is hard to imagine a setting without an access to multiple cores. Defaulting to single-threaded RTS seems to be a legacy these days, and the one we should cleanup at some point. The proposal suggest exactly this. We should default on the common case, which is parallel hardware today, and provide a way to fallback for users with special needs. The latter can be done by the means of the new ``-single-threaded`` flag.
-
+Parallel hardware is here. The overwhelming majority of GHC users probably has an access to multiple cores. In this setting, defaulting to single-threaded RTS seems to be a legacy, and the one we should cleanup at some point anyway. The proposal suggest exactly this. We should default on the common case, which is parallel hardware today, and provide a way to fallback for users of single-core architectures. The latter can be done by the means of the new ``-single-threaded`` flag.
 
 
 Proposed Change Specification
 -----------------------------
 
-***** below is still the template *****
-
-Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
-
-* grammar and semantics of any new syntactic constructs
-* the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
-
-Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+The GHC compiler should start in `-threaded` mode by default. To fallback to the non-threaded mode, one would have to pass `-single-threaded` flag to the compiler. Otherwise, if a user pass the `-threaded` flag, they should get a warning that this flag has no effect anymore.
 
 
 Effect and Interactions
 -----------------------
-Detail how the proposed change addresses the original problem raised in the motivation.
+The users of GHC will get their programs compiled with the threaded RTS by default. This is felt to be the reasonable default these days. 
 
-Discuss possibly contentious interactions with existing language or compiler features. 
-
+Those who passed `-threaded` before will get a new warning, which might be painful (e.g. in the `-Werror` setting).
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain casses it may degrade. In the lack of objective data at hand, we can only speculate that: 1) typical architecture of a GHC user has multiple cores; 2) switch to `-threaded` will *most likely* improve performance in such a setting. In contrast, the users of single-threaded acrchitectures might observe certain degradations upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via `-single-threaded` in the release notes).
 
+Implementation has very low cost and mostly concern with figuring out neccessary adaptations in the GHC test suite.
 
 Alternatives
 ------------
-List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+The alternative is status quo: deafult to the non-threaded RTS. This is a plausible options but feels outdated as of now.
 
 
 Unresolved Questions
 --------------------
-Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
-
-Hopefully this section will be empty by the time the proposal is brought to the steering committee.
-
+None
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?
+The implementation is started in _`!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_. The main challenge is to get test suite pass because of certain warnings arising after the switch to the new default.
+

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -14,7 +14,8 @@ Today, in order to use the threaded variant of the runtime, one have to pass the
 
 Motivation
 ------------
-Parallel hardware is here. The overwhelming majority of GHC users probably has an access to multiple cores. In this setting, defaulting to single-threaded RTS seems to be a legacy, and the one we should cleanup at some point anyway. The proposal suggest exactly this. We should default on the common case, which is parallel hardware today, and provide a way to fallback for users of single-core architectures. The latter can be done by the means of the new ``-single-threaded`` flag.
+
+Parallel hardware is here. The overwhelming majority of GHC users probably has access to multiple cores. GHC's `base` library contains essential features to utilize those resources. In this setting, **defaulting** to the single-threaded RTS seems to be a legacy, which is not only over-pessimistic about the program environment, but also leads to subtle crushes and deadlocks when those `base` features are in use. The proposal suggests addressing this by defaulting on the common case, which is parallel hardware today, and provide a way to fallback for users in need of single-threaded RTS mode for certain reasons (determinism, debugging, limited hardware, etc.). The latter can be done by the means of the new ``-single-threaded`` flag.
 
 
 Proposed Change Specification
@@ -25,20 +26,25 @@ The GHC compiler should start in ``-threaded`` mode by default. To fallback to t
 
 Effect and Interactions
 -----------------------
-The users of GHC will get their programs compiled with the threaded RTS by default. This is felt to be the reasonable default these days. 
+
+The users of GHC will get their programs compiled with the threaded RTS by default. This follows principle of the least surprise: many programs implicitly depending on tools such as `forkIO` can deadlock or crush with no good explanation with the single-threaded RTS. As surprising as it may sound, the threaded RTS comes closer to the principle of the least surprise than the single-threaded RTS.
+
+One of the main concerns with regards to the threaded RTS is parallel GC, which, anecdotally, almost certainly brings performance losses when not tuned carefully. It is important to understand that parallel GC **is not implied** by ``-threaded``. The threaded mode still starts the program with one capability by default (unless ``-N`` is explicitly provided by the user), and GC runs sequential.
 
 Those who passed ``-threaded`` before will get a new warning, which might be painful (e.g. in the ``-Werror`` setting).
 
 
 Costs and Drawbacks
 -------------------
-The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain casses it may degrade. In the lack of objective data at hand, we can only speculate that: 1) typical architecture of a GHC user has multiple cores; 2) switch to ``-threaded`` will *most likely* improve performance in such a setting. In contrast, the users of single-threaded acrchitectures might observe certain degradations upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via ``-single-threaded``) in the release notes.
 
-Implementation has a very low cost and mostly concern with figuring out neccessary adaptations in the GHC test suite.
+The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain cases it may degrade, i.e. programs with no concurrent IO or programs running on single-threaded architectures might observe performance degradation upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via ``-single-threaded``) in the release notes. Changes in performance shouldn't be significant on a typical architecture given that parallel GC is not implied by ``-threaded``.
+
+Implementation has a very low cost and mostly concern with figuring out necessary adaptations in the GHC test suite.
 
 
 Alternatives
 ------------
+
 The alternative is status quo: default to the non-threaded RTS. This is a plausible option but feels outdated as of now.
 
 There is also a minor concern about the fallback flag name. Possible options that have been suggested so far are ``-single-threaded`` and ``-non-threaded``.
@@ -46,10 +52,11 @@ There is also a minor concern about the fallback flag name. Possible options tha
 
 Unresolved Questions
 --------------------
-None
+None.
 
 
 Implementation Plan
 -------------------
-The implementation is started in `!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_. The main challenge is to get test suite pass because of certain warnings arising after the switch to the new default.
+
+The implementation is started in `!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_.
 

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -43,6 +43,8 @@ Alternatives
 ------------
 The alternative is status quo: deafult to the non-threaded RTS. This is a plausible option but feels outdated as of now.
 
+There is also a minor concern about the fallback flag name. Possible options taht have been suggested so far are ``-single-threaded`` and ``-non-threaded``
+
 
 Unresolved Questions
 --------------------

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -1,4 +1,4 @@
-Compile with the threaded RTS by default
+Compile with threaded RTS by default
 ==============
 
 .. proposal-number:: <blank>

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -43,7 +43,7 @@ Alternatives
 ------------
 The alternative is status quo: deafult to the non-threaded RTS. This is a plausible option but feels outdated as of now.
 
-There is also a minor concern about the fallback flag name. Possible options taht have been suggested so far are ``-single-threaded`` and ``-non-threaded``
+There is also a minor concern about the fallback flag name. Possible options taht have been suggested so far are ``-single-threaded`` and ``-non-threaded``.
 
 
 Unresolved Questions

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -5,9 +5,7 @@ Compile with threaded RTS by default
 .. trac-ticket:: 16126
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/240>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -34,7 +34,7 @@ Effect and Interactions
 
 The users of GHC will get their programs compiled with the threaded RTS by default. This follows principle of the least surprise: many programs implicitly depending on tools such as `forkIO` can deadlock or crush with no good explanation with the single-threaded RTS. As surprising as it may sound, the threaded RTS comes closer to the principle of the least surprise than the single-threaded RTS.
 
-One of the main concerns with regards to the threaded RTS is parallel GC, which, anecdotally, almost certainly brings performance losses when not tuned carefully. It is important to understand that parallel GC **is not implied** by ``-threaded``. The threaded mode still starts the program with one capability by default (unless ``-N`` is explicitly provided by the user), and GC runs sequential.
+One of the main concerns with regards to the threaded RTS is parallel GC, which, anecdotally, almost certainly brings performance losses when not tuned carefully (cf., e.g. `#9221 <https://gitlab.haskell.org/ghc/ghc/issues/9221>`_). It is important to understand that parallel GC **is not implied** by ``-threaded``. The threaded mode still starts the program with one capability by default (unless ``-N`` is explicitly provided by the user), and GC runs sequential.
 
 Those who passed ``-threaded`` before will get a new warning, which might be painful (e.g. in the ``-Werror`` setting).
 
@@ -50,7 +50,13 @@ Implementation has a very low cost and mostly concern with figuring out necessar
 Alternatives
 ------------
 
-The alternative is status quo: default to the non-threaded RTS. This is a plausible option but feels outdated as of now.
+One alternative is status quo: default to the non-threaded RTS. This is a plausible option but feels outdated as of now.
+
+Another alternative suggested by Cris Done:
+
+> GHC could determine at the Core/STG phase whether in the call graph from main, directly or transitively, there was a reference to ``fork#`` and other primops related to threading, and if neither ``-threaded`` nor ``-single-threaded`` was specified, it could warn "Your program may use multi-threaded code, please specify a mode by either: ``-threaded`` or ``-single-threaded``".
+
+This, in fact, does not exclude the option to switch the deafult.
 
 There is also a minor concern about the fallback flag name. Possible options that have been suggested so far are ``-single-threaded`` and ``-non-threaded``.
 
@@ -64,4 +70,3 @@ Implementation Plan
 -------------------
 
 The implementation is started in `!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_.
-

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -11,7 +11,7 @@ Compile with the threaded RTS by default
 .. sectnum::
 .. contents::
 
-Today, in order to use the threaded variant of the runtime, one have to pass the `-threaded` flag. The proposal suggests making `-threaded` the default: in order to get the threaded RTS one would not have to do anything, while to fallback to the current, single-threaded mode, one would use the new ``-single-threaded`` flag.
+Today, in order to use the threaded variant of the runtime, one have to pass the ``-threaded`` flag. The proposal suggests making ``-threaded`` the default: in order to get the threaded RTS one would not have to do anything, while to fallback to the current, single-threaded mode, one would use the new ``-single-threaded`` flag.
 
 
 Motivation
@@ -22,31 +22,34 @@ Parallel hardware is here. The overwhelming majority of GHC users probably has a
 Proposed Change Specification
 -----------------------------
 
-The GHC compiler should start in `-threaded` mode by default. To fallback to the non-threaded mode, one would have to pass `-single-threaded` flag to the compiler. Otherwise, if a user pass the `-threaded` flag, they should get a warning that this flag has no effect anymore.
+The GHC compiler should start in ``-threaded`` mode by default. To fallback to the non-threaded mode, one would have to pass ``-single-threaded`` flag to the compiler. Otherwise, if a user pass the ``-threaded`` flag, they should get a warning that this flag has no effect anymore.
 
 
 Effect and Interactions
 -----------------------
 The users of GHC will get their programs compiled with the threaded RTS by default. This is felt to be the reasonable default these days. 
 
-Those who passed `-threaded` before will get a new warning, which might be painful (e.g. in the `-Werror` setting).
+Those who passed ``-threaded`` before will get a new warning, which might be painful (e.g. in the ``-Werror`` setting).
+
 
 Costs and Drawbacks
 -------------------
-The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain casses it may degrade. In the lack of objective data at hand, we can only speculate that: 1) typical architecture of a GHC user has multiple cores; 2) switch to `-threaded` will *most likely* improve performance in such a setting. In contrast, the users of single-threaded acrchitectures might observe certain degradations upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via `-single-threaded` in the release notes).
+The main concern of this change is sudden changes to performance of compiled programs. In some cases it will improve, but in certain casses it may degrade. In the lack of objective data at hand, we can only speculate that: 1) typical architecture of a GHC user has multiple cores; 2) switch to ``-threaded`` will *most likely* improve performance in such a setting. In contrast, the users of single-threaded acrchitectures might observe certain degradations upon updating to a newer GHC, and we should make sure to advertise the option to opt-out (via ``-single-threaded``) in the release notes.
 
-Implementation has very low cost and mostly concern with figuring out neccessary adaptations in the GHC test suite.
+Implementation has a very low cost and mostly concern with figuring out neccessary adaptations in the GHC test suite.
+
 
 Alternatives
 ------------
-The alternative is status quo: deafult to the non-threaded RTS. This is a plausible options but feels outdated as of now.
+The alternative is status quo: deafult to the non-threaded RTS. This is a plausible option but feels outdated as of now.
 
 
 Unresolved Questions
 --------------------
 None
 
+
 Implementation Plan
 -------------------
-The implementation is started in _`!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_. The main challenge is to get test suite pass because of certain warnings arising after the switch to the new default.
+The implementation is started in `!538 <https://gitlab.haskell.org/ghc/ghc/merge_requests/538>`_. The main challenge is to get test suite pass because of certain warnings arising after the switch to the new default.
 

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -54,7 +54,7 @@ One alternative is status quo: default to the non-threaded RTS. This is a plausi
 
 Another alternative suggested by Cris Done:
 
-> GHC could determine at the Core/STG phase whether in the call graph from main, directly or transitively, there was a reference to ``fork#`` and other primops related to threading, and if neither ``-threaded`` nor ``-single-threaded`` was specified, it could warn "Your program may use multi-threaded code, please specify a mode by either: ``-threaded`` or ``-single-threaded``".
+    GHC could determine at the Core/STG phase whether in the call graph from main, directly or transitively, there was a reference to ``fork#`` and other primops related to threading, and if neither ``-threaded`` nor ``-single-threaded`` was specified, it could warn "Your program may use multi-threaded code, please specify a mode by either: ``-threaded`` or ``-single-threaded``".
 
 This, in fact, does not exclude the option to switch the deafult.
 

--- a/proposals/0000-threaded-by-default.rst
+++ b/proposals/0000-threaded-by-default.rst
@@ -15,7 +15,12 @@ Today, in order to use the threaded variant of the runtime, one have to pass the
 Motivation
 ------------
 
-Parallel hardware is here. The overwhelming majority of GHC users probably has access to multiple cores. GHC's `base` library contains essential features to utilize those resources. In this setting, **defaulting** to the single-threaded RTS seems to be a legacy, which is not only over-pessimistic about the program environment, but also leads to subtle crushes and deadlocks when those `base` features are in use. The proposal suggests addressing this by defaulting on the common case, which is parallel hardware today, and provide a way to fallback for users in need of single-threaded RTS mode for certain reasons (determinism, debugging, limited hardware, etc.). The latter can be done by the means of the new ``-single-threaded`` flag.
+Parallel hardware is here. The overwhelming majority of GHC users probably has access to multiple cores. Parts of GHC's ``base`` library, as well as FFI implementation, utilize those resources. In this setting, **defaulting** to the single-threaded RTS seems to be a legacy, which is not only over-pessimistic about the program environment, but also leads to subtle crushes and deadlocks when those GHC features are in use. E.g. 
+
+* using ``GHC.Conc.registerDelay`` aborts compilation without ``-threaded``,
+* calling a foreign function that is “safe” and blocks makes the nonthreaded RTS blocking altogether.
+
+The proposal suggests avoiding these subtle problems by defaulting on the threaded RTS, and provide a way to fallback for users in need of single-threaded RTS mode for certain reasons (determinism, debugging, limited hardware, etc.). The latter can be done by the means of the new ``-single-threaded`` flag.
 
 
 Proposed Change Specification


### PR DESCRIPTION
Compile with `-threaded` by default. For those in need of the non-threaded RTS, provide the new `-single-threaded` flag.

[Rendered](https://github.com/ulysses4ever/ghc-proposals/blob/master/proposals/0000-threaded-by-default.rst).

[Reddit thread](https://www.reddit.com/r/haskell/comments/byvq5w/ghc_proposal_compile_with_threaded_rts_by_default/).