### PR TITLE
Simplify type synonym and type instance scoping

### DIFF
--- a/proposals/0000-instance-scoping.rst
+++ b/proposals/0000-instance-scoping.rst
@@ -39,7 +39,7 @@ Proposed Change Specification
   (Implementation note: see ``Note [Implicit quantification in type synonyms]`` in ``GHC.Rename.HsType``.)
 
 * Change #2.   Introduce the following rule: in a type family instance declaration,
-  the instantiation of the family instance fully determined by the left hand side, without
+  the instantiation of the family instance is fully determined by the left hand side, without
   looking at the right hand side.
 
 Examples and motivation

--- a/proposals/0000-instance-scoping.rst
+++ b/proposals/0000-instance-scoping.rst
@@ -18,7 +18,7 @@ or type-family instance declarations.  This proposal suggests two
 related simplifications, that make the language easier to read, less ad hoc,
 and simpler to implement.
 
-It depends on proposal #326 (Inivisible parameters for declarations).
+It depends on proposal #326 (Invisible parameters for declarations).
 This proposal has a draft implementation in MR !3145.
 
 Proposed Change Specification
@@ -160,7 +160,7 @@ Here's an example from the wild (thanks Jakob Bruenker)::
   type family Trans pa pb where
     Trans rel MkR = rel -- this type checks but is a partial type family
 
-In current GHC this typechecks, but the type family is not total?  Why?
+In current GHC this typechecks, but the type family is not total.  Why?
 Because the fully-explicit version is::
 
   type family Trans pa pb where
@@ -173,7 +173,7 @@ looked total.  With Change #2, the original program::
     type family Trans pa pb where
       Trans rel MkR = rel
 
-would be rejected. WHy? Because the LHS imposes no kind constraints, so
+would be rejected. Why? Because the LHS imposes no kind constraints, so
 we get::
 
     type family Trans pa pb where
@@ -194,9 +194,9 @@ These changes will make fewer programs compile.
   need to be planned.
 
 * For change #2 there is a backward-compatible workaround, so we could
-  perhaps bring it in immediately.  It would be somwhat tricky to implement
-  a deprecation cycle, beucause we'd have to figure out whether the instantiaon
-  was driven by the RHS
+  perhaps bring it in immediately.  It would be somewhat tricky to implement
+  a deprecation cycle, because we'd have to figure out whether the instantiation
+  was driven by the RHS.
 
 
 Costs and Drawbacks

--- a/proposals/0000-instance-scoping.rst
+++ b/proposals/0000-instance-scoping.rst
@@ -84,11 +84,22 @@ With this proposal, both declarations woudl be illegal.  Instead you must write:
   type T2 @a = 'Just ('Nothing :: Maybe a)
 
 so that all the variables occurring on the RHS are bound on the LHS.
-
 This proposal exploits #326 to allow a nice, simple, uniform rule.
 As the manual says, "The reason for this exception [the strange, ad-hoc,
 top-level-kind-signature rule] is that there may be no other way to bind k".
 
+The same rule applies to type family instances::
+
+   type family F a :: k
+
+   type instance F Int = Any :: k -> k
+
+(where ``Any :: forall j. j``). This type instance is current legal, but under
+this proposal ``k`` would not be in scope.  You would have to write::
+
+   type instance F @(k->k) Int = Any :: k -> k
+
+This form is already allowed today; it does not require #326.
 
 Change #2
 ~~~~~~~~~

--- a/proposals/0000-instance-scoping.rst
+++ b/proposals/0000-instance-scoping.rst
@@ -1,32 +1,13 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
-
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
-Proposal title
-==============
+Simplify type synonym and type instance declarations
+=======================================================
 
 .. author:: Simon Peyton Jones
-.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
-.. ticket-url:: Leave blank. This will eventually be filled with the
-                ticket URL which will track the progress of the
-                implementation of the feature.
-.. implemented:: Leave blank. This will be filled in with the first GHC version which
-                 implements the described feature.
-.. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. date-accepted::
+.. ticket-url::
+.. implemented::
+.. highlight::
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/386>`_.
+.. sectnum::
 .. contents::
 
 Summary

--- a/proposals/0000-instance-scoping.rst
+++ b/proposals/0000-instance-scoping.rst
@@ -29,6 +29,9 @@ Proposal title
             number in the link, and delete this bold sentence.**
 .. contents::
 
+Summary
+---------
+
 In a couple of places GHC is being too clever when dealing with type synonym
 or type-family instance declarations.  This proposal suggests two
 related simplifications, that make the language easier to read, less ad hoc,
@@ -40,22 +43,23 @@ This proposal has a draft implementation in MR !3145.
 Proposed Change Specification
 -----------------------------
 
-1. Introduce the following rule: in
-   * a type synonym declaration, or
-   * a type family instance declaration
-   every type variable mentioned on the RHS must be bound on the LHS.
+* Change #1.  Introduce the following rule: in
 
-   To match this change, in the user manual, remove the text in
-   `Implicit quantification in type synonyms and type family instances
-   <https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/poly_kinds.html>`_.
-   from the beginning down to
-   "Kind variables can also be quantified in visible positions...".
+  * a type synonym declaration, or
+  * a type family instance declaration
+  every type variable mentioned on the RHS must be bound on the LHS.
 
-   (Implementation note: see ``Note [Implicit quantification in type synonyms]`` in ``GHC.Rename.HsType``.)
+  To match this change, in the user manual, remove the text in
+  `Implicit quantification in type synonyms and type family instances (6.4.11.12)
+  <https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/poly_kinds.html>`_,
+  from the beginning of that section down to
+  "Kind variables can also be quantified in visible positions...".
 
-2. Introduce the following rule: in a type family instance declaration,
-   the instantiation of the left hand side is fully determined, without
-   looking at the right hand side.
+  (Implementation note: see ``Note [Implicit quantification in type synonyms]`` in ``GHC.Rename.HsType``.)
+
+* Change #2.   Introduce the following rule: in a type family instance declaration,
+  the instantiation of the family instance fully determined by the left hand side, without
+  looking at the right hand side.
 
 Examples and motivation
 -----------------------
@@ -72,7 +76,7 @@ Consider::
 free variables of a *top-level* kind signature on the RHS are brought into scope
 implicitly, and will be quantified in the final kind of the type constructor.
 
-So ``T2`` is currently illegal, because the kind signature is not at the top level.
+In constrast, ``T2`` is currently illegal, because the kind signature is not at the top level.
 
 With this proposal, both declarations woudl be illegal.  Instead you must write:::
 
@@ -80,6 +84,10 @@ With this proposal, both declarations woudl be illegal.  Instead you must write:
   type T2 @a = 'Just ('Nothing :: Maybe a)
 
 so that all the variables occurring on the RHS are bound on the LHS.
+
+This proposal exploits #326 to allow a nice, simple, uniform rule.
+As the manual says, "The reason for this exception [the strange, ad-hoc,
+top-level-kind-signature rule] is that there may be no other way to bind k".
 
 
 Change #2


### PR DESCRIPTION
New proposal to simplify type synonym and type instance declarations

[rendered](https://github.com/ghc-proposals/ghc-proposals/blob/wip/spj-instance-scoping/proposals/0000-instance-scoping.rst)