### PR TITLE
Generalize #229 to include consym

### DIFF
--- a/proposals/0229-whitespace-bang-patterns.rst
+++ b/proposals/0229-whitespace-bang-patterns.rst
@@ -107,14 +107,14 @@ Proposed Change Specification
   ``-XTemplateHaskell`` is also enabled, as well as ``⦇`` as opening and ``⦈``
   as closing if ``-XArrows`` is also enabled.
 
-* Any unqualified ``varsym`` is interpreted as "prefix", "suffix", "tight
-  infix", or "loose infix", based on the preceding and following lexical
-  non-terminals:
+* Any unqualified operator (``varsym`` or ``consym``) is interpreted as
+  "prefix", "suffix", "tight infix", or "loose infix", based on the preceding
+  and following lexical non-terminals:
 
-  * Prefix occurrence: not(closing), ``varsym``, opening
-  * Suffix occurrence: closing, ``varsym``, not(opening)
-  * Tight infix occurrence: closing, ``varsym``, opening
-  * Loose infix occurrence: not(closing), ``varsym``, not(opening)
+  * Prefix occurrence: not(closing), operator, opening
+  * Suffix occurrence: closing, operator, not(opening)
+  * Tight infix occurrence: closing, operator, opening
+  * Loose infix occurrence: not(closing), operator, not(opening)
 
   The general principle can be demonstrated as follows::
 
@@ -182,8 +182,8 @@ Proposed Change Specification
   * ``?`` under ``-XImplicitParams``
   * ``.`` as module qualification
 
-  These are not subject to a meaning override as there is no ``varsym`` to
-  reinterpret.
+  These are not subject to a meaning override as there is no ``varsym`` or
+  ``consym`` to reinterpret.
 
 * In the grammar, a bang/lazy pattern must be followed by ``aexp1``, a
   strictness annotation must be followed by ``atype``.


### PR DESCRIPTION
Due to an oversight, the proposal talks about `varsym` specifically rather than operators in general (which can be either `varsym` or `consym`). In practice it manifests in an inconsistent behavior of `-Woperator-whitespace`, which I noticed while implementing #368

```haskell
ghci> f = \x y -> x: y
ghci> f = \x y -> x+ y

<interactive>:9:14: warning: [-Woperator-whitespace]
    The suffix use of a ‘+’ might be repurposed as special syntax
      by a future language extension.
    Suggested fix: add whitespace around it.
```

Note the lack of a warning in case of `:`. Likewise, it would not be triggered by any other operator that starts with `:`.

With the proposed amendment, this omission is fixed.