### PR TITLE
Add "Examples" section to template

### DIFF
--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -12,50 +12,77 @@ the link, and delete this bold sentence.**
 
 # Proposal title
 
-Here you should write a short abstract motivating and briefly summarizing the proposed change.
+Here you should write a short abstract motivating and briefly summarizing the
+proposed change.
 
 
 ## Motivation
 
-Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
 
 
 ## Proposed Change Specification
 
-Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
 
 * grammar and semantics of any new syntactic constructs
 * the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
 
-Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+Note, however, that this section need not describe details of the
+implementation of the feature or examples. The proposal is merely supposed to
+give a conceptual specification of the new feature and its behavior.
 
+## Examples
+
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
 
 ## Effect and Interactions
 
-Detail how the proposed change addresses the original problem raised in the motivation.
+Detail how the proposed change addresses the original problem raised in the
+motivation.
 
-Discuss possibly contentious interactions with existing language or compiler features.
+Discuss possibly contentious interactions with existing language or compiler
+features.
 
 
 ## Costs and Drawbacks
 
-Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+Give an estimate on development and maintenance costs. List how this effects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
 
 
 ## Alternatives
 
-List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+List existing alternatives to your proposed change as they currently exist and
+discuss why they are insufficient.
 
 
 ## Unresolved Questions
 
-Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
 
-Hopefully this section will be empty by the time the proposal is brought to the steering committee.
+Hopefully this section will be empty by the time the proposal is brought to
+the steering committee.
 
 
 ## Implementation Plan
 
-(Optional) If accepted who will implement the change? Which other resources and prerequisites are required for implementation?
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?
 

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -36,45 +36,71 @@ Here you should write a short abstract motivating and briefly summarizing the pr
 
 
 Motivation
-------------
-Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give an example. Explain how the status quo is insufficient or not ideal.
+----------
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
 
 
 Proposed Change Specification
 -----------------------------
-Specify the change in precise, comprehensive yet concise language. Avoid words like should or could. Strive for a complete definition. Your specification may include,
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
 
 * grammar and semantics of any new syntactic constructs
 * the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler features, in case that is otherwise ambiguous
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
 
-Note, however, that this section need not describe details of the implementation of the feature. The proposal is merely supposed to give a conceptual specification of the new feature and its behavior.
+Note, however, that this section need not describe details of the
+implementation of the feature or examples. The proposal is merely supposed to
+give a conceptual specification of the new feature and its behavior.
 
+Examples
+--------
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
 
 Effect and Interactions
 -----------------------
-Detail how the proposed change addresses the original problem raised in the motivation.
+Detail how the proposed change addresses the original problem raised in the
+motivation.
 
-Discuss possibly contentious interactions with existing language or compiler features.
+Discuss possibly contentious interactions with existing language or compiler
+features.
 
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects learnability of the language for novice users. Define and list any remaining drawbacks that cannot be resolved.
+Give an estimate on development and maintenance costs. List how this effects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
 
 
 Alternatives
 ------------
-List existing alternatives to your proposed change as they currently exist and discuss why they are insufficient.
+List existing alternatives to your proposed change as they currently exist and
+discuss why they are insufficient.
 
 
 Unresolved Questions
 --------------------
-Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
 
-Hopefully this section will be empty by the time the proposal is brought to the steering committee.
+Hopefully this section will be empty by the time the proposal is brought to
+the steering committee.
 
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other resources and prerequisites are required for implementation?
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?


### PR DESCRIPTION
Many proposals are best illustrated with examples. With our experience reviewing proposals, I have observed two common suboptimal (to me) ways in how these examples are presented:

1. No (or too few) examples are provided. This almost inevitably leads to someone asking for examples to be provided.

2. The examples are mixed in with other text, often the specification. This often leads to someone asking for a more tightly-stated specification.

This PR introduces a new *Examples* section of the template, encouraging proposers to include examples of their new language construct. This is explicitly *not* part of the specification, which has been amended to specifically exclude examples. I believe introducing this new section will improve the readability of proposals and cause fewer (sometimes tiresome) requests for revision of proposals.