### PR TITLE
WIP: Don't speak of `DynFlags`

### DIFF
--- a/proposals/0000-dynflags-bad.rst
+++ b/proposals/0000-dynflags-bad.rst
@@ -1,0 +1,106 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Proposal title
+==============
+
+.. author:: Your name
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. proposal-number:: Leave blank. This will be filled in when the proposal is
+                     accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+
+Here you should write a short abstract motivating and briefly summarizing the proposed change.
+
+
+Motivation
+----------
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
+
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
+
+* grammar and semantics of any new syntactic constructs
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
+
+Note, however, that this section need not describe details of the
+implementation of the feature or examples. The proposal is merely supposed to
+give a conceptual specification of the new feature and its behavior.
+
+Examples
+--------
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
+
+Effect and Interactions
+-----------------------
+Detail how the proposed change addresses the original problem raised in the
+motivation.
+
+Discuss possibly contentious interactions with existing language or compiler
+features.
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List existing alternatives to your proposed change as they currently exist and
+discuss why they are insufficient.
+
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to
+the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?

--- a/proposals/0000-dynflags-bad.rst
+++ b/proposals/0000-dynflags-bad.rst
@@ -1,22 +1,7 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
+Don't speak of ``DynFlags``
+===========================
 
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
-Proposal title
-==============
-
-.. author:: Your name
+.. author:: John Ericson
 .. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
 .. proposal-number:: Leave blank. This will be filled in when the proposal is
                      accepted.
@@ -32,75 +17,113 @@ Proposal title
 .. sectnum::
 .. contents::
 
-Here you should write a short abstract motivating and briefly summarizing the proposed change.
-
+``DynFlags`` hampers the modularity of GHC.
+Instead of referring to it directly, refer to a type parameter constrained to have just the information necessary.
+The benefits of this are somewhat uncertain, so merge the refactor on an experimental basis, and revert it if they aren't realized.
 
 Motivation
 ----------
-Give a strong reason for why the community needs this change. Describe the use
-case as clearly as possible and give an example. Explain how the status quo is
-insufficient or not ideal.
 
-A good Motivation section is often driven by examples and real-world scenarios.
+``DynFlags`` has no meaning.
+It is just a roll up of every configuration option anything needs ever.
+This is bad for modularity: it leaks information to components of the compiler that they shouldn't care about, and prevents adding additional components with more configuration options.
 
+The easiest way to replace it today is to use type variables and ``Has*`` classes to project smaller records.
+[Perhaps in ea future with row types we would do something different, but we can refactor to do that then.]
+``DynFlags`` would still be substituted for those variables to satisfy those constraints for GHC the executable, but other consumers of the library could instantiate with something different instead.
+
+With ``DynFlags`` not mentioned directly in most places, we should have opened up more opportunities to modularize the compiler further.
+For example, we could break module ``hs-boot`` cycles, or even split the GHC library into multiple libraries.
+Unfortunately, it's hard to predict exactly what opportunities will arise *a priori*.
+But if we want modularity, we should be confident that referring to ``DynFlags`` indirectly is a necessary if not sufficient condition for these loftier goals.
+
+Many attempts to modularize GHC have floundered in the past.
+I think we have to be willing to stomach the risk of experiments to get us over the hump.
+I wish this proposal was more certain, the best I can do is say we try this on preliminary basis, and if the benefits are not good enough we revert it.
 
 Proposed Change Specification
 -----------------------------
-Specify the change in precise, comprehensive yet concise language. Avoid words
-like "should" or "could". Strive for a complete definition. Your specification
-may include,
 
-* grammar and semantics of any new syntactic constructs
-* the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler
-  features, in case that is otherwise ambiguous
+For the refactor itself.
 
-Note, however, that this section need not describe details of the
-implementation of the feature or examples. The proposal is merely supposed to
-give a conceptual specification of the new feature and its behavior.
+1. Create smaller configuration records and ``Has*`` classes to project them.
+   The exact break down can only be determined doing the work.
+   TODO finish draft refactor and provide some examples.
+
+2. Replace ``DynFlags`` with ``(HasFoo cfg, HasBar cfg) => cfg`` in functions.
+
+3. ``Outputable`` is an extremely widely used class with a method which mentions ``DynFlags``.
+   There is no one-size-fits-all constraint to replace it with, so add an associated ``Type -> Constraint`` instead::
+
+     -- | Class designating that some type has an 'SDoc' representation
+     class Outputable a where
+        ppr :: a -> SDoc
+        pprPrec :: Rational -> a -> SDoc
+        type OutputableNeedsOfConfig a :: * -> Constraint
+        -- Doing this breaks hs-boot files, which cannot have type family
+        -- instances. TODO link issue
+        -- type OutputableNeedsOfConfig a = NoConstraint
+
+        ppr :: OutputableNeedsOfConfig a r => a -> SDoc' r
+        -- ...
+
+   TODO bikeshed ``OutputableNeedsOfConfig`` name.
+
+   Constraints can be combined with a ``PairConstraint`` ::
+
+     class (f a, g a) => PairConstraint f g a
+     instance (f a, g a) => PairConstraint f g a
+
+4. Try to replace ``unsafeGlobalDynFlags`` with a smaller configuration record, or ideally none at all.
+   TODO exact plan, but need to finish ``Outputable`` refactor draft to know more.
+
+If the larger modularity goals are not borne out in **x** months' time, the PR should be reverted.
+TODO decide experiment length.
 
 Examples
 --------
