### PR TITLE
Rename 229 and change handling of prefix @

### DIFF
--- a/proposals/0229-whitespace-bang-patterns.rst
+++ b/proposals/0229-whitespace-bang-patterns.rst
@@ -1,10 +1,10 @@
-Simplify parsing of (~) and (!)
-===============================
+Whitespace-sensitive operator parsing (~, !, @, $, $$, -)
+=========================================================
 
 .. date-accepted:: 2019-08-24
 .. author:: Vladislav Zavialov
 .. ticket-url::
-.. implemented::
+.. implemented:: 8.12
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/229>`_.
 .. contents::
@@ -153,8 +153,8 @@ Proposed Change Specification
   ``(-x)`` is prefix negation. This change is to be guarded behind a new
   language extension ``-XLexicalNegation``.
 
-* The prefix ``@`` override is guarded behind the ``-XTypeApplications``
-  extension flag.
+* The prefix ``@`` override is no longer guarded behind the ``-XTypeApplications``
+  extension flag for the sake of improved error messages.
 
 * The prefix ``$`` and ``$$`` overrides are guarded behind the
   ``-XTemplateHaskell`` extension flag.


### PR DESCRIPTION
* Clarify the scope of the proposal by renaming it.
* Change the treatment of `f @t`, such that it's always treated as a type application regardless of enabled extensions. This is in violation of the Haskell Report, but the proposal as it stands already diverges from the report, whereas this amendment makes it possible to recover good error messages.

The corresponding change to the implementation is here: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3387

It was prompted by @phadej's observation that the existing implementation of the proposal produces low quality error messages.