### PR TITLE
Improve NegativeLiterals

### DIFF
--- a/proposals/0000-negative-literals-improved.md
+++ b/proposals/0000-negative-literals-improved.md
@@ -51,7 +51,8 @@ Changing the behavior of an existing extension may not be the best practice.
 
 ## Alternatives
 
-Don't change anything.
+* Don't change anything.
+* Deprecate `NegativeLiterals` in favor of `LexicalNegation`.
 
 ## Unresolved Questions
 

--- a/proposals/0000-negative-literals-improved.md
+++ b/proposals/0000-negative-literals-improved.md
@@ -1,0 +1,52 @@
+---
+author: Vladislav Zavialov
+date-accepted: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/344).
+
+# Negative Literals Improved
+
+At the moment, `NegativeLiterals` has the following issue, documented in the
+User's Guide:
+
+> One pitfall is that with `NegativeLiterals`, `x-1` will be parsed as `x`
+> applied to the argument `-1`, which is usually not what you want. `x - 1` or
+> even `x- 1` can be used instead for subtraction.
+
+We propose to fix this.
+
+## Motivation
+
+1. Having `x-1` parsed as `x (-1)` may violate users' expectations.
+2. Fixing this infelicity would make `NegativeLiterals` a subset of `LexicalNegation`.
+
+## Proposed Change Specification
+
+When lexing a negative literal, require that it is *not preceded by a closing
+token*. See
+[#229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst)
+for the definition of a closing token.
+
+## Effect and Interactions
+
+Code that relies on `x-1` being parsed as `x (-1)` will break.
+
+## Costs and Drawbacks
+
+Changing the behavior of an existing extension may not be the best practice.
+
+## Alternatives
+
+Don't change anything.
+
+## Unresolved Questions
+
+None at the moment.
+
+## Implementation Plan
+
+After the `LexicalNegation` patch is merged, the implementation will be
+trivial: modify `negLitPred` slightly.

--- a/proposals/0000-negative-literals-improved.md
+++ b/proposals/0000-negative-literals-improved.md
@@ -18,9 +18,14 @@ User's Guide:
 
 We propose to fix this.
 
+Additionally, unboxed literals (e.g. `-1#`) have the same issue even without
+the `NegativeLiterals` extension. We propose to fix this, too.
+
 ## Motivation
 
 1. Having `x-1` parsed as `x (-1)` may violate users' expectations.
+   As evidence, see [#18022](https://gitlab.haskell.org/ghc/ghc/-/issues/18022).
+
 2. Fixing this infelicity would make `NegativeLiterals` a subset of `LexicalNegation`.
 
 ## Proposed Change Specification
@@ -49,6 +54,3 @@ None at the moment.
 ## Implementation Plan
 
 Implemented in [Merge Request 3624](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3624).
-
-The change is a trivial adjustment to `negLitPred` in `Lexer.x`.
-

--- a/proposals/0000-negative-literals-improved.md
+++ b/proposals/0000-negative-literals-improved.md
@@ -48,5 +48,7 @@ None at the moment.
 
 ## Implementation Plan
 
-After the `LexicalNegation` patch is merged, the implementation will be
-trivial: modify `negLitPred` slightly.
+Implemented in [Merge Request 3624](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3624).
+
+The change is a trivial adjustment to `negLitPred` in `Lexer.x`.
+

--- a/proposals/0000-negative-literals-improved.md
+++ b/proposals/0000-negative-literals-improved.md
@@ -37,7 +37,13 @@ for the definition of a closing token.
 
 ## Effect and Interactions
 
-Code that relies on `x-1` being parsed as `x (-1)` will break.
+* Code that relies on `x-1` being parsed as `x (-1)` will break.
+
+* Enabling `-XLexicalNegation -XNegativeLiterals` has the same effect as
+  enabling `-XLexicalNegation` alone; however, enabling `-XNegativeLiterals`
+  alone does not have the same effect, as it does not affect expressions such
+  as `-x`.
+  In other words, `NegativeLiterals` becomes a subset of `LexicalNegation`.
 
 ## Costs and Drawbacks
 


### PR DESCRIPTION
At the moment, `NegativeLiterals` has the following issue, documented in the
User's Guide:

> One pitfall is that with `NegativeLiterals`, `x-1` will be parsed as `x`
> applied to the argument `-1`, which is usually not what you want. `x - 1` or
> even `x- 1` can be used instead for subtraction.

We propose to fix this.

[Rendered](https://github.com/int-index/ghc-proposals/blob/negative-literals-improved/proposals/0000-negative-literals-improved.md)

<!-- probot = {"1313345":{"who":"nomeata","what":"check status","when":"2020-07-22T09:00:00.000Z"}} -->