### PR TITLE
Stage Hygiene for Template Haskell

### DIFF
--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -23,7 +23,7 @@ Motivation
 
 Template Haskell currently doesn't work well with cross compilation.
 
-The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side affects to be run on the compiler's platform.
+The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side effects to be run on the compiler's platform.
 Also, while same-OS cross can sometimes be fairly lightweight
 —e.g. by having QEMU translate syscalls so the native kernel can be used—
 differnet-OS requires harder to provision virtual machines or real devices.

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -623,7 +623,7 @@ Rigid vars
 ~~~~~~~~~~
 
 Why bother with these abstract platforms?
-Why not have something like separate Linux vs Windows ``import``s and ``build-depends``, or separate native vs cross ones?
+Why not have something like separate Linux vs Windows ``import`` and ``build-depends``, or separate native vs cross ones?
 Many systems in fact work this way; I changed Nixpkgs and `Meson`_ to *not* work this way as best as I could.
 The simple answer is there's a combinatorial explosion.
 There's many arches * many OSes * many libcs * many linking strategies that may sadly be observable, etc.

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -1,4 +1,4 @@
-Stage Hygiene in Template Haskell
+Stage Hygiene for Template Haskell
 ==============
 
 .. proposal-number:: Leave blank. This will be filled in when the proposal is

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -260,7 +260,9 @@ Cabal
    N.B ``build-tool-depends`` can be thought of as a stage -1 executable dependencies list.
    "Those executables are executed at build time, like top-evel splices, and so need to be built for the build platform."
    `<https://github.com/haskell/cabal/issues/5411>`_ asks for a ``run-tool-depends`` which would be nothing but a stage 0 executable depends.
