### PR TITLE
Export ~ from Data.Type.Equality

### DIFF
--- a/proposals/0000-non-magical-eq.md
+++ b/proposals/0000-non-magical-eq.md
@@ -1,0 +1,76 @@
+---
+author: Vladislav Zavialov
+date-accepted: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/371).
+
+# Export `~` from `Data.Type.Equality`
+
+
+## Motivation
+
+The `~` type operator is magical, in that it's always in scope and does not require `TypeOperators` to use.
+But `~~`, `:~:`, and `:~~:` are not magical in the same way, they are
+exported from `Data.Type.Equality` and require `TypeOperators`.
+
+This is a historical accident which we propose to correct.
+
+## Proposed Change Specification
+
+* Do not bring `~` into scope magically, export it from `Data.Type.Equality`.
+
+* Re-export `~` from `Prelude`.
+
+* Drop the requieremnt to enable `TypeFamilies` or `GADTs`
+  to use the `~` type operator.
+
+* Require `TypeOperators` to use the `~` type operator.
+
+### Migration story
+
+Let `n` be the GHC version that implements this proposal.
+
+Starting with GHC `n`, include a compatibility fallback:
+
+* When the lookup for `~` fails because it is not in scope,
+  assume it refers to `Data.Type.Equality.~`.
+  When this happens and `-Wcompat` is in effect, emit a warning.
+
+Starting with GHC `n+2`, enable the warning by default.
+Either starting with GHC `n+8` or with the next major compiler version bump (GHC
+10), whichever comes first, remove the compatibility fallback.
+
+## Effect and Interactions
+
+* One less quirk.
+
+* The users are allowed to define their own ``~``.
+
+* The compiler internals are simplified, in particular things described in
+  ``Note [eqTyCon (~) is built-in syntax]``.
+
+* Haddock documentation for ``~`` will get fixed (it is currently missing in
+  the generated HTML).
+
+## Costs and Drawbacks
+
+This is a breaking change:
+
+* Users will need to enable `TypeOperators`
+* Authors of custom preludes will likely want to re-export `(~)`
+
+## Alternatives
+
+* Keep `~` special for historical reasons to avoid a breaking change.
+* A different migration schedule (e.g. include the warning in `-Wall` first).
+
+## Unresolved Questions
+
+None.
+
+## Implementation Plan
+
+There's a prototype implementation in [MR 4313](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4313).


### PR DESCRIPTION
The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0371-non-magical-eq.md) has been accepted; the following discussion is mostly of historic interest.

-------------------------------

The `~` type operator is magical, in that it's always in scope and does not require `TypeOperators` to use.
But `~~`, `:~:`, and `:~~:` are not magical in the same way, they are
exported from `Data.Type.Equality` and require `TypeOperators`.

This is a historical accident which we propose to correct.

[Rendered](https://github.com/int-index/ghc-proposals/blob/non-magical-eq/proposals/0000-non-magical-eq.md)

<!-- probot = {"1313345":{"who":"goldfirere","what":"accept","when":"2021-04-29T09:00:00.000Z"}} -->