### PR TITLE
Update GRC.rst

### DIFF
--- a/GRC.rst
+++ b/GRC.rst
@@ -48,8 +48,8 @@ Specifically, we aspire to these qualities:
 * We strive to be scrupulously polite at all times.  There should be no
   rudeness, name-calling, or harassment in our communication.
 
-* Where we disagree with someone, we avoid forms of expression that might make
-  our dialogue partner feel attacked, humiliated, demeaned, or marginalised.
+* Where we disagree with someone, we avoid forms of expression which intends to
+  attack, humiliate, demean, or marginalise our dialogue partner.
   Our critique should always be of specific statements and claims, never of
   people.
 


### PR DESCRIPTION
My goal with this pull request is the change the emotional state responsibility.

When I read this sentence:

> [..] we avoid forms of expression that might make our dialogue partner feel attacked [..]

I conclude that I have two responsibilities:

1. I should not use "aggressive" language
2. I have to worry of my partner feelings

In my opinion, while the first point is perfectly valid, I can control what I say, the second one is at least annoying.

 1. It can easily lead to the [mind reading](https://en.wikipedia.org/wiki/Jumping_to_conclusions) cognitive distortion which can increase anxiety.
 2. It does encourage emotional ownership, since it would imply outsourcing its control to someone else.

Finally, as a person, I am responsible of my emotional state, I treat other as responsible of theirs, and I hope to be recognized as such.