-   ``setup-depends`` can also be thought of as a stage -1 executable dependencies list.
+   ``setup-depends`` can also be thought of as a stage -1 dependencies list.
+   In both cases though, the metaphor is not perfect because separate executable are only loosely coupled.
+   E.g libraries for Template-Haskell must be built with the same compiler / same ABI, but executable deps (including `./Setup` itself), need not be.
 
 #. Connect today's "qualified goals" to stages.
    [TODO exact formalism, is it in scope?]

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -9,9 +9,7 @@ Stage Hygiene for Template Haskell
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/243`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -543,6 +543,16 @@ I think it good to enforce the normal form that the "main" stage is stage 0.
 As to the specific example, I would rather packages leverage public Cabal sub-libraries for Template Haskell anyways;
 I think that's a cleaner way to package code.
 
+It would be nice to go straight implement typed TH by quoting types.
+One would do something like::
+  [|| e... :: t... ||] :: Q (TExp [t| t... |])
+This correctly gets ``t...`` from the right for the argument to ``TExp``.
+The problem though is the parameter is type syntax rather than a type; we've thrown away all the semantics.
+We can explicitly normalize, however::
+  [|| e... :: t... ||] :: Q (TExp (Normalize [t| t... |])
+``Normalize`` could be some sort of magic type family that just tells GHC to do its thing, rather than a implementation of Haskell.
+It's good to know there are options going forward, but I think there is just too much uncertainty here to commit to anything at this time.
+
 Unresolved Questions
 --------------------
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -26,7 +26,7 @@ Haskell has an excellent culture of code reuse, but that means that arbitrary so
 That lack of being able to write idiomatic Haskell code with popular libraries for all platform is as big of a loss as not being able to Template Haskell itself.
 The risk of library fragmentation between between those writing code for weird platforms and those not is also bad for everyone.
 
-The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side effects to be run on the compiler's platform.
+The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side effects to be run on the platform doing the compiling (build platform).
 Also, while same-OS cross can sometimes be fairly lightweight
 — e.g. by having QEMU translate syscalls so the native kernel can be used —
 different-OS requires harder to provision virtual machines or real devices.
@@ -75,7 +75,7 @@ In the near future there would be
 ::
   AppE <$> [|| ... :: foreach (x :: Int) -> F x ||] <*> [|| 2^36 :: Int ||] :: Q (TExp (F ???))
 How do we type the whole expression, or ``AppE`` in particular?
-And say the compiling platform has 32-bit `Int`s?
+And say the platform the compiler runs on (build platform) has 32-bit `Int`s?
 The dependent function will have different result types due to overflow, which ruins the guarantees of typed Template Haskell.
 Even today we have similar problems with CPP'd type families:
 ::
@@ -285,7 +285,7 @@ Speeding up builds
   By virtue of the explicit stage attached to the import, the definitions do not unify even though the underlying build is the same.
   This can be compared to repeated abstract interfaces in backpack being instantiated with the same concrete module.
 
-  In the cross case, there is no getting around needing separate native and foreign builds for different stages, but there are still performance improvements.
+  In the cross case, there is no getting around needing separate builds for the different platform used in each stage, but there are still performance improvements.
   As said in the motivation, we only need what is needed when it is needed, versus everything twice with splice dumping and loading.
   This reduces the size and improves the parallelism of the build plan.
   More subtly, and perhaps more importantly, are benefits with rebuilds during development.

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -126,14 +126,14 @@ GHC
 
 2. Redefine quoting and splicing as acting on adjacent stages. Specifically, quoting quotes code from the next stage:
    ::
-     G(n) ⊢ syntax
+     G(n + 1) ⊢ syntax
      -----------------------
-     G(n + 1) ⊢ [| syntax |]
+     G(n) ⊢ [| syntax |]
    and splicing splices code from the previous stage:
    ::
-     G(n) ⊢ syntax
+     G(n - 1) ⊢ syntax
      -----------------------
-     G(n - 1) ⊢ $(syntax)
+     G(n) ⊢ $(syntax)
 
    The existing side conditions, which restricting nested quotes and splices (i.e. stages outside of -1, 0, and 1) remain in place, but are ripe for removal in #204.
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -435,7 +435,7 @@ Forward references across splices
    Hopefully a future proposal will tackle this.
 
 Faster and finer-grained builds
-  Because any import could be used by TH, GHC today must be extra cautious parallelizing complation. [#thanks-th-incr]_
+  Because any import could be used by TH, GHC today must be extra cautious parallelizing complation. [#thanks-mboes]_
   Firstly, a module must be built after object code or byte code for all imports is produced, lest that import be used in a splice.
   But we if we know exactly which imports could be used in splices, we'd need only wait for the interface of that module to be produced.
   Likewise, we wouldn't need to type check again if just the implementations of imports changed but the interface didn't.
@@ -515,6 +515,13 @@ Template Haskell in GHC
   In particular this means given a dependency edge where the needed and needing components are in the same package regardless of their relative stage indices,
   the same version of the package must be used for both.
 
+Static and dynamic linking
+  It's hard to build large swaths of the ecosystem with just static libraries. [#thanks-mboes]_
+  This is because GHCi "prefers" loading dynamic libraries.
+  The easiest thing to do is build both ways and then throw away the shared libraries.
+  The better thing to do is think of shared GHC -> static outputs as cross compilation.
+  Then only stage < 0 code for splices needs be built as shared libraries (or bytecode).
+  Plus, that builds aren't installed along side the stage 0 code, so there is no extra step to manually shave off the shared libraries.
 
 Costs and Drawbacks
 -------------------
@@ -662,7 +669,7 @@ In this case what one finds is there is very little use for a ``build me ~ host 
 It's just rather arcane.
 The crutch that bedeviled most code by stealth is now no longer needed!
 
-.. [#thanks-th-incr] Thanks @mboes for pointing this out.]
+.. [#thanks-mboes] Thanks @mboes for pointing these out.]
 
 .. _`"naive" Core interpreter`: https://github.com/ghc-proposals/ghc-proposals/issues/162
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -30,7 +30,7 @@ The risk of library fragmentation between between those writing code for weird p
 
 The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side effects to be run on the compiler's platform.
 Also, while same-OS cross can sometimes be fairly lightweight
-—e.g. by having QEMU translate syscalls so the native kernel can be used—
+— e.g. by having QEMU translate syscalls so the native kernel can be used —
 differnet-OS requires harder to provision virtual machines or real devices.
 
 Another alternative is dumping and loading splices, where one builds natively, dumping splices, and the builds cross with those dumped splices.
@@ -119,7 +119,8 @@ Since the splices all can be desugared away without the evaluation of user-writt
 
 Macro systems have often been judged by their (lack of) hygiene.
 Macros that delay all name resolution post splicing are deemed unhygienic.
-It has been argued in [InferringScope] that hygiene just is alpha-equivalence from a better vantage point, a point which was obscured by the early Scheme macro systems (and TH's) use of renaming and gensym in lieu of a more principled formalism.
+It has been argued in [InferringScope]_ that hygiene just is alpha-equivalence from a better vantage point,
+a point which was obscured by the early Scheme macro systems (and TH's) use of renaming and gensym in lieu of a more principled formalism.
 It is my hope that a lack of stage separation comes to be viewed as unhygienic in the same way.
 It should be immaterial whether build time "base" has any identifiers in common with the run-time "base", and nothing should be improperly captured or dangling either way.
 
@@ -199,7 +200,7 @@ Cabal
 
 #. Extend the ``build-depends`` syntax with a stage integer offset parameter.
    N.B ``build-tool-depends`` can be thought of as a stage -1 executable dependencies list.
-   `https://github.com/haskell/cabal/issues/5411`_ asks for a ``run-tool-depends`` which would be nothing but a stage 0 executable depends.
+   `<https://github.com/haskell/cabal/issues/5411>`_ asks for a ``run-tool-depends`` which would be nothing but a stage 0 executable depends.
    ``setup-depends`` can also be thought of as a stage -1 executable dependencies list.
 
 #. Likewise extend ``other-modules`` with a stage integer offset parameter, to support intra-package ``$import``.
