### PR TITLE
Fix date-accepted in 0313-delimited-continuation-primops.rst

### DIFF
--- a/proposals/0313-delimited-continuation-primops.rst
+++ b/proposals/0313-delimited-continuation-primops.rst
@@ -2,7 +2,7 @@ Delimited continuation primops
 ==============================
 
 .. author:: Alexis King
-.. date-accepted:: 2020-01-18
+.. date-accepted:: 2021-01-18
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell


### PR DESCRIPTION
I'm assuming that this was meant to be today? Apologies if I'm wrong and this was accepted a year ago.