### PR TITLE
Add concrete acceptance steps to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,6 +395,28 @@ is a polite ping/enquiry.
       proposal with the implementation status (i.e. ticket URL and the
       first version of GHC implementing it.)
 
+      Concretely, a committee member must perform the following steps:
+
+      1. Add a new commit on top of the PR branch that:
+
+         a. Changes the filename of the proposal to correspond to the PR number.
+
+         b. Updates any metadata fields that may have changed in ``master`` since
+            the PR branch split off.
+
+         c. Fills in these metadata fields as appropriate, including changing "is discussed"
+            to "was discussed".
+
+      2. Merge the PR branch into master, and push.
+
+      3. Update the PR description:
+
+         a. Update the "Rendered" link to point to the permanent home
+         of the accepted proposal.
+
+         b. Add the text "The proposal has been accepted; the following discussion is mostly of historic interest."
+
+      4. Set the PR to have the "Accepted" label.
 
 Review criteria
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -418,6 +418,10 @@ is a polite ping/enquiry.
 
       4. Set the PR to have the "Accepted" label.
 
+      5. Comment on the PR that the proposal was accepted.
+
+      6. Close the PR if GitHub has not detected the merge.
+
 Review criteria
 ---------------
 Here are some characteristics that a good proposal should have.

--- a/README.rst
+++ b/README.rst
@@ -409,18 +409,19 @@ is a polite ping/enquiry.
 
       2. Merge the PR branch into master, and push.
 
-      3. Update the PR description:
+      3. Update the PR description to start
+         with the text "The proposal has been accepted; the following discussion is mostly of historic interest."
+         where the word "proposal" links to the final rendered version pushed above.
 
-         a. Update the "Rendered" link to point to the permanent home
-         of the accepted proposal.
+      4. If the PR title has "(under review)", remove it.
+         
+      5. Set the PR to have the "Accepted" label.
 
-         b. Add the text "The proposal has been accepted; the following discussion is mostly of historic interest."
+      6. Comment on the PR that the proposal was accepted.
 
-      4. Set the PR to have the "Accepted" label.
+      7. Close the PR if GitHub has not detected the merge.
 
-      5. Comment on the PR that the proposal was accepted.
-
-      6. Close the PR if GitHub has not detected the merge.
+      8. Announce on the committee mailing list.
 
 Review criteria
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -401,7 +401,7 @@ is a polite ping/enquiry.
 
          a. Changes the filename of the proposal to correspond to the PR number.
 
-         b. Updates any metadata fields that may have changed in ``master`` since
+         b. Updates any metadata fields that may have changed in the template on ``master`` since
             the PR branch split off.
 
          c. Fills in these metadata fields as appropriate, including changing "is discussed"


### PR DESCRIPTION
In an attempt to share @nomeata's burden as secretary, I'd like to start merging my own acceptances. I believe I have outlined the concrete steps to take in this PR, but I would love confirmation.

For the rendered view, scroll up just a bit before [this heading](https://github.com/goldfirere/ghc-proposals/tree/concrete-acceptance#review-criteria).