@@ -303,13 +304,13 @@ Here is a rough plan.
 
 #. Make GHC multi-target. I am almost done with this.
 
-#. Land `https://gitlab.haskell.org/ghc/ghc/merge_requests/935`_, refactoring GHC to allow there being more than one "home package" per session.
-   This PR also may help with the 2019 GSOC around `https://gitlab.haskell.org/ghc/ghc/wikis/Multi-Session-GHC-API`.
+#. Land `<https://gitlab.haskell.org/ghc/ghc/merge_requests/935>`_, refactoring GHC to allow there being more than one "home package" per session.
+   This PR also may help with the 2019 GSOC around `<https://gitlab.haskell.org/ghc/ghc/wikis/Multi-Session-GHC-API>`_.
 
 #. Parameterize dependency data types (for module and package dependencies) to track dependencies per stage.
 
 #. Refactor the implementation of Template Haskell to use the per-stage data-types.
 
-.. "naive" core interpreter: #162
+.. _`"naive" core interpreter`: https://github.com/ghc-proposals/ghc-proposals/issues/162
 
 .. [InferringScope] https://cs.brown.edu/~sk/Publications/Papers/Published/pkw-inf-scope-syn-sugar/paper.pdf

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -143,6 +143,7 @@ GHC
    This means import a module in stage *n* instead of stage 0 as per normal.
    ::
      $let <integer-literal> <<existing syntax>> = <<existing syntax>>
+   In both case the ``$`` must not be followed by whitespace, both to avoid conflicts with other syntax and to be consistent with splices.
    The means bind identifiers in stage *n* instead of stage 0 as per normal.
    Module exports however are restricted to stage 0.
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -195,7 +195,7 @@ Hypothetical ``ios-th`` package:
 ::
   module Ios.Macros where
 
-  #ifdef ios_TARGET_OS
+  #ifndef ios_TARGET_OS
   # error Module shouldn't be built. Fix Cabal file!
   #endif
 
@@ -208,7 +208,7 @@ end user code:
 ::
   module MyApp.Ios where
 
-  #ifdef ios_HOST_OS
+  #ifndef ios_HOST_OS
   # error Module shouldn't be built. Fix Cabal file!
   #endif
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -1,18 +1,3 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
-
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
 Stage Hygiene in Template Haskell
 ==============
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -222,6 +222,8 @@ Effect and Interactions
 Here is an example of many the features used together, rewriting the code from the motivation.
 Hypothetical ``ios-th`` package:
 ::
