### PR TITLE
Bracket-sensitive layout rule

### DIFF
--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -127,7 +127,18 @@ A new language extension is added, called `BracketSensitiveLayout`.  When
 enabled, the following rule is added to the beginning of the layout algorithm in
 [section 10.3 of the Haskell 2010 Report](https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3):
 
-* L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is one of: ), ], or }.
+* L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is a closing bracket.
+
+Without language extensions, the phrase "is a closing bracket" means one of `}`, `)`, and `]`.  More
+generally, using the token classifications in
+[proposal 229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst#proposed-change-specification),
+a closing bracket is defined as a token that is "closing", but not "opening".  This extends
+closing brackets to include:
+
+* `#)` when `UnboxedTuples` are enabled.
+* `|]` and `||]` when `TemplateHaskellQuotes` is enabled.
+* `|)` when `Arrows` is enabled.
+* `⟧` and `⦈` when `UnicodeSyntax` is enabled along with any of `TemplateHaskellQuotes` or `Arrows`, respectively.
 
 ## Examples
 

--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -7,12 +7,12 @@ implemented: ""
 
 This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/346).
 
-# Looser Layout Rules
+# Bracket-Sensitive Layout Rule
 
 This proposal makes the following valid Haskell code:
 
 ```
-{-# LANGUAGE LooseLayout #-}
+{-# LANGUAGE BracketSensitiveLayout #-}
 
 foo = (
   1,
@@ -44,16 +44,16 @@ choose.
 
 ## Proposed Change Specification
 
-A new language extension is added, called `LooseLayout`.  When enabled, the
-following rule is added to the beginning of the layout algorithm in
+A new language extension is added, called `BracketSensitiveLayout`.  When
+enabled, the following rule is added to the beginning of the layout algorithm in
 [section 10.3 of the Haskell 2010 Report](https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3):
 
 * L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is one of: ), ], or }.
 
 ## Examples
 
-With the `LooseLayout` extension enabled, the following are all valid, while
-they were previously syntax errors:
+With the `BracketSensitiveLayout` extension enabled, the following are all valid,
+while they were previously syntax errors:
 
 ```
 foo = (
@@ -162,8 +162,7 @@ a solution.
 
 ## Unresolved Questions
 
-The extension name is terrible and doesn't communicate what it's doing very
-well.  I cannot yet think of a better name.
+None yet.
 
 ## Implementation Plan
 

--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -81,8 +81,24 @@ mylist = [
 ```
 
 In Haskell, due to the layout rule, this is not allowed most of the time.
-Haskell has, therefore, developed some unique formatting conventions,
-such as:
+
+```
+foo = (
+  1,
+  2
+)
+
+test.hs:4:1: error:
+    parse error (possibly incorrect indentation or mismatched brackets)
+  |
+4 | )
+  | ^
+```
+
+There are two consequences of this:
+
+**Divergence in formatting:** Haskell has, therefore, developed some unique
+formatting conventions, such as:
 
 ```
 indentedCloseBracket = (
@@ -105,21 +121,31 @@ leadingCommas =
   )
 ```
 
-Some Haskell programmers have grown fond of these new styles and prefer
-them on their own merits.  However, it's not optimal to force programmers
-into unusual style choices when it's easy to tweak the layout rule to not
-require them.
+These aren't necessarily bad on their own.  Many Haskell programmers are fond
+of these new styles, and prefer them on their own merits.  However, it's not
+optimal to force programmers into unusual style choices just because of the
+limitations of layout.  It's easy to tweak the layout rule to not require them,
+letting programmers make their own choices.
 
-This layout rule has also caused complexity in multiple pieces of Haskell
-tooling.  For example, comments [here](https://www.tweag.io/blog/2019-10-11-ormolu-first-release/):
+**Tool complexity:** This layout rule has also caused complexity in multiple
+pieces of Haskell tooling, where applying natural rules consistently leads to
+syntax errors, and tools introduce ad hoc rules to work around it.
+
+I have not done a comprehensive search for tools that have had to react to this.
+But from memory, I know this is identified as an issue in the article
+[here](https://www.tweag.io/blog/2019-10-11-ormolu-first-release/):
 
 > That’s why we make an exception in our rendering rules—we move the
 > closing parenthesis one indentation level to the right on the rare
 > occasions it’s necessary.
 
-and the workaround [here](https://github.com/google/codeworld/blob/master/web/js/codeworld-mode.js#L593).
+and is also the cause of the workaround
+[here](https://github.com/google/codeworld/blob/43a3b947bfa57c7fc1b49c67090c3f569de80b8c/web/js/codeworld-mode.js#L593):
 
-So let's fix the layout rule, and let people choose.
+    minIndent = isBracket(parent) ? parent.column : parent.column + 1;
+
+Because of all this, I propose to fix the layout rule, so that formatting is
+not dictated by limitations of tools.
 
 ## Proposed Change Specification
 

--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -270,39 +270,56 @@ a chance to add a more specific error message for this mistake.
 
 ## Costs and Drawbacks
 
-There are two drawbacks worth considering:
+There are some (closely related) drawbacks worth considering:
 
-1. It makes the layout rule more complex.  This is something Haskellers
-   should definitely be concerned about.  However, I believe that these
-   close-bracket tokens are already obviously not the starts of new
-   statements, and the meanings of the new programs accepted by this rule
-   are abundantly clear, which substantially mitigates the cost.
+1. It makes the layout rule a little bit more complex.  This is something
+   Haskellers should be concerned about, lest it require more cognitive
+   load for programmers to read and understand the structure of code.
+   However, I believe that these closing bracket tokens are already
+   obviously not the starts of new statements, and the meanings of the new
+   programs accepted by this rule are abundantly clear, which substantially
+   mitigates the cost.  (This is, however, a good reason not to adopt
+   the alternative mentioned below.)
 2. Having more optional syntax means that GHC no longer enforces as much
-   consistency in style.  The intent here isn't to fork the layout rule
-   indefinitely.  This change should only be accepted if the committee
-   sees a real chance that it will be adopted in a future Haskell Report.
+   consistency in style.  However, GHC already accepts plenty of terrible
+   formatting.  Realistically, no one can rely on GHC to maintain consistent
+   style in Haskell code.  There are other tools, such as linters and
+   formatters, to do that job.  GHC's role is to accept programs when their
+   meaning is clear.
+3. There is a cost to having more language options, and two different
+   syntax rules.  This is an inherent cost in making any change.  The intent
+   here isn't to fork the layout rule in the long run.  This change should
+   only be accepted if the committee sees a real chance that it would be
+   adopted universally in a future Haskell Report.
 
 The implementation and maintenance cost for GHC should not be significant.
 
 ## Alternatives
 
-The main alternative today, mentioned above, is to adopt new formatting
-conventions different from other languages, as Haskell programmers currently
-do.  This is obviously possible, but they make the transition from other
-languages to Haskell more difficult.
+* The main alternative today, mentioned above, is to adopt new formatting
+  conventions different from other languages, as Haskell programmers currently
+  do.  This is obviously possible, but they make the transition from other
+  languages to Haskell more difficult.
 
-Another alternative would be to adopt this proposal, but even further expand
-the list of tokens that do *not* start new statements in layout.  Instead of
-just close brackets, one could for instance add `=`, `,`, `::`, `in`, and
-any infix operator.  I have not proposed to do so because it is less obvious
-which tokens are continuations of the previous statement, and it then becomes
-much harder to explain parsing rules.  Indeed, *which* tokens may occur at
-the beginning of a layout statement may depend on other language extensions
-in effect.  In the past, `deriving` was such a token, but now we have
-`-XStandaloneDeriving` and it much be removed from the list.  To avoid these
-unhappy effects, I propose to limit ourselves to close-brackets, which are
-both the most important part of the problem, and the least problematic as
-a solution.
+* Another alternative would be to adopt this proposal, but even further expand
+  the list of tokens that do *not* start new statements in layout.  Plenty of
+  other tokens, such as `=`, `,`, `::`, `in`, and any infix operator, cannot
+  appear at the start of any statement in any layout context.
+
+  This is a bad idea for two reasons.
+  
+  1. Even if these tokens cannot start a statement, it is less obvious that
+     this is so.  This adds cognitive load when reading code.
+  2. Which tokens may occur at the beginning of a layout statement may depend
+     on other language extensions in effect, and change over time.  In the
+     past, `deriving` was such a token, but now we have `-XStandaloneDeriving`
+     and it must be removed from the list.  The consequence of this is that
+     new syntax would potentially break code that doesn't even use it, by
+     requiring changes to the layout rule.  This is clearly unacceptable.
+
+  To avoid these unhappy effects, we should limit ourselves to close-brackets,
+  which are both the most important part of the problem to solve, and the one
+  that is most obviously not the start of a new layout statement.
 
 ## Unresolved Questions
 

--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -140,6 +140,10 @@ closing brackets to include:
 * `|)` when `Arrows` is enabled.
 * `⟧` and `⦈` when `UnicodeSyntax` is enabled along with any of `TemplateHaskellQuotes` or `Arrows`, respectively.
 
+Because proposal 229 already introduces the requirement that new tokens are correctly classified
+as opening or closing, this will automatically extend the new layout rule to additional kinds of
+closing brackets if they are added in the future.
+
 ## Examples
 
 With the `BracketSensitiveLayout` extension enabled, the following are all valid,

--- a/proposals/0000-bracket-sensitive-layout.md
+++ b/proposals/0000-bracket-sensitive-layout.md
@@ -39,7 +39,16 @@ foo =
 Admittedly, some Haskell programmers have grown fond of these new styles.
 This proposal doesn't prevent them from being used by choice.  However,
 it's not optimal to force programmers into unusual style choices when it's
-easy to fix the layout rule.  So let's fix the layout rule, and let people
+easy to fix the layout rule to not have that effect.
+
+This rule has also caused complexity in Haskell tooling.  See
+[here](https://www.tweag.io/blog/2019-10-11-ormolu-first-release/):
+
+> That’s why we make an exception in our rendering rules—we move the
+> closing parenthesis one indentation level to the right on the rare
+> occasions it’s necessary.
+
+So let's fix the layout rule, and let people
 choose.
 
 ## Proposed Change Specification

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -126,13 +126,19 @@ make additional Haskell programs legal.
 
 ## Costs and Drawbacks
 
-I suspect the implementation is not difficult, nor should the
-maintenance cost be significant.
+There are two drawbacks worth considering:
 
-The main drawback is that it makes the layout rule more complex.  However, I
-submit that these close-bracket tokens are already obviously not the starts
-of new statements, and the meanings of the new programs accepted by this
-rule are abundantly clear.
+1. It makes the layout rule more complex.  This is something Haskellers
+   should definitely be concerned about.  However, I believe that these
+   close-bracket tokens are already obviously not the starts of new
+   statements, and the meanings of the new programs accepted by this rule
+   are abundantly clear, which substantially mitigates the cost.
+2. Having more optional syntax means that GHC no longer enforces as much
+   consistency in style.  The intent here isn't to fork the layout rule
+   indefinitely.  This change should only be accepted if the committee
+   sees a real chance that it will be adopted in a future Haskell Report.
+
+The implementation and maintenance cost for GHC should not be significant.
 
 ## Alternatives
 

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -25,8 +25,8 @@ foo = (
 In most other programming languages, it is commonplace to align closing
 parentheses, brackets, or braces with the statement that they belong to.
 In Haskell, due to the layout rule, this is not allowed most of the time.
-Because of this, Haskell has developed some unique formatting conventions,
-such as leading commas:
+Partly vecause of this, Haskell has developed some unique formatting
+conventions, such as leading commas:
 
 ```
 foo =
