### PR TITLE
Add author and date metadata to all proposals

### DIFF
--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -16,6 +16,8 @@ To get hyperlinks, use backticks, angle brackets, and an underscore `like this <
 Proposal title
 ==============
 
+.. author:: Your name
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
 .. proposal-number:: Leave blank. This will be filled in when the proposal is
                      accepted.
 .. ticket-url:: Leave blank. This will eventually be filled with the

--- a/proposals/0001-proposal-process.rst
+++ b/proposals/0001-proposal-process.rst
@@ -2,6 +2,8 @@ A Proposal for Proposals
 ========================
 
 
+.. author:: Ben Gamari
+.. date-accepted:: 2018-02-27
 .. sectnum::
    :start: 1
 .. contents::

--- a/proposals/0001-proposal-process.rst
+++ b/proposals/0001-proposal-process.rst
@@ -3,7 +3,7 @@ A Proposal for Proposals
 
 
 .. author:: Ben Gamari
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-01-03
 .. sectnum::
    :start: 1
 .. contents::

--- a/proposals/0002-overloaded-record-fields.rst
+++ b/proposals/0002-overloaded-record-fields.rst
@@ -3,7 +3,7 @@ Overloaded Record Fields
 
 .. proposal-number:: 0002
 .. author:: Adam Gundry
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-02-04
 .. implemented:: 8.2
 .. sectnum::
    :start: 2

--- a/proposals/0002-overloaded-record-fields.rst
+++ b/proposals/0002-overloaded-record-fields.rst
@@ -2,6 +2,8 @@ Overloaded Record Fields
 ========================
 
 .. proposal-number:: 0002
+.. author:: Adam Gundry
+.. date-accepted:: 2018-02-27
 .. implemented:: 8.2
 .. sectnum::
    :start: 2

--- a/proposals/0003-levity-polymorphism.rst
+++ b/proposals/0003-levity-polymorphism.rst
@@ -3,7 +3,7 @@ Revise Levity Polymorphism
 
 .. proposal-number:: 0003
 .. author:: Richard Eisenberg
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-02-04
 .. ticket-url:: https://phabricator.haskell.org/D2842
 .. implemented:: 8.2.1
 .. highlight:: haskell

--- a/proposals/0003-levity-polymorphism.rst
+++ b/proposals/0003-levity-polymorphism.rst
@@ -2,6 +2,8 @@ Revise Levity Polymorphism
 ==========================
 
 .. proposal-number:: 0003
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://phabricator.haskell.org/D2842
 .. implemented:: 8.2.1
 .. highlight:: haskell

--- a/proposals/0004-hexFloats.rst
+++ b/proposals/0004-hexFloats.rst
@@ -2,6 +2,8 @@ Hexadecimal Floats in Haskell
 =============================
 
 .. proposal-number:: 0004
+.. author:: Joachim Breitner
+.. date-accepted:: 2017-04-02
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/13126
 .. implemented:: 8.4.1
 .. highlight:: haskell

--- a/proposals/0005-bidir-constr-sigs.rst
+++ b/proposals/0005-bidir-constr-sigs.rst
@@ -2,6 +2,8 @@ Pattern synonym construction function signatures
 ================================================
 
 .. proposal-number:: 0005
+.. author:: David Feuer
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14602
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0005-bidir-constr-sigs.rst
+++ b/proposals/0005-bidir-constr-sigs.rst
@@ -3,7 +3,7 @@ Pattern synonym construction function signatures
 
 .. proposal-number:: 0005
 .. author:: David Feuer
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-01-25
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14602
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0006-deriving-empty.rst
+++ b/proposals/0006-deriving-empty.rst
@@ -2,6 +2,8 @@ Overhaul deriving instances for empty data types
 ================================================
 
 .. proposal-number:: 0006
+.. author:: Ryan Scott
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/7401, https://gitlab.haskell.org/ghc/ghc/issues/10577, https://gitlab.haskell.org/ghc/ghc/issues/13117
 .. implemented:: 8.4
 .. highlight:: haskell

--- a/proposals/0006-deriving-empty.rst
+++ b/proposals/0006-deriving-empty.rst
@@ -3,7 +3,7 @@ Overhaul deriving instances for empty data types
 
 .. proposal-number:: 0006
 .. author:: Ryan Scott
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-08-28
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/7401, https://gitlab.haskell.org/ghc/ghc/issues/10577, https://gitlab.haskell.org/ghc/ghc/issues/13117
 .. implemented:: 8.4
 .. highlight:: haskell

--- a/proposals/0007-instance-foralls.rst
+++ b/proposals/0007-instance-foralls.rst
@@ -3,7 +3,7 @@ More explicit ``forall``\s
 
 .. proposal-number:: 0007
 .. author:: Richard Eisenberg
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-06-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/2600, https://gitlab.haskell.org/ghc/ghc/issues/14268
 .. implemented:: 8.8
 .. sectnum::

--- a/proposals/0007-instance-foralls.rst
+++ b/proposals/0007-instance-foralls.rst
@@ -2,6 +2,8 @@ More explicit ``forall``\s
 ==========================
 
 .. proposal-number:: 0007
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/2600, https://gitlab.haskell.org/ghc/ghc/issues/14268
 .. implemented:: 8.8
 .. sectnum::

--- a/proposals/0008-type-infix.rst
+++ b/proposals/0008-type-infix.rst
@@ -3,7 +3,7 @@ Require namespacing fixity declarations for type names and ``WARNING``/``DEPRECA
 
 .. proposal-number:: 0008
 .. author:: Ryan Scott
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-11-03
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14032
 .. implemented:: None yet
 .. sectnum::

--- a/proposals/0008-type-infix.rst
+++ b/proposals/0008-type-infix.rst
@@ -2,6 +2,8 @@ Require namespacing fixity declarations for type names and ``WARNING``/``DEPRECA
 =============================================================================================
 
 .. proposal-number:: 0008
+.. author:: Ryan Scott
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14032
 .. implemented:: None yet
 .. sectnum::

--- a/proposals/0009-numeric-underscores.rst
+++ b/proposals/0009-numeric-underscores.rst
@@ -3,7 +3,7 @@ Underscores in Numeric Literals
 
 .. proposal-number:: 0009
 .. author:: Takenobu Tani
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-11-14
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14473
 .. implemented:: 8.6.1
 .. highlight:: haskell

--- a/proposals/0009-numeric-underscores.rst
+++ b/proposals/0009-numeric-underscores.rst
@@ -2,6 +2,8 @@ Underscores in Numeric Literals
 ===============================
 
 .. proposal-number:: 0009
+.. author:: Takenobu Tani
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14473
 .. implemented:: 8.6.1
 .. highlight:: haskell

--- a/proposals/0010-block-arguments.rst
+++ b/proposals/0010-block-arguments.rst
@@ -3,7 +3,7 @@ BlockArguments Extension
 
 .. proposal-number:: 10
 .. author:: Takano Akio
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2017-12-05
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/10843
 .. implemented:: 8.6.1
 .. highlight:: haskell

--- a/proposals/0010-block-arguments.rst
+++ b/proposals/0010-block-arguments.rst
@@ -2,6 +2,8 @@ BlockArguments Extension
 ========================
 
 .. proposal-number:: 10
+.. author:: Takano Akio
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/10843
 .. implemented:: 8.6.1
 .. highlight:: haskell

--- a/proposals/0011-deprecate-stm-invariants.rst
+++ b/proposals/0011-deprecate-stm-invariants.rst
@@ -2,6 +2,8 @@ Deprecating STM invariant mechanism
 ===================================
 
 .. proposal-number:: 11
+.. author:: Ben Gamari
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14324
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0011-deprecate-stm-invariants.rst
+++ b/proposals/0011-deprecate-stm-invariants.rst
@@ -3,7 +3,7 @@ Deprecating STM invariant mechanism
 
 .. proposal-number:: 11
 .. author:: Ben Gamari
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2018-02-03
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14324
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0012-Wall-uni-patterns.rst
+++ b/proposals/0012-Wall-uni-patterns.rst
@@ -2,6 +2,8 @@ Extend ``-Wall`` with ``incomplete-uni-patterns`` and ``incomplete-record-update
 ==============
 
 .. proposal-number:: 12
+.. author:: tomjaguarpaw
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15656
 .. implemented::
 .. sectnum::

--- a/proposals/0012-Wall-uni-patterns.rst
+++ b/proposals/0012-Wall-uni-patterns.rst
@@ -3,7 +3,7 @@ Extend ``-Wall`` with ``incomplete-uni-patterns`` and ``incomplete-record-update
 
 .. proposal-number:: 12
 .. author:: tomjaguarpaw
-.. date-accepted:: 2018-02-27
+.. date-accepted:: 2018-02-07
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15656
 .. implemented::
 .. sectnum::

--- a/proposals/0013-unlifted-newtypes.rst
+++ b/proposals/0013-unlifted-newtypes.rst
@@ -2,6 +2,8 @@ Unlifted Newtypes
 =================
 
 .. proposal-number:: 13
+.. author:: Andrew Martin
+.. date-accepted:: 2018-02-27
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15219
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0014-small-primitives.rst
+++ b/proposals/0014-small-primitives.rst
@@ -2,6 +2,8 @@
 Add more fixed size primitive types, like ``Int8#/Word8#``
 ==========================================================
 
+.. author:: Michal Terepeta
+.. date-accepted:: 2018-03-01
 .. proposal-number:: 14
 .. ticket-url:: https://phabricator.haskell.org/D5006, https://phabricator.haskell.org/D5258
 .. implemented::

--- a/proposals/0015-type-level-type-applications.rst
+++ b/proposals/0015-type-level-type-applications.rst
@@ -2,6 +2,8 @@ Type-level type applications
 ============================
 
 .. proposal-number:: 15
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-03-01
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/12045
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0016-as-patterns-synonyms.rst
+++ b/proposals/0016-as-patterns-synonyms.rst
@@ -2,7 +2,7 @@ As patterns in pattern synonyms
 ==============
 
 .. proposal-number:: 16
-.. author:: simonpj
+.. author:: Simon Peyton Jones
 .. date-accepted:: 2018-03-18
 .. ticket-url:: Leave blank. This will eventually be filled with the
                 ticket URL which will track the progress of the

--- a/proposals/0016-as-patterns-synonyms.rst
+++ b/proposals/0016-as-patterns-synonyms.rst
@@ -2,6 +2,8 @@ As patterns in pattern synonyms
 ==============
 
 .. proposal-number:: 16
+.. author:: simonpj
+.. date-accepted:: 2017-11-10
 .. ticket-url:: Leave blank. This will eventually be filled with the
                 ticket URL which will track the progress of the
                 implementation of the feature.

--- a/proposals/0016-as-patterns-synonyms.rst
+++ b/proposals/0016-as-patterns-synonyms.rst
@@ -3,7 +3,7 @@ As patterns in pattern synonyms
 
 .. proposal-number:: 16
 .. author:: simonpj
-.. date-accepted:: 2017-11-10
+.. date-accepted:: 2018-03-18
 .. ticket-url:: Leave blank. This will eventually be filled with the
                 ticket URL which will track the progress of the
                 implementation of the feature.

--- a/proposals/0017-source-plugins.rst
+++ b/proposals/0017-source-plugins.rst
@@ -2,6 +2,8 @@ Source plugins
 ==============
 
 .. proposal-number:: 17
+.. author:: Ryan Scott
+.. date-accepted:: 2018-04-13
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14709
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0018-quantified-constraints.rst
+++ b/proposals/0018-quantified-constraints.rst
@@ -2,6 +2,8 @@ Quantified Constraints
 ======================
 
 .. proposal-number:: 18
+.. author:: Ryan Scott
+.. date-accepted:: 2018-04-23
 
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/2893
 

--- a/proposals/0019-constraint-vs-type.rst
+++ b/proposals/0019-constraint-vs-type.rst
@@ -2,6 +2,8 @@ Declare ``Constraint`` is not apart from ``Type``
 =================================================
 
 .. proposal-number:: 19
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-04-24
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0020-no-type-in-type.rst
+++ b/proposals/0020-no-type-in-type.rst
@@ -2,6 +2,8 @@ Embrace ``Type :: Type``
 ==========================
 
 .. proposal-number:: 20
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-04-24
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15195
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0021-unlifted-array.rst
+++ b/proposals/0021-unlifted-array.rst
@@ -2,6 +2,8 @@ UnliftedArray
 ==============
 
 .. proposal-number:: 21
+.. author:: Andrew Martin
+.. date-accepted:: 2018-05-14
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0022-plugin-recompilation.rst
+++ b/proposals/0022-plugin-recompilation.rst
@@ -2,6 +2,8 @@ Refining the plugin recompilation API
 ==============
 
 .. proposal-number:: 22
+.. author:: Matthew Pickering
+.. date-accepted:: 2018-05-15
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/7414
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0023-deriving-via.rst
+++ b/proposals/0023-deriving-via.rst
@@ -2,6 +2,8 @@ Deriving Via
 ============
 
 .. proposal-number:: 23
+.. author:: Icelandjack
+.. date-accepted:: 2018-05-22
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15178
 .. implemented:: 8.6
 .. highlight:: haskell

--- a/proposals/0024-no-kind-vars.rst
+++ b/proposals/0024-no-kind-vars.rst
@@ -2,6 +2,8 @@ Treat kind variables and type variables identically in ``forall``
 =================================================================
 
 .. proposal-number:: 24
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-05-22
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15264
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0025-resize-boxed.rst
+++ b/proposals/0025-resize-boxed.rst
@@ -2,6 +2,8 @@ Offer more array resizing primitives
 ====================================
 
 .. proposal-number:: 25
+.. author:: David Feuer
+.. date-accepted:: 2018-07-02
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0026-explicit-specificity.rst
+++ b/proposals/0026-explicit-specificity.rst
@@ -2,6 +2,8 @@ Explicit specificity in type variable binders
 =============================================
 
 .. proposal-number:: 26
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-07-02
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16393
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0027-atomicModifyMutVar.rst
+++ b/proposals/0027-atomicModifyMutVar.rst
@@ -2,6 +2,8 @@ Replace the ``atomicModifyMutVar#`` primop
 ==========================================
 
 .. proposal-number:: 27
+.. author:: David Feuer
+.. date-accepted:: 2018-07-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15364
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0028-deprecating-exports-proposal.rst
+++ b/proposals/0028-deprecating-exports-proposal.rst
@@ -2,7 +2,7 @@ Deprecating Exports
 ===================
 
 .. proposal-number:: 28
-.. author:: alanasp
+.. author:: Alanas Plascinskas
 .. date-accepted:: 2018-07-14
 .. ticket-url::
 .. implemented::

--- a/proposals/0028-deprecating-exports-proposal.rst
+++ b/proposals/0028-deprecating-exports-proposal.rst
@@ -2,6 +2,8 @@ Deprecating Exports
 ===================
 
 .. proposal-number:: 28
+.. author:: alanasp
+.. date-accepted:: 2018-07-14
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0029-scoped-type-variables-types.rst
+++ b/proposals/0029-scoped-type-variables-types.rst
@@ -2,6 +2,8 @@ Allow ScopedTypeVariables to refer to types
 ===========================================
 
 .. proposal-number:: 29
+.. author:: Joachim Breitner
+.. date-accepted:: 2018-04-24
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15050
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0029-scoped-type-variables-types.rst
+++ b/proposals/0029-scoped-type-variables-types.rst
@@ -3,7 +3,7 @@ Allow ScopedTypeVariables to refer to types
 
 .. proposal-number:: 29
 .. author:: Joachim Breitner
-.. date-accepted:: 2018-04-24
+.. date-accepted:: 2018-08-04
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15050
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0030-remove-star-kind.rst
+++ b/proposals/0030-remove-star-kind.rst
@@ -2,6 +2,8 @@ Remove the * kind syntax
 ========================
 
 .. proposal-number:: 30
+.. author:: Vladislav Zavialov
+.. date-accepted:: 2018-08-04
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0031-type-applications-in-patterns.rst
+++ b/proposals/0031-type-applications-in-patterns.rst
@@ -3,7 +3,7 @@ Type Applications in Patterns
 
 .. proposal-number:: 31
 .. author:: Ryan Scott
-.. date-accepted:: 2018-04-19
+.. date-accepted:: 2018-08-16
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15530
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0031-type-applications-in-patterns.rst
+++ b/proposals/0031-type-applications-in-patterns.rst
@@ -2,6 +2,8 @@ Type Applications in Patterns
 =============================
 
 .. proposal-number:: 31
+.. author:: Ryan Scott
+.. date-accepted:: 2018-04-19
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15530
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0032-type-data.rst
+++ b/proposals/0032-type-data.rst
@@ -2,7 +2,7 @@ Define Kinds Without Promotion
 ==============================
 
 .. proposal-number:: 32
-.. author:: Gabor Greif
+.. author:: Iavor Diatchki
 .. date-accepted:: 2018-09-12
 .. ticket-url::
 .. implemented::

--- a/proposals/0032-type-data.rst
+++ b/proposals/0032-type-data.rst
@@ -2,6 +2,8 @@ Define Kinds Without Promotion
 ==============================
 
 .. proposal-number:: 32
+.. author:: Gabor Greif
+.. date-accepted:: 2018-09-12
 .. ticket-url::
 .. implemented::
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/106>`_.