+  {-# LANGUAGE TemplateHaskell #-}
+  {-# LANGUAGE NoTemplateStagePersistence #-}
   module Ios.Macros where
 
   #ifndef ios_TARGET_OS
@@ -235,6 +237,8 @@ Hypothetical ``ios-th`` package:
   iosBoilerplateHelper name = ... [| ... :: Foo |] ...
 end user code:
 ::
+  {-# LANGUAGE TemplateHaskell #-}
+  {-# LANGUAGE NoTemplateStagePersistence #-}
   module MyApp.Ios where
 
   #ifndef ios_HOST_OS

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -126,14 +126,14 @@ GHC
 
 2. Redefine quoting and splicing as acting on adjacent stages. Specifically, quoting quotes code from the next stage:
    ::
-     G(n + 1) ⊢ syntax
+     G ⊢(n + 1) syntax
      -----------------------
-     G(n) ⊢ [| syntax |]
+     G ⊢(n) [| syntax |]
    and splicing splices code from the previous stage:
    ::
-     G(n - 1) ⊢ syntax
+     G ⊢(n - 1) syntax
      -----------------------
-     G(n) ⊢ $(syntax)
+     G ⊢(n) $(syntax)
 
    The existing side conditions, which restricting nested quotes and splices (i.e. stages outside of -1, 0, and 1) remain in place, but are ripe for removal in #204.
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -169,20 +169,11 @@ Remember, this is still strictly better than today when the choice is cross comp
 Untyped TH is liberated from the fragmentation, and hopefully the others follow.
 
 As a final side benefit, now that Template Haskell will be defined and implemented in terms of stages, we can relax ``-XTemplateHaskellQuotes``.
-For example, the following current prohibited:
-::
-  [| $(x) |]
-But actually imposes no problems.
-This is the same as
-::
-  x
-and likewise
-::
-  [| f $(x) b |]
-and is the same as
-::
-  AppE <$> [| f |] <*> x <*>  [| b |]
-Since the splices all can be desugared away without the evaluation of user-written code, there is no reason to penalize them.
+Splices within quotes are currently prohibited.
+For example, one cannot write ``[| $(x) |]``.
+But actually this imposes no problems.
+``[| $(x) |]`` is the same as plain ``x``, and likewise ``[| f $(x) b |]`` is the same as ``AppE <$> [| f |] <*> x <*>  [| b |]``.
+Since these splices all can be desugared away without the evaluation of user-written code, there is no reason to penalize them.
 
 Macro systems have often been judged by their (lack of) hygiene.
 Macros that delay all name resolution post splicing are deemed unhygienic.

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -15,13 +15,18 @@ Stage Hygiene in Template Haskell
 .. sectnum::
 .. contents::
 
-Here you should write a short abstract motivating and briefly summarizing the proposed change.
-
+Template Haskell currently doesn't work well with cross compilation.
+This is a big nuisance for anyone making phone or browser software.
+To fix this, enforce stronger separation between the stages.
 
 Motivation
 ------------
 
-Template Haskell currently doesn't work well with cross compilation.
+In the olden days, one couldn't use Template Haskell with cross compilation at all.
+This is bad in itself, but also bad from an ecosystem perspective.
+Haskell has an excellent culture of code reuse, but that means that arbitrary software is very likely to depend on Template Haskell.
+That lack of being able to write idiomatic Haskell code with popular libraries for all platform is as big of a loss as not being able to Template Haskell itself.
+The risk of library fragmentation between between those writing code for weird platforms and those not is also bad for everyone.
 
 The external interpreter made it at least possible, relatively automatically, but doesn't work if you explicitly want side effects to be run on the compiler's platform.
 Also, while same-OS cross can sometimes be fairly lightweight
@@ -111,6 +116,12 @@ and is the same as
 ::
   AppE <$> [| f |] <*> x <*>  [| b |]
 Since the splices all can be desugared away without the evaluation of user-written code, there is no reason to penalize them.
+
+Macro systems have often been judged by their (lack of) hygiene.
+Macros that delay all name resolution post splicing are deemed unhygienic.
+It has been argued in [InferringScope] that hygiene just is alpha-equivalence from a better vantage point, a point which was obscured by the early Scheme macro systems (and TH's) use of renaming and gensym in lieu of a more principled formalism.
+It is my hope that a lack of stage separation comes to be viewed as unhygienic in the same way.
+It should be immaterial whether build time "base" has any identifiers in common with the run-time "base", and nothing should be improperly captured or dangling either way.
 
 Proposed Change Specification
 ------------
@@ -284,7 +295,6 @@ Need some way to prevent that outright, or catch those errors early, perhaps by 
 [Thankfully the other direction is fine.
 Libraries can experiment with this extension without forcing an ecosystem split.]
 
-
 Implementation Plan
 -------------------
 
@@ -301,3 +311,5 @@ Here is a rough plan.
 #. Refactor the implementation of Template Haskell to use the per-stage data-types.
 
 .. "naive" core interpreter: #162
+
+.. [InferringScope] https://cs.brown.edu/~sk/Publications/Papers/Published/pkw-inf-scope-syn-sugar/paper.pdf

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -9,7 +9,7 @@ Stage Hygiene for Template Haskell
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/243`_.
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/243>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -149,10 +149,14 @@ GHC
 
    The existing side conditions, which restricting nested quotes and splices (i.e. stages outside of -1, 0, and 1) remain in place, but are ripe for removal in #204.
 
-3. Add new syntax for stage-offset imports:
+3. Add new syntax for stage-offset imports and bindings:
    ::
-     #import <integer-literal> <<existing syntax>>
-   This means import a module in stage *n + offset* instead of stage 0 as per normal.
+     $import <integer-literal> <<existing syntax>>
+   This means import a module in stage *n* instead of stage 0 as per normal.
+   ::
+     $let <integer-literal> <<existing syntax>> = <<existing syntax>>
+   The means bind identifers in stage *n* instead of stage 0 as per normal.
+   Module exports however are restricted to stage 0.
 
 4. Relax ``-XTemplateHaskellQuotes`` to instead allow Template Haskell constructs, but restrict their usage so all syntax is in stages >= 0.
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -1,0 +1,78 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Proposal title
+==============
+
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Here you should write a short abstract motivating and briefly summarizing the proposed change.
+
+
+Motivation
+------------
+Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
+
+* grammar and semantics of any new syntactic constructs
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
+
+Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+
+
+Effect and Interactions
+-----------------------
+Detail how the proposed change addresses the original problem raised in the motivation.
+
+Discuss possibly contentious interactions with existing language or compiler features.
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other ressources and prerequisites are required for implementation?

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -263,11 +263,6 @@ Cabal
    `<https://github.com/haskell/cabal/issues/5411>`_ asks for a ``run-tool-depends`` which would be nothing but a stage 0 executable depends.
    ``setup-depends`` can also be thought of as a stage -1 executable dependencies list.
 
-#. Likewise extend ``other-modules`` with a stage integer offset parameter, to support intra-package ``$import``.
-   Leave ``exposed-modules`` as is, however. Libraries should only expose stage 0 modules, just as modules only expose stage 0 definitions.
-   Restrict the ``other-modules`` offset to be <= 0, as positive stage code is either pointless or would escape via references from quotes causing build system havoc.
-   Unexposed negative stage modules need not be installed at all, as there is no way for stage 0 to reference them (splices eliminate references).
-
 #. Connect today's "qualified goals" to stages.
    [TODO exact formalism, is it in scope?]
    Some properties that must be true in the brave new world:

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -41,13 +41,16 @@ If the splice is within the ``ifdef``, it won't be dumped.
 But if it is outside the ``ifdef``, the native one won't build!
 
 What we need instead is a way to say is different platforms:
- - Splices alone run on the build platform (of the module being built, not GHC).
- - Normal code, as usual, runs on the host platform.
- - quoted code runs on the target platform.
+
+- Splices alone run on the build platform (of the module being built, not GHC).
+- Normal code, as usual, runs on the host platform.
+- quoted code runs on the target platform.
+
 This solves all the above problems:
- - No need to emulate any other platforms, since evaluation only happens within splices.
- - No need to build everything twice.
- - No all-or-nothing CPP problem.
+
+- No need to emulate any other platforms, since evaluation only happens within splices.
+- No need to build everything twice.
+- No all-or-nothing CPP problem.
 
 To do this, we need to cleanly separate the stages induced by quoting and splicing.
 This is not a new idea for programming langauges in general.
@@ -149,10 +152,11 @@ GHC
    Which is implied by ``-XTemplateHaskellQuotes`` (and thus plain ``-XTemplateHaskell``) for backwards compat.
    It allows the current behavior where we blur the distinction between stages.
    In particular, with this enabled:
-    - Stage 0 identifiers bound in another module can be used in stage 1 (quotes) and stage -1 (splices).
-    - Stage 0 identifiers bound anywhere can be used in stage 1, and are automatically.
-    - Typed template haskell is allowed.
-    - The ``Lift`` type class and all its associated definitions are made available.
+
+   - Stage 0 identifiers bound in another module can be used in stage 1 (quotes) and stage -1 (splices).
+   - Stage 0 identifiers bound anywhere can be used in stage 1, and are automatically.
+   - Typed template haskell is allowed.
+   - The ``Lift`` type class and all its associated definitions are made available.
 
    With ``-XNoTemplateStagePersistence``, overriding the default, all of those are *disabled*.
 

--- a/proposals/0000-th-stage-hygiene.rst
+++ b/proposals/0000-th-stage-hygiene.rst
@@ -147,7 +147,7 @@ GHC
      -----------------------
      G ⊢(n) $(syntax)
 
-   The existing side conditions, which restricting nested quotes and splices (i.e. stages outside of -1, 0, and 1) remain in place, but are ripe for removal in #204.
+   The existing side conditions, which restricting nested quotes and splices (i.e. stages outside of -1, 0, and 1) remain in place, but are ripe for removal in https://github.com/ghc-proposals/ghc-proposals/pulls/204.
 
 #. Add new syntax for stage-offset imports and bindings:
    ::


### PR DESCRIPTION
Template Haskell currently doesn't work well with cross compilation. This is a big nuisance for anyone making phone or browser software. To fix this, enforce stronger separation between the stages.

There are some TODOs, but I am purposefully leaving them there now to be resolved during discussion.

[Rendered](https://github.com/Ericson2314/ghc-proposals/blob/th-stage-hygiene/proposals/0000-th-stage-hygiene.rst)