### PR TITLE
Set clearer expectations about the proposal process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ This section outlines what stages a proposal may go through. The stage is identi
    `≡ List of proposals under review <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+committee+review%22>`_
 
 6. Eventually, the committee rejects a proposal (label: Rejected), or passes it back to the
-   author for review (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_), or accepts it (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Accepted%22>`_).
+   author for review (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_), or accepts it (label: `Accepted <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Accepted%22>`_).
 
    Acceptance of the proposal implies that the implementation will be accepted
    into GHC provided it is well-engineered, well-documented, and does not

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,8 @@ Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/
 
 Poposals should follow the structure given in the `ReStructuredText template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, or the `Markdown template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.  (The two are identical except for format.)
 
+See the section `Review criteria <#review-criteria>`_ below for more information about what makes a strong proposal, and how it will be reviewed.
+
 To start a proposal, create a pull request that adds your proposal as ``proposals/0000-proposal-name.rst`` or ``proposals/0000-proposal-name.md``. Use the corresponding ``proposals/0000-template`` file as a template.
 
 If you are unfamiliar with git and github, you can use the GitHub web interface to perform these steps:

--- a/README.rst
+++ b/README.rst
@@ -148,12 +148,12 @@ Here are some characteristics that a good proposal should have
 
 * It should offer evidence of utility.  Even the strongest proposals carry costs:
 
-  * For programmers: they usually make the language just a bit more complicated;
-  * For GHC maintainers: they make the implementation a bit more complicated;
-  * For those wanting to proposals in the future: they usually add new back-compat burdens, and consume syntactic design space.
-  * Moreover, all these costs contitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.
+  * For programmers: most proposals make the language just a bit more complicated;
+  * For GHC maintainers:  most proposals make the implementation a bit more complicated;
+  * For future proposers:  most proposals consume syntactic design space add/or add new back-compat burdens, both of which make new proposals harder to fit in.
+  * It is much, much harder subsequently to remove an extensiuon than it is to add it.
 
-  The tax may well be worth it (a language without polymorphism
+  All these costs contitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.  The tax may well be worth it (a language without polymorphism
   would be simpler but we don't want it), but the case should be made.
 
   The case is stronger if lots of people jump in saying "yes, this would be so

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ How to start a new proposal
 
 Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ or `Markdown <https://github.github.com/gfm/>`_. While the proposal process itself has no preference, keep in mind that the `GHC Users Guide <http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/editing-guide.html>`_ uses ReStructuredText exclusively. Accepted proposals written in ReStructuredText thus have the slight benefit that they can be more easily included in the official GHC documentation.
 
-Poposals should follow the structure given in the `ReStructuredText template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, or the `Markdown template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.  (The two are identical except for format.)
+Proposals should follow the structure given in the `ReStructuredText template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, or the `Markdown template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.  (The two are identical except for format.)
 
 See the section `Review criteria <#review-criteria>`_ below for more information about what makes a strong proposal, and how it will be reviewed.
 

--- a/README.rst
+++ b/README.rst
@@ -15,53 +15,57 @@ GHC.
 * `≡ List of implemented proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_
 * `≡ List of all proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=>`_
 
-What is the timeline of a proposal?
+The life cycle of a proposal
 -----------------------------------
 
-1. The author drafts a proposal.
+This section outlines what stages a proposal may go through. The stage is identified by a GitHub label, which is identified in the following list.
+
+1. (No label.) The author drafts a proposal.
 
    `What is a proposal? <#what-is-a-proposal>`_ • `What should a proposal look like? <#what-should-a-proposal-look-like>`_
 
-2. The author submits the proposal to the wider Haskell community for discussion, as a pull request against this repository.
+2. (No label.) The author submits the proposal to the wider Haskell community for discussion, as a pull request against this repository.
 
    `How to submit a proposal <#how-to-start-a-new-proposal>`_
 
-3. The wider community discusses the proposal in the commit section of the pull
+3. (No label.)  The wider community discusses the proposal in the commit section of the pull
    request, while the author refines the proposal. This phase lasts as long as necessary.
 
    `Discussion goals <#discussion-goals>`_ •
    `How to comment on a proposal <#how-to-comment-on-a-proposal>`_ •
    `≡ List of proposals under discussion <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+no%3Alabel>`_
 
-4. Eventually *the proposal author* brings the proposal before the committee for review.
+4. Label: `Pending shepherd recommendation <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+shepherd+recommendation%>`_.  Eventually *the proposal author* brings the proposal before the committee for review.
 
    `How to bring a proposal before the committee <#how-to-bring-a-proposal-before-the-committee>`_ •
-   `Who is the committee? <#who-is-the-committee>`_
+   `Who is the committee? <#who-is-the-committee>`_   •
+   `≡ List of proposals waiting for shepherd <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+shepherd+recommendation%22>`_ •
 
-5. One committee member steps up as a shepherd, and generates consensus within the committee within four or five weeks.
+5. Label: `Pending committee review <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+committee+review>`_.  One committee member steps up as a shepherd, and generates consensus within the committee within four or five weeks.
 
    `Committee process <#committee-process>`_ •
    `Review criteria <#review-criteria>`_ •
-   `≡ List of proposals waiting for shepherd <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+shepherd+recommendation%22>`_ •
    `≡ List of proposals under review <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+committee+review%22>`_
 
-6. Eventually, the committee rejects a proposal, or passes it back to the
-   author for review, or accepts it.
+6. Eventually, the committee rejects a proposal (label: Rejected), or passes it back to the
+   author for review (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_), or accepts it (label: Accepted).
 
    Acceptance of the proposal implies that the implementation will be accepted
    into GHC provided it is well-engineered, well-documented, and does not
    complicate the code-base too much.
 
-   `≡ List of accepted proposals <https://github.com/ghc-proposals/ghc-proposals/tree/master/proposals>`_
+   `≡ List of accepted proposals <https://github.com/ghc-proposals/ghc-proposals/tree/master/proposals>`_ •
+   `≡ List of proposals being revised <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_ •
+   `≡ List of rejected proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%Rejected%22>`_
 
-7. If a proposal sees no activity for along time, they are marked as “dormant”,
+7. Label: `Dormant <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Dormant>`_.  If a proposal sees no activity for along time, it is marked as “dormant”,
    and eventually closed.
 
    `What is a dormant proposal <#what-is-a-dormant-proposal>`_ •
    `≡ List of dormant proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22dormant%22>`_
 
 
-8. Once a proposal is accepted, it still has to be implemented.  The author
+8. Label: `Implemented <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_.   Once a proposal is accepted, it still has to be implemented.  The author
    may do that, or someone else. We mark the proposal as “implemented” once it
    hits GHC’s ``master`` branch (and we are happy to be nudged to do so by
    email or GitHub issue).

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,45 @@ g. *Implementation Plan* (Optional): If accepted who will implement the change? 
 
   This is also a good section to outline the changes to the implementation, or otherwise include insights that assume familiarity with the implementation.
 
+Here are some characteristics that a good proposal should have
+
+* It should be self-standing.  Some proposals accumulate a long and interesting discussion
+  thread, but in ten years time all that will be gone (except for the most assiduous readers).
+  Before acceptance, therefore, the proposal should be edited to reflect the fruits of
+  that dicussion, so that it can stand alone.
+
+* It should be precise, especially the "Proposed change specification"
+  section.  Language design is complicated, with lots of
+  interactions. It is not enough to offer a few suggestive examples
+  and hope that the reader can infer the rest.  Vague proposals waste
+  everyone's time; precision is highly valued.
+
+  We do not insist on a fully formal specification, with a
+  machine-checked proof.  There is no such baseline to work from, and
+  it would set the bar far too high.  On the other hand, for
+  proposals involving syntactic changes, it is very reasonable to ask for
+  a BNF for the changes.
+
+  Ultimately, the necessary degree of precision is a judgement that the committee
+  must make; but authors should try hard to offer precision.
+
+* It should offer evidence of utility.  Even the strongest proposals carry costs:
+
+  * For programmers: they usually make the language just a bit more complicated;
+  * For GHC maintainers: they make the implementation a bit more complicated;
+  * For those wanting to proposals in the future: they usually add new back-compat burdens, and consume syntactic design space.
+  * Moreover, all these costs contitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.
+
+  The tax may well be worth it (a language without polymorphism
+  would be simpler but we don't want it), but the case should be made.
+
+  The case is stronger if lots of people jump in saying "yes, this would be so
+  useful to me".  The committee is often faced with proposals that are reasonable,
+  but where there is a suspicion that no one other than the author cares.
+  Defusing this suspicion, by describing use-cases and inviting support from others,
+  is helpful.
+
+* It should be compiously iillustrated with examples, to aid understanding.
 
 Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ or `Markdown <https://github.github.com/gfm/>`_. While the proposal process itself has no preference, keep in mind that the `GHC Users Guide <http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/editing-guide.html>`_ uses ReStructuredText exclusively. Accepted proposals written in ReStructuredText thus have the slight benefit that they can be more easily included in the official GHC documentation.
 
@@ -212,11 +251,12 @@ comment or proposal, feel free to use GitHub's "Reactions"
 How to bring a proposal before the committee
 ---------------------------------------------
 
-When the discussion has ebbed down and the author thinks the proposal is ready, he
+When the discussion has ebbed down and the author thinks the proposal is ready, he or she
 
-1. reviews the discussion thread and ensure that the proposal text accounts for
-   all salient points.
-2. adds a comment to the a pull request, briefly summarizing the major points raised
+1. Reviews the discussion thread and ensure that the proposal text accounts for
+   all salient points. *Remember, the proposal must stand by itself, and be understandable
+   without reading the disucssion thread.* 
+2. Adds a comment to the a pull request, briefly summarizing the major points raised
    during the discussion period and stating your belief that the proposal is
    ready for review. In this comment, tag the committee secretary (currently
    ``@nomeata``).
@@ -274,6 +314,13 @@ Committee process
 The committee process starts once the secretary has been notified that a
 proposal is ready for decision.
 
+The steps below have timescales attached, show that everyone shares
+the same expectations.  But they are only reasonable expectations.
+The committee consists of volunteers with day jobs, who are reviewing
+proposals in their spare time.  If they do not meet the timescales
+indicated below (e.g they might be on holiday), a reasonable response
+is a polite ping/enquiry.
+
 -  The secretary nominates a member of the committee, the *shepherd*, to oversee
    the discussion. The secretary
 
@@ -284,7 +331,7 @@ proposal is ready for decision.
 
 -  Based on the proposal text (but not the GitHub commentary), the shepherd
    decides whether the proposal ought to be accepted or rejected or returned for
-   revision.
+   revision.  The shepherd should do this within two weeks.
 
 -  If the shepherd thinks the proposal ought to be rejected, they post their
    justifications on the GitHub thread, and invite the authors to respond with
@@ -309,17 +356,58 @@ proposal is ready for decision.
    * drop a short mail to the mailing list informing the committee that
      discussion has started.
 
--  Discussion among the committee ensues on the discussion thread.
-   Silence is understood as agreement with the shepherd's recommendation.
+-  Discussion among the committee ensues, in two places
+
+   * *Technical discussion* takes place on the discussion thread, where others may
+     continue contribute.
+
+   * *Evaluative discussion", about whether to accept, reject, or return the
+     proposal for revision, takes place on the committee's email list,
+     which others can read but not post to.
+
+   Silence is typically understood as agreement with the shepherd's recommendation.
    Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
 
+   This phase should conclude within a month.
+
+-  For acceptance, a proposal must have at least *some* enthusiastic support
+   from member(s) of the committee. The committee, fallible though its members may be,
+   is the guardian of the language.   If all of them are luke-warm about a change,
+   there is a presumption that it should be rejected, or at least "parked".
+   (See "evidence of utility" above, under "What a proposal should look like".)
+
+-  A typical situation is that the committee, now that they have been asked
+   to review the proposal in detail, unearths some substantive technical issues.
+   This is absolutely fine -- it is what the review process is *for*!
+
+   If the technical debate is not rapidly resolved, the shepherd
+   should return the proposal for revision. Further technical
+   discussion can then take place, the author can incorporate tha
+   conclusions in the proposal itself, and re-submit it.  Returning a
+   proposal for revision is not a negative judgement; on the contrary
+   it might connote "we absolutely love this proposal but we want it
+   to be clear on these points".
+
+   In fact, this should happen if *any* substantive technical debate
+   takes place.  The goal of the commitee review is to say yes/no to a
+   proposal *as it stands*.  If new issues come up, they should be
+   resolved, incorporated in the proposal, and the revised proposal
+   should then be re-submitted for timely yes/no decision.  In this way,
+   *no propoosal should languish in the committee review stage for long*,
+   and every proposal can be accepted as-is, rather than suject to a raft
+   of ill-specified futher modifications.
+
 -  The decision is announced, by the shepherd or the secretary, on the Github
    thread and the mailing list.
 
-   The secretary tags the pull request accordingly, and either merges or closes it.
-   In particular
+   Notwithstanding the return/resubmit cycle described above, it may be
+   that the shepherd accepts a proposal subject to some specified minor changes
+   to the proposal text.  In that case the author should carry them out.
+
+   The secretary then tags the pull request accordingly, and either
+   merges or closes it.  In particular
 
    *  **If we say no:**
       The pull request will be closed and labeled

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Here are some characteristics that a good proposal should have
   Defusing this suspicion, by describing use-cases and inviting support from others,
   is helpful.
 
-* It should be compiously iillustrated with examples, to aid understanding.
+* It should be compiously illustrated with examples, to aid understanding.
 
 Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ or `Markdown <https://github.github.com/gfm/>`_. While the proposal process itself has no preference, keep in mind that the `GHC Users Guide <http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/editing-guide.html>`_ uses ReStructuredText exclusively. Accepted proposals written in ReStructuredText thus have the slight benefit that they can be more easily included in the official GHC documentation.
 

--- a/README.rst
+++ b/README.rst
@@ -100,34 +100,12 @@ contributor to write a formal proposal.
 What should a proposal look like?
 ---------------------------------
 
-Each proposal document must follow the following outline. Templates are available for both `ReStructuredText <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, and `Markdown <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.
+Each proposal document must follow the outline in the proposal templates. Templates are available for both `ReStructuredText <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, and `Markdown <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.
 
-a. *Motivation*: Give a strong reason for why the community needs this change. Describe the use case as clearly as possible and give at least one concrete example. Explain how the status quo is insufficient or not ideal.
-
-b. *Proposed Change Specification*: Specify the change in precise and comprehensive yet concise language. Your specification may include,
-
-   - grammar and semantics of any new syntactic constructs
-   - the types and semantics of any new library interfaces
-   - how the proposed change addresses the original problem (perhaps referring back to the example)
-
-  The change should be phrased relative to the Haskell report and/or the GHC user manual. Do not assume familiarity with the implementation, and avoid referncing the implementation.
-
-c. *Effect and Interactions*. Detail how the proposed change addresses the original problem raised in the motivation. Detail how the proposed change interacts with existing language or compiler features. Think about what surprising or problematic interactions may occur.
-
-d. *Costs and Drawbacks*. What are the drawbacks and costs to the community should this change be implemented? For example, does this make Haskell harder to learn for novice users?  Does it make Haskell code harder to read or reason about? Will the implementation be complex or invasive?
-
-e. *Alternatives*: List alternatives to your proposed change and discuss why they are insufficient.
-
-f. *Unresolved questions*: Explicitly list any remaining issues that remain in the conceptual design and specification. Be upfront and trust that the community will help. Please do not list *implementation* issues.
-
-g. *Implementation Plan* (Optional): If accepted who will implement the change? It's quite okay to say "unknown" if you don't feel willing or able to carry out the implementation yourself.
-
-  This is also a good section to outline the changes to the implementation, or otherwise include insights that assume familiarity with the implementation.
-
-Here are some characteristics that a good proposal should have
+Here are some characteristics that a good proposal should have:
 
 * It should be self-standing.  Some proposals accumulate a long and interesting discussion
-  thread, but in ten years time all that will be gone (except for the most assiduous readers).
+  thread, but in ten years' time all that will be gone (except for the most assiduous readers).
   Before acceptance, therefore, the proposal should be edited to reflect the fruits of
   that dicussion, so that it can stand alone.
 
@@ -151,9 +129,9 @@ Here are some characteristics that a good proposal should have
   * For programmers: most proposals make the language just a bit more complicated;
   * For GHC maintainers:  most proposals make the implementation a bit more complicated;
   * For future proposers:  most proposals consume syntactic design space add/or add new back-compat burdens, both of which make new proposals harder to fit in.
-  * It is much, much harder subsequently to remove an extensiuon than it is to add it.
+  * It is much, much harder subsequently to remove an extension than it is to add it.
 
-  All these costs contitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.  The tax may well be worth it (a language without polymorphism
+  All these costs constitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.  The tax may well be worth it (a language without polymorphism
   would be simpler but we don't want it), but the case should be made.
 
   The case is stronger if lots of people jump in saying "yes, this would be so
@@ -162,7 +140,8 @@ Here are some characteristics that a good proposal should have
   Defusing this suspicion, by describing use-cases and inviting support from others,
   is helpful.
 
-* It should be compiously illustrated with examples, to aid understanding.
+* It should be copiously illustrated with examples, to aid understanding. However,
+  these examples should *not* be the specification.
 
 Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ or `Markdown <https://github.github.com/gfm/>`_. While the proposal process itself has no preference, keep in mind that the `GHC Users Guide <http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/editing-guide.html>`_ uses ReStructuredText exclusively. Accepted proposals written in ReStructuredText thus have the slight benefit that they can be more easily included in the official GHC documentation.
 
@@ -349,23 +328,22 @@ is a polite ping/enquiry.
 
    * post their recommendation, with a rationale, on the GitHub discussion thread,
    * label the pull request as ``Pending committee review``,
-   * notify the committee by mentioning ``@ghc-proposals/ghc-steering-committee``,
-   * include the sentence “This proposal will now be discussed by the committee.
-     We welcome all authors to join the discussion, but kindly ask others to
-     refrain from posting.” in the comment
+   * re-title the proposal, appending ``(under review)`` at the end. (This enables easy email filtering.)
    * drop a short mail to the mailing list informing the committee that
      discussion has started.
 
 -  Discussion among the committee ensues, in two places
 
    * *Technical discussion* takes place on the discussion thread, where others may
-     continue contribute.
+     continue to contribute.
 
    * *Evaluative discussion*, about whether to accept, reject, or return the
      proposal for revision, takes place on the committee's email list,
      which others can read but not post to.
 
-   Silence is typically understood as agreement with the shepherd's recommendation.
+   It is expected that every committee member express an opinion about every proposal under review.
+   The most minimal way to do this is to "thumbs-up" the shepherd's recommendation on GitHub.
+
    Ideally, the committee reaches consensus, as determined by the secretary or
    the shepherd. If consensus is elusive, then we vote, with the Simons
    retaining veto power.
@@ -398,6 +376,9 @@ is a polite ping/enquiry.
    *no propoosal should languish in the committee review stage for long*,
    and every proposal can be accepted as-is, rather than suject to a raft
    of ill-specified futher modifications.
+
+   The author of the proposal may invite committee collaboration on clarifying
+   technical points. There is a place to do this in the proposal template.
 
 -  The decision is announced, by the shepherd or the secretary, on the Github
    thread and the mailing list.

--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,10 @@ Here are some characteristics that a good proposal should have.  But see also "R
   All these costs constitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.  The tax may well be worth it (a language without polymorphism
   would be simpler but we don't want it), but the case should be made.
 
-  The case is stronger if lots of people jump in saying "yes, this would be so
-  useful to me".  The committee is often faced with proposals that are reasonable,
+  The case is stronger if lots of people express support by giving a "thumbs-up"
+  in GitHub. Even better is the community contributes new examples that illustrate
+  how the proposal will be broadly useful.
+  The committee is often faced with proposals that are reasonable,
   but where there is a suspicion that no one other than the author cares.
   Defusing this suspicion, by describing use-cases and inviting support from others,
   is helpful.
@@ -230,12 +232,12 @@ comment or proposal, feel free to use GitHub's "Reactions"
 How to bring a proposal before the committee
 ---------------------------------------------
 
-When the discussion has ebbed down and the author thinks the proposal is ready, he or she
+When the discussion has ebbed down and the author thinks the proposal is ready, they
 
-1. Reviews the discussion thread and ensure that the proposal text accounts for
+1. Review the discussion thread and ensure that the proposal text accounts for
    all salient points. *Remember, the proposal must stand by itself, and be understandable
    without reading the discussion thread.* 
-2. Adds a comment to the a pull request, briefly summarizing the major points raised
+2. Add a comment to the a pull request, briefly summarizing the major points raised
    during the discussion period and stating your belief that the proposal is
    ready for review. In this comment, tag the committee secretary (currently
    ``@nomeata``).
@@ -293,7 +295,7 @@ Committee process
 The committee process starts once the secretary has been notified that a
 proposal is ready for decision.
 
-The steps below have timescales attached, show that everyone shares
+The steps below have timescales attached, so that everyone shares
 the same expectations.  But they are only reasonable expectations.
 The committee consists of volunteers with day jobs, who are reviewing
 proposals in their spare time.  If they do not meet the timescales
@@ -328,7 +330,7 @@ is a polite ping/enquiry.
 
    * post their recommendation, with a rationale, on the GitHub discussion thread,
    * label the pull request as ``Pending committee review``,
-   * re-title the proposal, appending ``(under review)`` at the end. (This enables easy email filtering.)
+   * re-title the proposal pull request, appending ``(under review)`` at the end. (This enables easy email filtering.)
    * drop a short mail to the mailing list informing the committee that
      discussion has started.
 
@@ -373,12 +375,15 @@ is a polite ping/enquiry.
    proposal *as it stands*.  If new issues come up, they should be
    resolved, incorporated in the proposal, and the revised proposal
    should then be re-submitted for timely yes/no decision.  In this way,
-   *no propoosal should languish in the committee review stage for long*,
-   and every proposal can be accepted as-is, rather than suject to a raft
+   *no proposal should languish in the committee review stage for long*,
+   and every proposal can be accepted as-is, rather than subject to a raft
    of ill-specified further modifications.
 
    The author of the proposal may invite committee collaboration on clarifying
-   technical points. There is a place to do this in the proposal template.
+   technical points; conversely members of the committee may offer such help.
+
+   When a proposal is returned for revision, GitHub labels are updated accordingly
+   and the ``(under review)`` suffix is removed from the title of the PR.
 
 -  The decision is announced, by the shepherd or the secretary, on the Github
    thread and the mailing list.
@@ -444,7 +449,7 @@ and any other relevant considerations, appropriately.
 -  *Does not create a language fork*.  By a "fork" we mean
 
   * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"; 
-  * And it also fails the test "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the propoosal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
+  * And it also fails the test "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the proposal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
    
    The idea is that unless we can see a path to a point where everyone has the extension turned on, we're left with different groups of people using incompatible dialects of the language. A similar problem arises with extensions that are mutually incompatible.
 

--- a/README.rst
+++ b/README.rst
@@ -443,8 +443,8 @@ and any other relevant considerations appropriately.
    
 -  *Does not create a language fork*.  By a "fork" we mean
 
-  * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"; and if not,
-  * It fails the rest "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the propoosal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
+  * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"; 
+  * And it also fails the test "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the propoosal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
    
    The idea is that unless we can see a path to a point where everyone has the extension turned on, we're left with different groups of people using incompatible dialects of the language. A similar problem arises with extensions that are mutually incompatible.
 

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ What should a proposal look like?
 
 Each proposal document must follow the outline in the proposal templates. Templates are available for both `ReStructuredText <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, and `Markdown <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.
 
-Here are some characteristics that a good proposal should have:
+Here are some characteristics that a good proposal should have.  But see also "Review criteria" below, for further guidance about the critera used to evaluate proposals.
 
 * It should be self-standing.  Some proposals accumulate a long and interesting discussion
   thread, but in ten years' time all that will be gone (except for the most assiduous readers).
@@ -439,6 +439,13 @@ and any other relevant considerations appropriately.
    solutions, none of which have that "aha" feeling of "this is the Right
    Way to solve this"; in that case we might delay rather than forge ahead
    regardless.
+   
+-  *Does not create a language fork*.  By a "fork" we mean
+
+  * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"
+  * It fails the rest "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the propoosal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
+   
+   The idea is that unless we can see a path to a point where everyone has the extension turned on, we're left with different groups of people using incompatible dialects of the language. A similar problem arises with extensions that are mutually incompatible.
 
 -  *Fit with the language.* If we just throw things into GHC
    willy-nilly, it will become a large ball of incoherent and

--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ is a polite ping/enquiry.
    * *Technical discussion* takes place on the discussion thread, where others may
      continue contribute.
 
-   * *Evaluative discussion", about whether to accept, reject, or return the
+   * *Evaluative discussion*, about whether to accept, reject, or return the
      proposal for revision, takes place on the committee's email list,
      which others can read but not post to.
 

--- a/README.rst
+++ b/README.rst
@@ -420,8 +420,9 @@ Review criteria
 ---------------
 
 Below are some criteria that the committee and the supporting GHC
-community will generally use to evaluate a proposal. Note that this list
-is merely set of a guidelines; it is the committee's job to weigh these
+community will generally use to evaluate a proposal. This list
+is merely set of a guidelines and questions to consider; none is an absolute bar.
+It is the committee's job to weigh these
 and any other relevant considerations appropriately.
 
 -  *Utility and user demand*. What exactly is the problem that the

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,33 @@ GHC.
 * `≡ List of implemented proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_
 * `≡ List of all proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=>`_
 
+What is a proposal?
+-------------------
+
+A GHC Proposal is a document describing a proposed change to the compiler, the
+GHC/Haskell language, or the libraries in the ``GHC.*`` module namespace. These
+include,
+
+* A syntactic change to GHC/Haskell (e.g. the various ``ShortImports``
+  `proposals <https://gitlab.haskell.org/ghc/ghc/issues/10478>`_, ``do``
+  `expressions <https://gitlab.haskell.org/ghc/ghc/issues/10843>`_ without ``$``)
+
+* A major change to the user-visible behaviour of the compiler (e.g. the recent
+  `change <https://gitlab.haskell.org/ghc/ghc/issues/11762>`_ in super-class
+  solving, and ``-Wall`` `behavior <https://gitlab.haskell.org/ghc/ghc/issues/11370>`_)
+
+* The addition of major features to the compiler (e.g. ``-XTypeInType``, GHCi
+  `commands <https://gitlab.haskell.org/ghc/ghc/issues/10874>`_,
+  `type-indexed <https://gitlab.haskell.org/ghc/ghc/wikis/typeable>`_
+  ``Typeable`` representations)
+
+Changes to the GHC API or the plugin API are not automatically within the scope
+of the committee, and can be contributed following the usual GHC workflow.
+Should the GHC maintainers deem a change significant or controversial enough to
+warrant that, they may, at their discretion, involve the committee and ask the
+contributor to write a formal proposal.
+
+
 The life cycle of a proposal
 -----------------------------------
 
@@ -48,7 +75,7 @@ This section outlines what stages a proposal may go through. The stage is identi
    `≡ List of proposals under review <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Pending+committee+review%22>`_
 
 6. Eventually, the committee rejects a proposal (label: Rejected), or passes it back to the
-   author for review (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_), or accepts it (label: Accepted).
+   author for review (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_), or accepts it (label: `Needs revision <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Accepted%22>`_).
 
    Acceptance of the proposal implies that the implementation will be accepted
    into GHC provided it is well-engineered, well-documented, and does not
@@ -61,7 +88,7 @@ This section outlines what stages a proposal may go through. The stage is identi
 7. Label: `Dormant <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22Dormant>`_.  If a proposal sees no activity for along time, it is marked as “dormant”,
    and eventually closed.
 
-   `What is a dormant proposal <#what-is-a-dormant-proposal>`_ •
+   `What is a dormant proposal? <#what-is-a-dormant-proposal>`_ •
    `≡ List of dormant proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22dormant%22>`_
 
 
@@ -74,85 +101,12 @@ This section outlines what stages a proposal may go through. The stage is identi
 
 Do not hesitate to `contact <#questions>`_ us if you have questions.
 
-What is a proposal?
--------------------
-
-A GHC Proposal is a document describing a proposed change to the compiler, the
-GHC/Haskell language, or the libraries in the ``GHC.*`` module namespace. These
-include,
-
-* A syntactic change to GHC/Haskell (e.g. the various ``ShortImports``
-  `proposals <https://gitlab.haskell.org/ghc/ghc/issues/10478>`_, ``do``
-  `expressions <https://gitlab.haskell.org/ghc/ghc/issues/10843>`_ without ``$``)
-
-* A major change to the user-visible behaviour of the compiler (e.g. the recent
-  `change <https://gitlab.haskell.org/ghc/ghc/issues/11762>`_ in super-class
-  solving, and ``-Wall`` `behavior <https://gitlab.haskell.org/ghc/ghc/issues/11370>`_)
-
-* The addition of major features to the compiler (e.g. ``-XTypeInType``, GHCi
-  `commands <https://gitlab.haskell.org/ghc/ghc/issues/10874>`_,
-  `type-indexed <https://gitlab.haskell.org/ghc/ghc/wikis/typeable>`_
-  ``Typeable`` representations)
-
-Changes to the GHC API or the plugin API are not automatically within the scope
-of the committee, and can be contributed following the usual GHC workflow.
-Should the GHC maintainers deem a change significant or controversial enough to
-warrant that, they may, at their discretion, involve the committee and ask the
-contributor to write a formal proposal.
-
-
-What should a proposal look like?
----------------------------------
-
-Each proposal document must follow the outline in the proposal templates. Templates are available for both `ReStructuredText <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, and `Markdown <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.
-
-Here are some characteristics that a good proposal should have.  But see also "Review criteria" below, for further guidance about the critera used to evaluate proposals.
-
-* It should be self-standing.  Some proposals accumulate a long and interesting discussion
-  thread, but in ten years' time all that will be gone (except for the most assiduous readers).
-  Before acceptance, therefore, the proposal should be edited to reflect the fruits of
-  that dicussion, so that it can stand alone.
-
-* It should be precise, especially the "Proposed change specification"
-  section.  Language design is complicated, with lots of
-  interactions. It is not enough to offer a few suggestive examples
-  and hope that the reader can infer the rest.  Vague proposals waste
-  everyone's time; precision is highly valued.
-
-  We do not insist on a fully formal specification, with a
-  machine-checked proof.  There is no such baseline to work from, and
-  it would set the bar far too high.  On the other hand, for
-  proposals involving syntactic changes, it is very reasonable to ask for
-  a BNF for the changes.
-
-  Ultimately, the necessary degree of precision is a judgement that the committee
-  must make; but authors should try hard to offer precision.
-
-* It should offer evidence of utility.  Even the strongest proposals carry costs:
-
-  * For programmers: most proposals make the language just a bit more complicated;
-  * For GHC maintainers:  most proposals make the implementation a bit more complicated;
-  * For future proposers:  most proposals consume syntactic design space add/or add new back-compat burdens, both of which make new proposals harder to fit in.
-  * It is much, much harder subsequently to remove an extension than it is to add it.
-
-  All these costs constitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.  The tax may well be worth it (a language without polymorphism
-  would be simpler but we don't want it), but the case should be made.
-
-  The case is stronger if lots of people express support by giving a "thumbs-up"
-  in GitHub. Even better is the community contributes new examples that illustrate
-  how the proposal will be broadly useful.
-  The committee is often faced with proposals that are reasonable,
-  but where there is a suspicion that no one other than the author cares.
-  Defusing this suspicion, by describing use-cases and inviting support from others,
-  is helpful.
-
-* It should be copiously illustrated with examples, to aid understanding. However,
-  these examples should *not* be the specification.
+How to start a new proposal
+---------------------------
 
 Proposals are written in either `ReStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ or `Markdown <https://github.github.com/gfm/>`_. While the proposal process itself has no preference, keep in mind that the `GHC Users Guide <http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/editing-guide.html>`_ uses ReStructuredText exclusively. Accepted proposals written in ReStructuredText thus have the slight benefit that they can be more easily included in the official GHC documentation.
 
-How to start a new proposal
----------------------------
+Poposals should follow the structure given in the `ReStructuredText template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.rst>`_, or the `Markdown template <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0000-template.md>`_.  (The two are identical except for format.)
 
 To start a proposal, create a pull request that adds your proposal as ``proposals/0000-proposal-name.rst`` or ``proposals/0000-proposal-name.md``. Use the corresponding ``proposals/0000-template`` file as a template.
 
@@ -427,6 +381,49 @@ is a polite ping/enquiry.
 
 Review criteria
 ---------------
+Here are some characteristics that a good proposal should have.
+
+* *It should be self-standing*.  Some proposals accumulate a long and interesting discussion
+  thread, but in ten years' time all that will be gone (except for the most assiduous readers).
+  Before acceptance, therefore, the proposal should be edited to reflect the fruits of
+  that dicussion, so that it can stand alone.
+
+* *It should be precise*, especially the "Proposed change specification"
+  section.  Language design is complicated, with lots of
+  interactions. It is not enough to offer a few suggestive examples
+  and hope that the reader can infer the rest.  Vague proposals waste
+  everyone's time; precision is highly valued.
+
+  We do not insist on a fully formal specification, with a
+  machine-checked proof.  There is no such baseline to work from, and
+  it would set the bar far too high.  On the other hand, for
+  proposals involving syntactic changes, it is very reasonable to ask for
+  a BNF for the changes.
+
+  Ultimately, the necessary degree of precision is a judgement that the committee
+  must make; but authors should try hard to offer precision.
+
+* *It should offer evidence of utility*.  Even the strongest proposals carry costs:
+
+  * For programmers: most proposals make the language just a bit more complicated;
+  * For GHC maintainers:  most proposals make the implementation a bit more complicated;
+  * For future proposers:  most proposals consume syntactic design space add/or add new back-compat burdens, both of which make new proposals harder to fit in.
+  * It is much, much harder subsequently to remove an extension than it is to add it.
+
+  All these costs constitute a permanent tax on every future programmer, langauge designer, and GHC maintainer.
+  The tax may well be worth it (a language without polymorphism
+  would be simpler but we don't want it), but the case should be made.
+
+  The case is stronger if lots of people express support by giving a "thumbs-up"
+  in GitHub. Even better is the community contributes new examples that illustrate
+  how the proposal will be broadly useful.
+  The committee is often faced with proposals that are reasonable,
+  but where there is a suspicion that no one other than the author cares.
+  Defusing this suspicion, by describing use-cases and inviting support from others,
+  is helpful.
+
+* *It should be copiously illustrated with examples*, to aid understanding. However,
+  these examples should *not* be the specification.
 
 Below are some criteria that the committee and the supporting GHC
 community will generally use to evaluate a proposal. These criteria
@@ -438,7 +435,10 @@ and any other relevant considerations, appropriately.
    feature solves? Is it an important problem, felt by many users, or is
    it very specialised? The whole point of a new feature is to be useful
    to people, so a good proposal will explain why this is so, and
-   ideally offer evidence of some form.
+   ideally offer evidence of some form.  The "Endorsements" section of
+   the proposal provides an opportunity for third parties to express
+   their support for the proposal, and the reasons they would like to
+   see it adopted.
 
 -  *Elegant and principled*. Haskell is a beautiful and principled
    language. It is tempting to pile feature upon feature (and GHC
@@ -449,12 +449,12 @@ and any other relevant considerations, appropriately.
    solutions, none of which have that "aha" feeling of "this is the Right
    Way to solve this"; in that case we might delay rather than forge ahead
    regardless.
-   
+
 -  *Does not create a language fork*.  By a "fork" we mean
 
   * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"; 
   * And it also fails the test "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the proposal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
-   
+
    The idea is that unless we can see a path to a point where everyone has the extension turned on, we're left with different groups of people using incompatible dialects of the language. A similar problem arises with extensions that are mutually incompatible.
 
 -  *Fit with the language.* If we just throw things into GHC

--- a/README.rst
+++ b/README.rst
@@ -247,7 +247,7 @@ When the discussion has ebbed down and the author thinks the proposal is ready, 
 <#committee-process>`_.  (If this does not happen within a day or two, please
 ping the secretary or the committee.)
 
-What is a dormant proposal
+What is a dormant proposal?
 --------------------------
 
 In order to keep better track of actively discussed proposals, proposals that
@@ -258,7 +258,7 @@ proposal by picking up the discussion (and possibly asking `the secretary
 
 You can see the `list of dormant proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Aopen+is%3Apr+label%3A%22dormant%22>`_.
 
-Who is the committee
+Who is the committee?
 --------------------
 You can reach the committee by email at ghc-steering-committee@haskell.org:
 

--- a/README.rst
+++ b/README.rst
@@ -420,10 +420,10 @@ Review criteria
 ---------------
 
 Below are some criteria that the committee and the supporting GHC
-community will generally use to evaluate a proposal. This list
-is merely set of a guidelines and questions to consider; none is an absolute bar.
-It is the committee's job to weigh these
-and any other relevant considerations appropriately.
+community will generally use to evaluate a proposal. These criteria
+are guidelines and questions that the committee will consider.
+None of these criteria is an absolute bar: it is the committee's job to weigh them,
+and any other relevant considerations, appropriately.
 
 -  *Utility and user demand*. What exactly is the problem that the
    feature solves? Is it an important problem, felt by many users, or is

--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ When the discussion has ebbed down and the author thinks the proposal is ready, 
 
 1. Reviews the discussion thread and ensure that the proposal text accounts for
    all salient points. *Remember, the proposal must stand by itself, and be understandable
-   without reading the disucssion thread.* 
+   without reading the discussion thread.* 
 2. Adds a comment to the a pull request, briefly summarizing the major points raised
    during the discussion period and stating your belief that the proposal is
    ready for review. In this comment, tag the committee secretary (currently
@@ -362,7 +362,7 @@ is a polite ping/enquiry.
 
    If the technical debate is not rapidly resolved, the shepherd
    should return the proposal for revision. Further technical
-   discussion can then take place, the author can incorporate tha
+   discussion can then take place, the author can incorporate that
    conclusions in the proposal itself, and re-submit it.  Returning a
    proposal for revision is not a negative judgement; on the contrary
    it might connote "we absolutely love this proposal but we want it
@@ -375,7 +375,7 @@ is a polite ping/enquiry.
    should then be re-submitted for timely yes/no decision.  In this way,
    *no propoosal should languish in the committee review stage for long*,
    and every proposal can be accepted as-is, rather than suject to a raft
-   of ill-specified futher modifications.
+   of ill-specified further modifications.
 
    The author of the proposal may invite committee collaboration on clarifying
    technical points. There is a place to do this in the proposal template.
@@ -442,7 +442,7 @@ and any other relevant considerations appropriately.
    
 -  *Does not create a language fork*.  By a "fork" we mean
 
-  * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"
+  * It fails the test "Is this extension something that most people would be happy to enable, even if they don't want to use it?"; and if not,
   * It fails the rest "Do we think there's a reasonable chance this extension will make it into a future language standard?"; that is, the propoosal reflects the stylistic preferences of a subset of the Haskell community, rather than a consensus about the direction that (in the committee's judgement) we want to push the whole language.
    
    The idea is that unless we can see a path to a point where everyone has the extension turned on, we're left with different groups of people using incompatible dialects of the language. A similar problem arises with extensions that are mutually incompatible.

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -89,9 +89,9 @@ and prerequisites are required for implementation?
 ## Endorsements
 
 (Optional) This section provides an opportunty for any third parties to express their
-support for the proposal, and to say why they wuuld like to see it adopted.
+support for the proposal, and to say why they would like to see it adopted.
 It is not mandatory for have any endorsements at all, but the substantial
-teh proposal is, the more desirable it is to offer evidence that there is
+the proposal is, the more desirable it is to offer evidence that there is
 significant demand from the community.  This section is one way to provide
 such evidence.
 

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -81,24 +81,6 @@ Hopefully this section will be empty by the time the proposal is brought to
 the steering committee.
 
 
-## Proposal Collaboration
-
-Choose **one** of the following two statements (and delete the other), or write
-your own that addresses this theme:
-
-1. Writing precise specifications is hard. Accordingly, I invite the committee
-   members to collaborate in writing this proposal, helping to make the specification
-   of my new features as tight as possible and easiest to implement. These
-   external contributions are meant to clarify my intent, not change it, and I retain
-   the ability to shape the final proposal.
-   
-2. Writing precise specifications is hard. Accordingly, I seek to increase my
-   ability to perform this skill and welcome constructive, detailed criticism
-   in how to make my specification more precise. I recognize that doing so may
-   take many rounds and will interpret others' advice as a way to improve my
-   craft. If I get frustrated with the process, I will speak up early.
-
-
 ## Implementation Plan
 
 (Optional) If accepted who will implement the change? Which other resources

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -31,7 +31,7 @@ Specify the change in precise, comprehensive yet concise language. Avoid words
 like "should" or "could". Strive for a complete definition. Your specification
 may include,
 
-* grammar and semantics of any new syntactic constructs
+* BNF grammar and semantics of any new syntactic constructs
 * the types and semantics of any new library interfaces
 * how the proposed change interacts with existing language or compiler
   features, in case that is otherwise ambiguous
@@ -79,6 +79,24 @@ not list *implementation* issues.
 
 Hopefully this section will be empty by the time the proposal is brought to
 the steering committee.
+
+
+## Proposal Collaboration
+
+Choose **one** of the following two statements (and delete the other), or write
+your own that addresses this theme:
+
+1. Writing precise specifications is hard. Accordingly, I invite the committee
+   members to collaborate in writing this proposal, helping to make the specification
+   of my new features as tight as possible and easiest to implement. These
+   external contributions are meant to clarify my intent, not change it, and I retain
+   the ability to shape the final proposal.
+   
+2. Writing precise specifications is hard. Accordingly, I seek to increase my
+   ability to perform this skill and welcome constructive, detailed criticism
+   in how to make my specification more precise. I recognize that doing so may
+   take many rounds and will interpret others' advice as a way to improve my
+   craft. If I get frustrated with the process, I will speak up early.
 
 
 ## Implementation Plan

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -90,7 +90,7 @@ and prerequisites are required for implementation?
 
 (Optional) This section provides an opportunty for any third parties to express their
 support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the substantial
+It is not mandatory for have any endorsements at all, but the more substantial
 the proposal is, the more desirable it is to offer evidence that there is
 significant demand from the community.  This section is one way to provide
 such evidence.

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -86,3 +86,12 @@ the steering committee.
 (Optional) If accepted who will implement the change? Which other resources
 and prerequisites are required for implementation?
 
+## Endorsements
+
+(Optional) This section provides an opportunty for any third parties to express their
+support for the proposal, and to say why they wuuld like to see it adopted.
+It is not mandatory for have any endorsements at all, but the substantial
+teh proposal is, the more desirable it is to offer evidence that there is
+significant demand from the community.  This section is one way to provide
+such evidence.
+

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -100,23 +100,6 @@ Hopefully this section will be empty by the time the proposal is brought to
 the steering committee.
 
 
-Proposal Collaboration
-----------------------
-Choose **one** of the following two statements (and delete the other), or write
-your own that addresses this theme:
-
-1. Writing precise specifications is hard. Accordingly, I invite the committee
-   members to collaborate in writing this proposal, helping to make the specification
-   of my new features as tight as possible and easiest to implement. These
-   external contributions are meant to clarify my intent, not change it, and I retain
-   the ability to shape the final proposal.
-   
-2. Writing precise specifications is hard. Accordingly, I seek to increase my
-   ability to perform this skill and welcome constructive, detailed criticism
-   in how to make my specification more precise. I recognize that doing so may
-   take many rounds and will interpret others' advice as a way to improve my
-   craft. If I get frustrated with the process, I will speak up early.
-
 Implementation Plan
 -------------------
 (Optional) If accepted who will implement the change? Which other resources

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -109,7 +109,7 @@ Endorsements
 -------------
 (Optional) This section provides an opportunty for any third parties to express their
 support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the substantial
+It is not mandatory for have any endorsements at all, but the more substantial
 the proposal is, the more desirable it is to offer evidence that there is
 significant demand from the community.  This section is one way to provide
 such evidence.

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -50,7 +50,7 @@ Specify the change in precise, comprehensive yet concise language. Avoid words
 like "should" or "could". Strive for a complete definition. Your specification
 may include,
 
-* grammar and semantics of any new syntactic constructs
+* BNF grammar and semantics of any new syntactic constructs
 * the types and semantics of any new library interfaces
 * how the proposed change interacts with existing language or compiler
   features, in case that is otherwise ambiguous
@@ -99,6 +99,23 @@ not list *implementation* issues.
 Hopefully this section will be empty by the time the proposal is brought to
 the steering committee.
 
+
+Proposal Collaboration
+----------------------
+Choose **one** of the following two statements (and delete the other), or write
+your own that addresses this theme:
+
+1. Writing precise specifications is hard. Accordingly, I invite the committee
+   members to collaborate in writing this proposal, helping to make the specification
+   of my new features as tight as possible and easiest to implement. These
+   external contributions are meant to clarify my intent, not change it, and I retain
+   the ability to shape the final proposal.
+   
+2. Writing precise specifications is hard. Accordingly, I seek to increase my
+   ability to perform this skill and welcome constructive, detailed criticism
+   in how to make my specification more precise. I recognize that doing so may
+   take many rounds and will interpret others' advice as a way to improve my
+   craft. If I get frustrated with the process, I will speak up early.
 
 Implementation Plan
 -------------------

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -108,8 +108,8 @@ and prerequisites are required for implementation?
 Endorsements
 -------------
 (Optional) This section provides an opportunty for any third parties to express their
-support for the proposal, and to say why they wuuld like to see it adopted.
+support for the proposal, and to say why they would like to see it adopted.
 It is not mandatory for have any endorsements at all, but the substantial
-teh proposal is, the more desirable it is to offer evidence that there is
+the proposal is, the more desirable it is to offer evidence that there is
 significant demand from the community.  This section is one way to provide
 such evidence.

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -104,3 +104,12 @@ Implementation Plan
 -------------------
 (Optional) If accepted who will implement the change? Which other resources
 and prerequisites are required for implementation?
+
+Endorsements
+-------------
+(Optional) This section provides an opportunty for any third parties to express their
+support for the proposal, and to say why they wuuld like to see it adopted.
+It is not mandatory for have any endorsements at all, but the substantial
+teh proposal is, the more desirable it is to offer evidence that there is
+significant demand from the community.  This section is one way to provide
+such evidence.


### PR DESCRIPTION
This PR is my attempt to write down clearer expectations about the GHC proposals process.

Particularly

1. The need for precision
2. The idea that a proposal should not languish under committee review for long; but may well be returned for revision without any negative implication.  (As I did yesterday for Richard's role-inference proposal, which I basically like.)
3. Clearly stating that a proposal should be accepted/rejected as-is.  If it needs modification (a typical case) it should be returned fro revision.
4.  Adding explicit timescale expectations so authors know wnen to time out.

All of this is, of course, for the committee to debate.