--- a/proposals/0033-unbanged-strict-patterns.rst
+++ b/proposals/0033-unbanged-strict-patterns.rst
@@ -2,6 +2,8 @@ Make unboxed tuple patterns lazy / warn on unbanged strict patterns
 ===================================================================
 
 .. proposal-number:: 33
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-09-12
 .. ticket-url:: https://phabricator.haskell.org/D2842
 .. implemented::
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/35>`_.

--- a/proposals/0034-stable-names.rst
+++ b/proposals/0034-stable-names.rst
@@ -2,6 +2,8 @@ Remove an undocumented `StableName` guarantee
 =============================================
 
 .. proposal-number:: 34
+.. author:: David Feuer
+.. date-accepted:: 2018-09-30
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0035-forall-arrow.rst
+++ b/proposals/0035-forall-arrow.rst
@@ -2,6 +2,8 @@ A syntax for visible dependent quantification
 =============================================
 
 .. proposal-number:: 35
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-09-30
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16326
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0036-kind-signatures.rst
+++ b/proposals/0036-kind-signatures.rst
@@ -2,6 +2,8 @@ Top-level kind signatures
 =========================
 
 .. proposal-number:: 36
+.. author:: Richard Eisenberg
+.. date-accepted:: 2018-09-30
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0037-unpack-pragma-precedence.rst
+++ b/proposals/0037-unpack-pragma-precedence.rst
@@ -2,6 +2,8 @@ Lower precedence for {-# UNPACK #-}
 ===================================
 
 .. proposal-number:: 37
+.. author:: Vladislav Zavialov
+.. date-accepted:: 2018-10-20
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/14761
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0038-fail-rebindable-with-overloaded-strings.rst
+++ b/proposals/0038-fail-rebindable-with-overloaded-strings.rst
@@ -3,7 +3,7 @@ Make rebindable ``fail`` work with overloaded strings
 
 .. proposal-number:: 38
 .. author:: Shayne Fletcher
-.. date-accepted:: 2018-09-30
+.. date-accepted:: 2018-10-21
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15645
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0038-fail-rebindable-with-overloaded-strings.rst
+++ b/proposals/0038-fail-rebindable-with-overloaded-strings.rst
@@ -2,6 +2,8 @@ Make rebindable ``fail`` work with overloaded strings
 =====================================================
 
 .. proposal-number:: 38
+.. author:: Shayne Fletcher
+.. date-accepted:: 2018-09-30
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15645
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0039-dot-type-operator.rst
+++ b/proposals/0039-dot-type-operator.rst
@@ -2,6 +2,8 @@ The dot type operator
 =====================
 
 .. proposal-number:: 39
+.. author:: Vladislav Zavialov
+.. date-accepted:: 2018-11-05
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/363
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0040-unrestricted-overloadedlabels.rst
+++ b/proposals/0040-unrestricted-overloadedlabels.rst
@@ -2,6 +2,8 @@ Unrestricted Overloaded Labels
 ==============================
 
 .. proposal-number:: 40
+.. author:: howtonotwin
+.. date-accepted:: 2018-11-05
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/11671
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0041-ghci-instances.rst
+++ b/proposals/0041-ghci-instances.rst
@@ -2,6 +2,8 @@ List instances for a type in GHCi
 ==============
 
 .. proposal-number:: 41
+.. author:: Xavier Denis
+.. date-accepted:: 2018-11-05
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15610
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0042-record-set-field.rst
+++ b/proposals/0042-record-set-field.rst
@@ -2,6 +2,8 @@ Add ``setField`` to ``HasField``
 ================================
 
 .. proposal-number:: 42
+.. author:: Neil Mitchell
+.. date-accepted:: 2019-01-22
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16232
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0043-forall-keyword.rst
+++ b/proposals/0043-forall-keyword.rst
@@ -2,6 +2,8 @@ Make ``forall`` a keyword
 =========================
 
 .. proposal-number:: 43
+.. author:: Richard Eisenberg
+.. date-accepted:: 2019-05-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/363
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0043-forall-keyword.rst
+++ b/proposals/0043-forall-keyword.rst
@@ -3,7 +3,7 @@ Make ``forall`` a keyword
 
 .. proposal-number:: 43
 .. author:: Richard Eisenberg
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-02-14
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/363
 .. implemented:: 8.8
 .. highlight:: haskell

--- a/proposals/0044-minimal-should-warn-extras.rst
+++ b/proposals/0044-minimal-should-warn-extras.rst
@@ -2,6 +2,8 @@ MINIMAL should warn about extra definitions
 ===========================================
 
 .. proposal-number:: 44
+.. author:: Levent Erkok
+.. date-accepted:: 2019-03-14
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16314
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0045-pointer-rep.rst
+++ b/proposals/0045-pointer-rep.rst
@@ -2,6 +2,8 @@ Pointer Rep
 ==============
 
 .. proposal-number:: 45
+.. author:: Andrew Martin
+.. date-accepted:: 2019-05-11
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0045-pointer-rep.rst
+++ b/proposals/0045-pointer-rep.rst
@@ -3,7 +3,7 @@ Pointer Rep
 
 .. proposal-number:: 45
 .. author:: Andrew Martin
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-04-17
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0046-scc-parsing.rst
+++ b/proposals/0046-scc-parsing.rst
@@ -3,7 +3,7 @@ Meaning-preserving parsing rules for SCC annotations
 
 .. proposal-number:: 46
 .. author:: Vladislav Zavialov
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-04-17
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0046-scc-parsing.rst
+++ b/proposals/0046-scc-parsing.rst
@@ -2,6 +2,8 @@ Meaning-preserving parsing rules for SCC annotations
 ====================================================
 
 .. proposal-number:: 46
+.. author:: Vladislav Zavialov
+.. date-accepted:: 2019-05-11
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0047-levity-polymorphic-lift.rst
+++ b/proposals/0047-levity-polymorphic-lift.rst
@@ -2,6 +2,8 @@ Levity-polymorphic `Lift`
 =========================
 
 .. proposal-number:: 47
+.. author:: Alec Theriault
+.. date-accepted:: 2019-05-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/789
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0047-levity-polymorphic-lift.rst
+++ b/proposals/0047-levity-polymorphic-lift.rst
@@ -3,7 +3,7 @@ Levity-polymorphic `Lift`
 
 .. proposal-number:: 47
 .. author:: Alec Theriault
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-04-17
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/789
 .. implemented:: 8.10
 .. highlight:: haskell

--- a/proposals/0048-printing-foralls.rst
+++ b/proposals/0048-printing-foralls.rst
@@ -3,7 +3,7 @@ Clean up printing of foralls
 
 .. proposal-number:: 48
 .. author:: Richard Eisenberg
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-04-17
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16320
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0048-printing-foralls.rst
+++ b/proposals/0048-printing-foralls.rst
@@ -2,6 +2,8 @@ Clean up printing of foralls
 ============================
 
 .. proposal-number:: 48
+.. author:: Richard Eisenberg
+.. date-accepted:: 2019-05-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16320
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0049-module-qualified-syntax.rst
+++ b/proposals/0049-module-qualified-syntax.rst
@@ -2,6 +2,8 @@ Allow ``qualified`` to follow module name
 =========================================
 
 .. proposal-number:: 49
+.. author:: Shayne Fletcher
+.. date-accepted:: 2019-05-11
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/853
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0049-module-qualified-syntax.rst
+++ b/proposals/0049-module-qualified-syntax.rst
@@ -3,7 +3,7 @@ Allow ``qualified`` to follow module name
 
 .. proposal-number:: 49
 .. author:: Shayne Fletcher
-.. date-accepted:: 2019-05-11
+.. date-accepted:: 2019-05-02
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/merge_requests/853
 .. implemented::
 .. highlight:: haskell

--- a/proposals/0050-type-lambda.rst
+++ b/proposals/0050-type-lambda.rst
@@ -2,6 +2,8 @@ Binding type variables in lambda-expressions
 ============================================
 
 .. proposal-number:: 50
+.. author:: Richard Eisenberg
+.. date-accepted:: 2019-05-09
 .. trac-ticket::
 .. implemented::
 .. highlight:: haskell


### PR DESCRIPTION
This was automatically generated by using `git blame` to determine who wrote the last line in the file (the author), and then finding the date the file was created (presumably the accepted date.)
It was generated via

```bash
#!/bin/bash

for FILE in proposals/*; do

AUTHOR=$(git blame $FILE | tail -n1 | cut -f2 -d'(' | sed 's/  \+/#/g' | cut -f1 -d'#' | cut -f1,2 -d' ' | cat <( echo -n ".. author:: ") -)
DATE=$(git log --format="format:%ai" $FILE | tail -n1 | cut -f'1' -d' ' | cat <( echo -n ".. date-accepted:: ") -)

sed -i "5i$AUTHOR" $FILE
sed -i "6i$DATE" $FILE

done
```

Closes #247