### PR TITLE
Add banana and Unicode brackets to propsal #229

### DIFF
--- a/proposals/0229-whitespace-bang-patterns.rst
+++ b/proposals/0229-whitespace-bang-patterns.rst
@@ -101,6 +101,12 @@ Proposed Change Specification
 * Under ``-XTemplateHaskell``, classify ``[|``, ``[||``, ``[p|``, ``[t``, and
   so on, as opening; and ``|]``, ``||]``, as closing.
 
+* Under ``-XArrows``, classify ``(|`` as opening and ``|)`` as closing.
+
+* Under ``-XUnicodeSyntax``, classify ``⟦`` as opening and ``⟧`` as closing if
+  ``-XTemplatehHaskell`` is also enabled, as well as ``⦇`` as opening and ``⦈``
+  as closing if ``-XArrows`` is also enabled.
+
 * Any unqualified ``varsym`` is interpreted as "prefix", "suffix", "tight
   infix", or "loose infix", based on the preceding and following lexical
   non-terminals:

--- a/proposals/0229-whitespace-bang-patterns.rst
+++ b/proposals/0229-whitespace-bang-patterns.rst
@@ -104,7 +104,7 @@ Proposed Change Specification
 * Under ``-XArrows``, classify ``(|`` as opening and ``|)`` as closing.
 
 * Under ``-XUnicodeSyntax``, classify ``⟦`` as opening and ``⟧`` as closing if
-  ``-XTemplatehHaskell`` is also enabled, as well as ``⦇`` as opening and ``⦈``
+  ``-XTemplateHaskell`` is also enabled, as well as ``⦇`` as opening and ``⦈``
   as closing if ``-XArrows`` is also enabled.
 
 * Any unqualified ``varsym`` is interpreted as "prefix", "suffix", "tight


### PR DESCRIPTION
Classify the brackets `(|`, `|)`, `⟦`, `⟧`, `⦇`, and `⦈` as opening/closing tokens under the extensions that enable them.

See also: GHC [Issue #18225](https://gitlab.haskell.org/ghc/ghc/issues/18225) and [Merge Request !3339](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3339).