### PR TITLE
Clarify modifiers design principle

### DIFF
--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -307,8 +307,6 @@ This proposal adds two new syntactical constructs:
   where the ``btype`` after the ``%`` must be of kind ``Multiplicity``
   (see below).
 
-  This form is allowed only when the lambda binds precisely one variable.
-
 - Record fields can be labeled with a multiplicity. This modifies
   the syntax for record fields as follows::
      

--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -288,24 +288,25 @@ This proposal adds two new syntactical constructs:
 
   ::
 
-    \x :: A %'One -> x
+    \ (%'One x) :: A -> x
 
   is the identity function at type ``A ⊸ A``. A binder can be
   annotated with a multiplicity without a type like this
 
   ::
 
-    \x %'One -> x
+    \ %'One x -> x
 
   This modifies the syntax entry for lambda expressions
   as follows
 
   ::
 
-    lexp -> \ apat1 ... apatn [PREFIX_PERCENT btype] -> exp
+    lpat -> [PREFIX_PERCENT btype] lpat
 
   where the ``btype`` after the ``%`` must be of kind ``Multiplicity``
-  (see below).
+  (see below). The ``lpat`` must be a bare variable, or an error
+  occurs.
 
 - Record fields can be labeled with a multiplicity. This modifies
   the syntax for record fields as follows::

--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -284,7 +284,7 @@ This proposal adds two new syntactical constructs:
 
       type family F (a :: *) :: Multiplicity
       f ::  forall (a :: *). Int  %(F a) -> a -> a
-- When ``-XScopedTypeVariables`` is switched on, binders can also be annotated with a multiplicity:
+- Lambda-bound variables can also be annotated with a multiplicity:
 
   ::
 
@@ -297,40 +297,21 @@ This proposal adds two new syntactical constructs:
 
     \x %'One -> x
 
-  This modifies the syntax entry for pattern with signature annotation
-  as follows as follows
+  This modifies the syntax entry for lambda expressions
+  as follows
 
   ::
 
-    pat -> pat [PREFIX_PERCENT btype] [:: type]
+    lexp -> \ apat1 ... apatn [PREFIX_PERCENT btype] -> exp
 
   where the ``btype`` after the ``%`` must be of kind ``Multiplicity``
   (see below).
 
-  This form is disallowed for:
+  This form is allowed only when the lambda binds precisely one variable.
 
-  - Type variables
-
-    ::
-
-      forall (a %'One). a -> Int -- rejected
-  - Top-level signatures (though, see `Toplevel binders`_)
-
-    ::
-
-      foo %'One :: A -> B -- rejected
-      foo x = …
-
-  The form is however permitted in records (see `Records`_ below)
-
-  ::
-
-    data R = R { unrestrictedField %'Many :: A, linearField %'One :: B }
-
-  This modifies the field declaration syntax to
-
-  ::
-
+- Record fields can be labeled with a multiplicity. This modifies
+  the syntax for record fields as follows::
+     
     fielddecl -> vars [PREFIX_PERCENT btype] :: (type | ! atype)
 
 In the fashion of levity polymorphism, the proposal introduces a data

--- a/proposals/0370-modifiers.rst
+++ b/proposals/0370-modifiers.rst
@@ -102,8 +102,7 @@ Proposed Change Specification
     modifier may have a top-level type signature.
 
 11. A modifier of type ``Multiplicity`` changes the multiplicity of the following arrow,
-    preceding pattern-bound variable of a lambda (but only when the lambda binds just one
-    variable),
+    preceding pattern-bound variable of a lambda,
     or preceding record field.
     Multiple modifiers of type ``Multiplicity`` on the same arrow are not allowed.
     Any other use of a modifier is an error.

--- a/proposals/0370-modifiers.rst
+++ b/proposals/0370-modifiers.rst
@@ -66,9 +66,9 @@ Proposed Change Specification
 
      fexp     ::= {modifier} aexp | fexp aexp
 
-5. With ``-XModifiers``, introduce modifier syntax in lambda expressions as follows::
+5. With ``-XModifiers``, introduce modifier syntax in patterns as follows::
 
-     lexp     ::= \ apat1 ... apatn {modifier} -> exp
+     lpat     ::= {modifier} lpat | ...
 
 6. With ``-XModifiers``, introduce modifier syntax on record field declarations as follows::
      
@@ -102,7 +102,7 @@ Proposed Change Specification
     modifier may have a top-level type signature.
 
 11. A modifier of type ``Multiplicity`` changes the multiplicity of the following arrow,
-    preceding pattern-bound variable of a lambda,
+    or following pattern-bound variable of a lambda,
     or preceding record field.
     Multiple modifiers of type ``Multiplicity`` on the same arrow are not allowed.
     Any other use of a modifier is an error.

--- a/proposals/0370-modifiers.rst
+++ b/proposals/0370-modifiers.rst
@@ -71,19 +71,26 @@ Proposed Change Specification
      lpat     ::= {modifier} lpat | ...
 
 6. With ``-XModifiers``, introduce modifier syntax on record field declarations as follows::
-     
+
      fielddecl ::= vars {modifier} '::' (type | '!' atype)
 
 7. With ``-XModifiers``, introduce modifier syntax on top-level declarations as follows::
 
-     topdecl ::= {modifier} 'type' simpletype '=' type
-             |   {modifier} 'data' [context '=>'] simpletype ['=' constrs] [deriving]
-             |   {modifier} 'newtype' [context '=>'] simpletype = newconstr [deriving]
-             |   {modifier} 'class' [scontext '=>'] tycls tyvar ['where' cdecls]
-             |   {modifier} 'instance' [scontext '=>'] qtycls inst ['where' idecls]
-             |   {modifier} 'default' '(' type1 ',' ... ',' typen ')'
-             |   {modifier} 'foreign' fdecl
-             |   decl                            -- unchanged
+     topdecl ::= {modifier} [ ';' ] 'type' simpletype '=' type
+             |   {modifier} [ ';' ] 'data' [context '=>'] simpletype ['=' constrs] [deriving]
+             |   {modifier} [ ';' ] 'newtype' [context '=>'] simpletype = newconstr [deriving]
+             |   {modifier} [ ';' ] 'class' [scontext '=>'] tycls tyvar ['where' cdecls]
+             |   {modifier} [ ';' ] 'instance' [scontext '=>'] qtycls inst ['where' idecls]
+             |   {modifier} [ ';' ] 'default' '(' type1 ',' ... ',' typen ')'
+             |   {modifier} [ ';' ] 'foreign' fdecl
+             |   {modifier} ';' decl
+
+   Recall that the Haskell 2010 Report uses brackets to denote an optional bit
+   of syntax. The optional semicolons allow modifiers to appear on a line
+   previous from the declaration affected. The semicolon is mandatory on
+   ``decl`` because ``decl``\ s do not start with keywords (except for fixity
+   declarations) and may have modifiers of their own. The semicolon makes
+   clear that the modifier is meant to affect the entire declaration.
 
 8. Reserve the use of ``%`` in a prefix occurrence to be used only for modifiers;
    though this proposal does not do so, we can imagine extending the modifier syntax
@@ -91,7 +98,7 @@ Proposed Change Specification
    import lists, etc.).
 
 9. Modifiers are parsed, renamed, and type-checked as *types*.
-   
+
 10. The type of a modifier is determined only by synthesis, never by checking.
     That is, in the bidirectional type-checking scheme used by GHC, we find the
     type of the modifier by running the synthesis judgment. Effectively, this
@@ -175,7 +182,7 @@ Effect and Interactions
   the general scheme (but ``%1`` is one such exception). It is possible that
   future extensions to this idea will be disambiguated before the type checker
   gets a chance to do its work.
-  
+
 * This proposal means that ``Int %m -> Bool``, acceptable today as a
   multiplicity-polymorphic function, would be rejected. The user would need
   to add a kind annotation to tell us that ``m`` is a multiplicity (and not,
@@ -209,7 +216,7 @@ Effect and Interactions
   via a plugin. Perhaps some modifier supports some function call to the GHC API that
   transforms the meaning of bit of syntax. The possibilities are
   tantalizing.
-  
+
 * These modifiers recall Java's `Annotations <https://en.wikipedia.org/wiki/Java_annotation>`_
   mechanism, which were a direct inspiration.
 
@@ -232,7 +239,7 @@ Effect and Interactions
 * Because modifiers are treated as types, they will typically begin with
   a capital letter. (Note that a polymorphic multiplicity is a type variable,
   and this is fine.)
-  
+
 Costs and Drawbacks
 -------------------
 * The loss of the inferred kind of ``m`` in multiplicity polymorphism is a
@@ -260,7 +267,10 @@ Alternatives
 
 * We could avoid ambiguity using extra punctuation (e.g. ``class ( %Mod1, %Mod2 ) C a b => D a b c where ...``),
   but "modifiers come before what they modify" is simple and uniform.
-  
+
+* We could require semicolons between modifiers and opening keyword
+  for all declarations, but it seems easy enough and harmless enough not to.
+
 Unresolved Questions
 --------------------
 * Is it too soon? That is, this proposal solves a problem we do not yet have:


### PR DESCRIPTION
This PR is an amendment to the previously accepted Modifiers proposal #370.

Changes:

* Clarify that modifiers *precede* the thing they modify.

* Correct the syntax for linear record fields, which was different than the syntax in the accepted linear types proposal.

* Allow a limited facility for future compatibility.

Also:

* Change the syntax for annotating a lambda-expression with a multiplicity. This did not conform to the general scheme for modifiers. Given that this feature is also unimplemented, it seemed like a good time to tweak the syntax to allow for a more uniform treatment for modifiers. This patch also comes with a tweak to the linear-types proposal to mirror the update here.

Original modifiers proposal: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0370-modifiers.rst
Updated modifiers proposal: https://github.com/goldfirere/ghc-proposals/blob/clarify-modifiers/proposals/0370-modifiers.rst
Diff: https://github.com/goldfirere/ghc-proposals/compare/7bb3ca581771fcac4753140e51e8df33bc10c0c0...clarify-modifiers  You can view a "rich diff", showing the changes in a rendered version, by clicking on the "page" icon to the top-right of the modified files on that page.