### PR TITLE
Update a couple missed cases to the new linear arrow syntax

### DIFF
--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -282,7 +282,7 @@ This proposal adds two new syntactical constructs:
     ::
 
       type family F (a :: *) :: Multiplicity
-      f ::  forall (a :: *). Int  :(F a)-> a -> a
+      f ::  forall (a :: *). Int  #(F a)-> a -> a
 - When ``-XScopedTypeVariables`` is switched on, binders can also be annotated with a multiplicity:
 
   ::
@@ -364,7 +364,7 @@ A new type constructor is added
 The linear and unrestricted arrows are aliases:
 
 - ``(->)`` is an alias for ``FUN 'Many``
-- ``(->.)`` (ASCII syntax) and ``(⊸)`` (Unicode syntax) are aliases
+- ``(#->)`` (ASCII syntax) and ``(⊸)`` (Unicode syntax) are aliases
   for ``FUN 'One``
 
 Printing


### PR DESCRIPTION
I believe a couple arrows were missed when changing the linear arrow syntax. (Of course, I may be mistaken – I might have missed something myself, since there was tons of discussion and I didn't read it all.)

The syntax of linear arrows underwent a couple of revisions over the course of the proposal, and I think updating these few cases was probably overlooked by accident.

The syntax section specifies the current accepted syntax as `#->` and `# p ->`. For reference, here's [the comment changing `:p->` to `#p->`](https://github.com/ghc-proposals/ghc-proposals/pull/111#issuecomment-475681083) and [the comment changing `->.` to `#->`](https://github.com/ghc-proposals/ghc-proposals/pull/111#issuecomment-519175000).
