### PR TITLE
Negative literals and meaning-preserving SCC implemented

### DIFF
--- a/proposals/0099-explicit-specificity.rst
+++ b/proposals/0099-explicit-specificity.rst
@@ -4,7 +4,7 @@ Explicit specificity in type variable binders
 .. author:: Richard Eisenberg
 .. date-accepted:: 2018-07-02
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16393
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/99>`_.
 .. contents::

--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -4,7 +4,7 @@
 .. author:: Arnaud Spiwack
 .. date-accepted:: 2018-10-22
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/15981
-.. implemented:: 8.12 (technology preview)
+.. implemented:: 9.0 (technology preview)
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/111>`_.
 .. contents::

--- a/proposals/0176-scc-parsing.rst
+++ b/proposals/0176-scc-parsing.rst
@@ -3,8 +3,8 @@ Meaning-preserving parsing rules for SCC annotations
 
 .. author:: Vladislav Zavialov
 .. date-accepted:: 2019-04-17
-.. ticket-url::
-.. implemented::
+.. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/15730
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/176>`_.
 .. contents::

--- a/proposals/0195-code-texp.rst
+++ b/proposals/0195-code-texp.rst
@@ -5,7 +5,7 @@ Make Q (TExp a) into a newtype
 .. author:: Matthew Pickering
 .. date-accepted:: 2020-05-26
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/16177
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/195>`_.
 .. contents::

--- a/proposals/0216-qualified-do.rst
+++ b/proposals/0216-qualified-do.rst
@@ -4,7 +4,7 @@ Qualified do
 .. author:: Facundo Domínguez, Arnaud Spiwack, Matthías Páll Gissurarson
 .. date-accepted:: 2020-05-21
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/18214
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/216>`_.
 .. contents::

--- a/proposals/0229-whitespace-bang-patterns.rst
+++ b/proposals/0229-whitespace-bang-patterns.rst
@@ -4,7 +4,7 @@ Whitespace-sensitive operator parsing (~, !, @, $, $$, -)
 .. date-accepted:: 2019-08-24
 .. author:: Vladislav Zavialov
 .. ticket-url::
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/229>`_.
 .. contents::

--- a/proposals/0246-overloaded-bracket.rst
+++ b/proposals/0246-overloaded-bracket.rst
@@ -4,7 +4,7 @@ Overloaded Quotations
 .. author:: Matthew Pickering
 .. date-accepted:: 2019-12-06
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2247
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/246>`_.
 .. contents::

--- a/proposals/0287-simplify-subsumption.rst
+++ b/proposals/0287-simplify-subsumption.rst
@@ -4,7 +4,7 @@ Simplify subsumption
 .. author:: Simon PJ
 .. date-accepted:: 2020-01-24
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/issues/17775
-.. implemented:: 8.12
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/287>`_.
 .. contents::

--- a/proposals/0344-negative-literals-improved.rst
+++ b/proposals/0344-negative-literals-improved.rst
@@ -4,7 +4,7 @@ Negative Literals Improved
 .. author:: Vladislav Zavialov
 .. date-accepted:: 2020-07-22
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3624
-.. implemented::
+.. implemented:: 9.0
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/344>`_.
 .. contents::


### PR DESCRIPTION
While we are at it: there's an "Implemented" label that is currently not always used. I think it's pretty convenient to see implemented proposals with a tag. Could you add it to #29, #37, #54, #71, #99, #103, #111, #176, #190, #195, #216, #246, #287, #344?