### PR TITLE
Proposal 13 (UnliftedNewtypes) has been implemented

### DIFF
--- a/proposals/0013-unlifted-newtypes.rst
+++ b/proposals/0013-unlifted-newtypes.rst
@@ -3,7 +3,7 @@ Unlifted Newtypes
 
 .. proposal-number:: 13
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15219
-.. implemented::
+.. implemented:: 8.10
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/98>`_.
 .. sectnum::


### PR DESCRIPTION
It will debut in GHC 8.10. See GHC commit [effdd948](https://gitlab.haskell.org/ghc/ghc/commit/effdd948056923f3bc03688c24d7e0339d6272f5), which just landed in `master`.