@@ -36,18 +36,17 @@ foo =
   )
 ```
 
-This is partly to work around the fact that more common styles from other
-languages don't work here.  Admittedly, some Haskell programmers have
-grown fond of these new styles.  This proposal doesn't prevent them from
-being used by choice.  However, it's not optimal to force programmers into
-unusual style choices when it's easy to fix the layout rule.  So let's
-fix the layout rule, and let people choose.
+Admittedly, some Haskell programmers have grown fond of these new styles.
+This proposal doesn't prevent them from being used by choice.  However,
+it's not optimal to force programmers into unusual style choices when it's
+easy to fix the layout rule.  So let's fix the layout rule, and let people
+choose.
 
 ## Proposed Change Specification
 
 A new language extension is added, called `LooseLayout`.  When enabled, the
 following rule is added to the beginning of the layout algorithm in
-section 10.3 of the Haskell 2010 Report:
+[section 10.3 of the Haskell 2010 Report](https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3):
 
 * L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is one of: ), ], or }.
 

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -48,8 +48,8 @@ fix the layout rule, and let people choose.
 ## Proposed Change Specification
 
 A new language extension is added, called `LooseLayout`.  When enabled, the
-following rule is added to the beginnign of the layout algorithm from
-section 10.2 of the Haskell 2010 Report:
+following rule is added to the beginning of the layout algorithm in
+section 10.3 of the Haskell 2010 Report:
 
 * L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is one of: ), ], or }.
 

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -156,7 +156,8 @@ a solution.
 
 ## Unresolved Questions
 
-None so far.
+The extension name is terrible and doesn't communicate what it's doing very
+well.  I cannot yet think of a better name.
 
 ## Implementation Plan
 

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -1,0 +1,170 @@
+---
+author: Chris Smith <cdsmith@gmail.com>
+date-accepted: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
+**After creating the pull request, edit this file again, update the number in
+the link, and delete this bold sentence.**
+
+# Looser Layout Rules
+
+This proposal makes the following valid Haskell code:
+
+```
+{-# LANGUAGE LooseLayout #-}
+
+foo = (
+  1,
+  2
+)
+```
+
+## Motivation
+
+In most other programming languages, it is commonplace to align closing
+parentheses, brackets, or braces with the statement that they belong to.
+In Haskell, due to the layout rule, this is not allowed most of the time.
+Because of this, Haskell has developed some unique formatting conventions,
+such as leading commas:
+
+```
+foo =
+  ( first
+  , second
+  , third
+  )
+```
+
+This is partly to work around the fact that more common styles from other
+languages don't work here.  Admittedly, some Haskell programmers have
+grown fond of these new styles.  This proposal doesn't prevent them from
+being used by choice.  However, it's not optimal to force programmers into
+unusual style choices when it's easy to fix the layout rule.  So let's
+fix the layout rule, and let people choose.
+
+## Proposed Change Specification
+
+A new language extension is added, called `LooseLayout`.  When enabled, the
+following rule is added to the beginnign of the layout algorithm from
+section 10.2 of the Haskell 2010 Report:
+
+* L (\<n\> : t : ts) (m : ms) = L (t : ts) (m : ms), **if** m = n, and t is one of: ), ], or }.
+
+## Examples
+
+With the `LooseLayout` extension enabled, the following are all valid, while
+they were previously syntax errors:
+
+```
+foo = (
+  1,
+  2
+)
+```
+
+```
+main = do
+  mapM_ print [
+    1,
+    2,
+    3
+  ]
+```
+
+```
+foo = a ++ b
+  where
+    a = [
+      1,
+      2,
+      3
+    ]
+    b = [
+      4,
+      5,
+      6
+    ]
+```
+
+The following also becomes legal, though I'm not sure it should be:
+
+```
+names = [
+  "Abe",
+  "Beth",
+  "Charles"
+] ++ [
+  "Donna",
+  "Emily",
+  "Frank"
+]
+```
+
+I'd suggest this would be considered bad style, at least.  But not
+all poor formatting is excluded by the parser.
+
+Note that the following is still **not** legal, because the indentation
+of the closing bracket is less than the current layout context, instead
+of equal to it:
+
+```
+foo = a ++ b
+  where
+    a = [
+      1,
+      2
+  ]
+```
+
+## Effect and Interactions
+
+I don't know what else there is to say.
+
+I am fairly sure that enabling this extension would not make
+any change to the meaning of legal Haskell programs.  It would only
+make additional Haskell programs legal.
+
+## Costs and Drawbacks
+
+I suspect the implementation is not difficult, nor should the
+maintenance cost be significant.
+
+The main drawback is that it makes the layout rule more complex.  However, I
+submit that these close-bracket tokens are already obviously not the starts
+of new statements, and the meanings of the new programs accepted by this
+rule are abundantly clear.
+
+## Alternatives
+
+The main alternative today, mentioned above, is to adopt new formatting
+conventions different from other languages, as Haskell programmers currently
+do.  This is obviously possible, but they make the transition from other
+languages to Haskell more difficult.
+
+Another alternative would be to adopt this proposal, but even further expand
+the list of tokens that do *not* start new statements in layout.  Instead of
+just close brackets, one could for instance add `=`, `,`, `::`, `in`, and
+any infix operator.  I have not proposed to do so because it is less obvious
+which tokens are continuations of the previous statement, and it then becomes
+much harder to explain parsing rules.  Indeed, *which* tokens may occur at
+the beginning of a layout statement may depend on other language extensions
+in effect.  In the past, `deriving` was such a token, but now we have
+`-XStandaloneDeriving` and it much be removed from the list.  To avoid these
+unhappy effects, I propose to limit ourselves to close-brackets, which are
+both the most important part of the problem, and the least problematic as
+a solution.
+
+## Unresolved Questions
+
+None so far.
+
+## Implementation Plan
+
+I (cdsmith) will attempt to implement this if the proposal is accepted.  I
+am not an experienced GHC developer, but I do not expect the implementation
+to be difficult.
+
+## Endorsements

--- a/proposals/0000-loose-layout.md
+++ b/proposals/0000-loose-layout.md
@@ -5,9 +5,7 @@ ticket-url: ""
 implemented: ""
 ---
 
-This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
-**After creating the pull request, edit this file again, update the number in
-the link, and delete this bold sentence.**
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/346).
 
 # Looser Layout Rules
 


### PR DESCRIPTION
This short proposal changes the layout rule to allow a kind of formatting of close brackets that's common in most other programming languages.

[Rendered](https://github.com/cdsmith/ghc-proposals/blob/loose-layout/proposals/0000-bracket-sensitive-layout.md)