### PR TITLE
RFC: Give error messages unique reference IDs

### DIFF
--- a/proposals/new-proposal.md
+++ b/proposals/new-proposal.md
@@ -6,7 +6,7 @@ ticket-url: "https://github.com/ghc-proposals/ghc-proposals/pull/325"
 implemented: ""
 ---
 
-This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/325>).
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/325   ).
 
 # Give error messages unique reference IDs
 

--- a/proposals/new-proposal.md
+++ b/proposals/new-proposal.md
@@ -1,0 +1,39 @@
+---
+author: Your name
+date-accepted: ""
+proposal-number: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
+**After creating the pull request, edit this file again, update the number in
+the link, and delete this bold sentence.**
+
+# Give error messages unique reference IDs
+
+This is an idea I've thought about and assumed there is a good reason software doesn't do this.
+
+Mark error messages with some kind of ID
+
+```haskell
+> class a
+
+<interactive>:5:7: error:
+    [GHCERR_b356c55] Malformed head of type or class declaration: a
+```
+
+that way if we completely rewrite the error message we can still
+search for "`GHCERR_b356c55`" and will get results for *both* versions. 
+
+```haskell
+> class a
+
+<interactive>:5:7: error:
+    [GHCERR_b356c55] Hey you really can't write such things: a
+```
+
+
+## Motivation
+
+This is basically for better googling, it would clutter the error messages but I am curious about the discussion.

--- a/proposals/new-proposal.md
+++ b/proposals/new-proposal.md
@@ -1,14 +1,12 @@
 ---
-author: Your name
+author: Baldur Blöndal
 date-accepted: ""
-proposal-number: ""
-ticket-url: ""
+proposal-number: "325"
+ticket-url: "https://github.com/ghc-proposals/ghc-proposals/pull/325"
 implemented: ""
 ---
 
-This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
-**After creating the pull request, edit this file again, update the number in
-the link, and delete this bold sentence.**
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/325>).
 
 # Give error messages unique reference IDs
 


### PR DESCRIPTION
[Rendered](https://github.com/ghc-proposals/ghc-proposals/blob/948f2ab7c98b15e47dbe25185b19f4caec3554b6/proposals/new-proposal.md).

Discussion: Assign an ID to every error message:

```haskell
> class a

<interactive>:5:7: error:
    [GHCERR_b356c55] Malformed head of type or class declaration: a
```

"`GHCERR_b356c55`" lets you find e.g. StackOverflow answers even if the error message changes

```haskell
> class a

<interactive>:5:7: error:
    [GHCERR_b356c55] Hey you really can't write such things: a
```

I'm curious what you think