-This section illustrates the specification through the use of examples of the
-language change proposed. It is best to exemplify each point made in the
-specification, though perhaps one example can cover several points. Contrived
-examples are OK here. If the Motivation section describes something that is
-hard to do without this proposal, this is a good place to show how easy that
-thing is to do with the proposal.
+
+See the WIP MR.
 
 Effect and Interactions
 -----------------------
-Detail how the proposed change addresses the original problem raised in the
-motivation.
 
-Discuss possibly contentious interactions with existing language or compiler
-features.
-
+See the WIP MR.
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects
-learnability of the language for novice users. Define and list any remaining
-drawbacks that cannot be resolved.
 
+- ``PairConstraint`` is annoying,
+
+- Lots of dictionary inlining is needed to maintain the same performance.
+
+- Lots of types get bigger.
+  Though note they don't get "fancier", e.g. pseudo-dependent GADT stuff.
+  I hope that means they aren't harder to maintain, just merely take up more screen space.
+
+I view these as an unavoidable cost of modularity, or at least tying the knot with the type classes instead of the module system.
 
 Alternatives
 ------------
-List existing alternatives to your proposed change as they currently exist and
-discuss why they are insufficient.
 
+- Some other "poor man's row types" schemes.
+  note that passing in projection functions does work for the freestanding functions, but not ``Outputable`` when multiple when multiple projections are needed.
+
+- Create a big record for everything needed for each ``Outputable`` instance.
+  It would perhaps break some cycles, and wouldn't incur the drawbacks of this.
+  But, the larger modularity issues mentioned in the motivation remain unaddressed.
 
 Unresolved Questions
 --------------------
-Explicitly list any remaining issues that remain in the conceptual design and
-specification. Be upfront and trust that the community will help. Please do
-not list *implementation* issues.
 
-Hopefully this section will be empty by the time the proposal is brought to
-the steering committee.
-
+Exactly how big the types will get, and exactly what the benefits are.
+The first step is to finish the refactor, but the only certain proof is in running the experiment.
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other resources
-and prerequisites are required for implementation?
+
+I've started in `GHC !1033`_, but I'd love a buddy to take turns pushing on this.
+It's a massive refactor and accumulates conflicts fairly quickly, and so benefits from multiple people taking turns working on it.
+I'll to do the revert if the experiment fails, and do not request assistance for that.
+
+.. _`GHC !1033`: https://gitlab.haskell.org/ghc/ghc/merge_requests/1033

--- a/proposals/0000-dynflags-bad.rst
+++ b/proposals/0000-dynflags-bad.rst
@@ -29,7 +29,7 @@ It is just a roll up of every configuration option anything needs ever.
 This is bad for modularity: it leaks information to components of the compiler that they shouldn't care about, and prevents adding additional components with more configuration options.
 
 The easiest way to replace it today is to use type variables and ``Has*`` classes to project smaller records.
-[Perhaps in ea future with row types we would do something different, but we can refactor to do that then.]
+[Perhaps in the near future with row types we would do something different, but we can refactor to do that then.]
 ``DynFlags`` would still be substituted for those variables to satisfy those constraints for GHC the executable, but other consumers of the library could instantiate with something different instead.
 
 With ``DynFlags`` not mentioned directly in most places, we should have opened up more opportunities to modularize the compiler further.

--- a/proposals/0000-dynflags-bad.rst
+++ b/proposals/0000-dynflags-bad.rst
@@ -93,7 +93,10 @@ See the WIP MR.
 Costs and Drawbacks
 -------------------
 
-- ``PairConstraint`` is annoying,
+- ``PairConstraint`` is annoying.
+  One has to turn lists of ``Type -> Constraint`` into binary trees.
+  However, once we have higher order type families we can get rid of ``PairConstraint`` and the binary trees, and just use tuples.
+  Maybe we can even do that now by adding a second parameter that is never cased on to ``OutputableNeedsOfConfig``.
 
 - Lots of dictionary inlining is needed to maintain the same performance.
 


### PR DESCRIPTION
``DynFlags`` hampers the modularity of GHC.
Instead of referring to it directly, refer to a type parameter constrained to have just the information necessary.
The benefits of this are somewhat uncertain, so merge the refactor on an experimental basis, and revert it if they aren't realized.

[Rendered](https://github.com/Ericson2314/ghc-proposals/blob/dynflags-bad/proposals/0000-dynflags-bad.rst)
WIP MR: https://gitlab.haskell.org/ghc/ghc/merge_requests/1033

CC @wz1000 @bgamari 