### PR TITLE
Clarify that the Simons get another 3 years

### DIFF
--- a/committee.rst
+++ b/committee.rst
@@ -154,6 +154,8 @@ and Simon Marlow will be expected to be retained on the committee when
 their terms end. If either wishes to continue serving on the committee
 when their terms end, and if the majority of the rest of the committee supports this outcome,
 no public nomination process needs to take place to replace them.
+At that point, the key members are retained on the committee for another
+three-year term.
 
 These key members can be stripped of their status as key members by a
 majority vote of the committee, and other individuals can be made into


### PR DESCRIPTION
Another small bylaws tweak, clarifying that "key members" (e.g. the Simons) get another 3 years when they renew their membership.

If you are a committee member and like what you see, please just merge.