### PR TITLE
Linear types: remove the change to ($)

### DIFF
--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -607,15 +607,6 @@ implementing linear variants of ``base`` functions remain compatible
 with ``base`` (e.g. there need not be two ``Maybe`` types, two list
 types etc).
 
-The only function which will need to change is ``($)`` because its
-typing rule is built in the type checker. Ignoring the details about
-levity and higher-rank polymorphism in the typing rule, the type
-``($)`` will be:
-
-::
-
-  ($) :: (a %p -> b) ⊸ a %p -> b
-
 Defining a linear variant of ``base`` is out of scope of this
 proposal. Possible future standardisation of the library content is
 the competence of the Core Libraries Committee (CLC). For expository


### PR DESCRIPTION
This removes one paragraph that has been obsoleted.

The linear types proposal stated that `($)` should be made multiplicity polymorphic. When the proposal was being written, GHC had a special typing rule for `($)` and this change had to happen on the compiler level. For all other functions, multiplicity polymorphism could be delegated to writers of a linear base library.

With Quick Look impredicativity, `($)` no longer has a special typing rule, as described in [the QL proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0274-quick-look-impredicativity.rst#the-typing-rule-for) and implemented in [commit 97cff9190d34, GHC/Tc/Gen/Expr.hs](https://github.com/ghc/ghc/commit/97cff9190d346c3b51c32c88fd145fcf1e6678f1#diff-89732e476498f11fb81fe436f984a9768a468334edb579073c4cb28af3346176L349).

There is no longer a reason to treat `($)` differently. Implementation-wise, there is nothing to do - the deleted text has not been implemented.