### PR TITLE
No kind signatures on associated types

### DIFF
--- a/proposals/0054-kind-signatures.rst
+++ b/proposals/0054-kind-signatures.rst
@@ -77,7 +77,7 @@ Proposed Change Specification
    is done before ever examining the full declaration, just like how GHC treats type
    signatures.
 
-   Associated types may be given kind signatures within their classes.
+   Associated types may not be given top-level kind signatures. (See "Costs and Drawbacks" for discussion.)
 
    Unlike type signatures, the type variables brought into scope in a type-level kind
    signature do *not* scope over the type definition.
@@ -128,6 +128,13 @@ Checking and generalizing the kind can be done by already-written code (in TcHsT
 The hardest part will be complicating the code in TcTyClsDecls, which is already somewhat
 involved; however, I don't think this change will be invasive, as it will just affect the
 code that currently checks for CUSKs.
+
+This proposal excludes signatures on associated types, as it was unclear how best to
+choose a candidate from the design space. The need for signatures for associated types
+is less pressing (they cannot be recursive, because instances are independent of the
+family declaration), and so we live without associated type signatures until a clear
+design presents itself. See `PR#227 <https://github.com/ghc-proposals/ghc-proposals/pull/227>`_
+for lots of discussion.
 
 Alternatives
 ------------


### PR DESCRIPTION
This amendment to the accepted proposal on standalone kind signatures removes the ability to put a kind signature on associated types, as we could not choose a good design for this feature and the feature does not seem all that pressing.

* [Original, unchanged proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0036-kind-signatures.rst)
* Discussion of original proposal at #54.
* [Rendered version of updated proposal](https://github.com/goldfirere/ghc-proposals/blob/no-assoc-sak/proposals/0054-kind-signatures.rst)
* [Rendered version of diff](https://github.com/goldfirere/ghc-proposals/compare/8a2f26408decd4be7799179213b3d3416509eb18...no-assoc-sak?short_path=bf40b0d#diff-bf40b0d802d1ac546bd04c73dfd23dd6)
* Previous amendment to move associated type signatures to top-level at #227.

<!-- probot = {"1313345":{"who":"goldfirere","what":"submit to the committee.","when":"2019-08-20T09:00:00.000Z"}} -->