### PR TITLE
Add GC traceable pointer type

### DIFF
--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -62,8 +62,8 @@ data PrimArray a = PrimArray GAddr# Int#
 We don't need another slice type: the slicing operation can be implemented like:
 
 ```
-take :: Int -> PrimArray Word8 -> PrimArray Word8
-take (PrimArray gaddr len) (I# n) | n <=# len = PrimArray (gaddr `plusGAddr#` n) (len -# n)
+drop :: Int -> PrimArray Word8 -> PrimArray Word8
+drop (PrimArray gaddr len) (I# n) | n <=# len = PrimArray (gaddr `plusGAddr#` n) (len -# n)
                                   | otherwise = error "..."
 ```
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -35,6 +35,16 @@ We propose adding a new primitive type `GAddr#`, which is:
 + It can be added or substracted with offset, the result is still a `GAddr#`, which is traceable.
 + It can be passed to FFI like a pointer type, such as `char*` or `int16_t*` depend on types.
 
+An additional change is to change default string literals's type to use `GAddr#`, i.e. the following functions from `GHC.CString` will be changed to:
+
+```
+unpackCString# :: GAddr# -> [Char]
+unpackCStringUtf8# :: GAddr# -> [Char]
+...
+```
+
+User could continue to use rules to rewrite custom string type to use `GAddr#`. This change is breaking, and not necessary to be implemented in this proposal.
+
 ## Effect and Interactions
 
 Now we can have a unified slice and array type:

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -57,7 +57,7 @@ The new slice type could:
 + Save a closure length word.
 + Save an offset word.
 
-Which would be `3*8 = 16` bytes on a 64bit machine!
+Which would be `3*8 = 24` bytes on a 64bit machine!
 
 For FFI code, we should be able to write:
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -5,7 +5,7 @@ ticket-url: ""
 implemented: ""
 ---
 
-This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/414).
 **After creating the pull request, edit this file again, update the number in
 the link, and delete this bold sentence.**
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -35,7 +35,7 @@ We propose adding a new primitive type `GAddr#`, which is:
 + It can be added or substracted with offset, the result is still a `GAddr#`, which is traceable.
 + It can be passed to FFI like a pointer type, such as `char*` or `int16_t*` depend on types.
 
-An additional change is to change default string literals's type to use `GAddr#`, i.e. the following functions from `GHC.CString` will be changed to:
+An additional change is to change default string literal's type to use `GAddr#`, i.e. the following functions from `GHC.CString` will be changed to:
 
 ```
 unpackCString# :: GAddr# -> [Char]
@@ -43,7 +43,7 @@ unpackCStringUtf8# :: GAddr# -> [Char]
 ...
 ```
 
-User could continue to use rules to rewrite custom string type to use `GAddr#`. This change is breaking, and not necessary to be implemented in this proposal.
+User could continue to use rules to rewrite custom string type to use `GAddr#`. This change is breaking, and not necessarily to be implemented in this proposal.
 
 ## Effect and Interactions
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -28,9 +28,16 @@ Oh my!
 
 We propose adding a new primitive type `GAddr#`, which is:
 
-+ Allocated from a threaded local slab allocator, here slab means memory pool classified by size(16, 32, 64...).
-+ It's GC traceable.
++ Allocated from a threaded local slab allocator, here slab means memory pool classified by size(16, 32, 64...), allocation consisted by three steps: 
+    1. Find a suitable slab pool, which can be a block with special descriptor.
+    2. Find an empty mark bit/slab.
+    3. Set the mark bit and return slab address.
++ `GAddr#` is GC traceable, GC should consist two parts:
+    1. Clear all mark bits in a slab pool.
+    2. If a `GAddr#` traces back to a slab pool, set corresponding mark bit.
++ Large `GAddr#` could still go through the old large object allocation routine.
 + It can be added or substracted with offset, the result is still a `GAddr#`, which is traceable.
++ It's users' responsibility to ensure don't produce a `GAddr#` across slab boundary.
 + It can be passed to FFI like a pointer type, such as `char*` or `int16_t*` depend on types.
 
 An additional change is to change default string literal's type to use `GAddr#`, i.e. the following functions from `GHC.CString` will be changed to:
@@ -42,6 +49,7 @@ unpackCStringUtf8# :: GAddr# -> [Char]
 ```
 
 User could continue to use rules to rewrite custom string type to use `GAddr#`. This change is breaking, and not necessarily to be implemented in this proposal.
+
 
 ## Effect and Interactions
 
@@ -85,9 +93,8 @@ Don't do it, and continue to use `ByteArray#` as the main byte array type.
 
 ## Unresolved Questions
 
-I have none.
+How does this `GAddr#` interact with previous compact region works? Probably can't support compact operations.
 
 ## Implementation Plan
 
 I hope the Haskell foundation could help.
- 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -87,13 +87,17 @@ It seems we already have a slab allocator for the older generation in low pause 
 
 A drawback of `GAddr#` is that the allocation cost compared with `ByteArray#` may be higher, we have to find a suitable slab, and do some bit twiddling work.
 
+Under certain allocation pattern, slab based solution may lead to more memory fragmentation, but this is not an issue in realworld use case, and many other runtime systems use similar memory allocation scheme.
+
 ## Alternatives
 
 Don't do it, and continue to use `ByteArray#` as the main byte array type.
 
 ## Unresolved Questions
 
-How does this `GAddr#` interact with previous compact region works? Probably can't support compact operations.
++ How does this `GAddr#` interact with previous compact region works? Probably can't support compact operations.
+
++ Do we have to provide primitive operations to copy data back and forth between `Addr#`, `GAddr#` and `MutableByteArray#/ByteArray#`? That will be a lot of work.
 
 ## Implementation Plan
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -1,0 +1,85 @@
+---
+author: Dong
+date-accepted: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
+**After creating the pull request, edit this file again, update the number in
+the link, and delete this bold sentence.**
+
+# Add GC traceable pointers backed by a threaded slab allocator
+
+Currently, we have a messy story on standard byte array and slice types:
+
++ The standard byte slice type in GHC is `ByteString`, which is backed by `ForeignPtr`.
++ `ForeignPtr` is actually implemented with `MutableByteArray#` if it's allocated on GHC heap.
++ `ForeignPtr` uses `Addr#`, which uses `mutableByteArrayContent`, and in turn requires `touch#` to be safe.
++ The vector package use `ByteArray#` directly. 
++ Small `ByteArray#` could be unpinned, thus can't be passed in safe FFI.
++ If we pass `ByteArray#` to FFI, the slicing offset has to be passed separately.
+
+Oh my!
+
+## Motivation
+
++ We want a unified, easy to be used with FFI, memory, and CPU cost-effective pointer type to represent byte arrays. 
+
+## Proposed Change Specification
+
+We propose adding a new primitive type `GAddr#`, which is:
+
++ Allocated from a threaded local slab allocator, here slab means memory pool classified by size(16, 32, 64...).
++ It's GC traceable.
++ It can be added or substracted with offset, the result is still a `GAddr#`, which is traceable.
++ It can be passed to FFI like a pointer type, such as `char*` or `int16_t*` depend on types.
+
+## Effect and Interactions
+
+Now we can have a unified slice and array type:
+
+```
+data PrimArray a = PrimArray GAddr# Int#
+```
+
+We don't need another slice type: the slicing operation can be implemented like:
+
+```
+take :: Int -> PrimArray Word8 -> PrimArray Word8
+take (PrimArray gaddr len) (I# n) | n <=# len = PrimArray (gaddr +# n) (len -# n)
+                                  | otherwise = error "..."
+```
+
+The new slice type could:
+
++ Save an info table word.
++ Save a closure length word.
++ Save an offset word.
+
+Which would be `3*8 = 16` bytes a 64bit machine!
+
+For FFI code, we should be able write:
+
+```
+memcpy :: GAddr# -> GAddr# -> Int# -> IO ()
+```
+
+## Costs and Drawbacks
+
+It seems we already have a slab allocator for the older generation in low pause GC work, so the extra work is adding new primitive types mainly.
+
+A drawback of `GAddr#` is that the allocation cost compared with `ByteArray#` may be higher, we have to find a suitable slab, and do some bit twiddling work.
+
+## Alternatives
+
+Don't do it, and continue to use `ByteArray#` as the main byte array type.
+
+## Unresolved Questions
+
+I have none.
+
+## Implementation Plan
+
+I hope the Haskell foundation could help.
+ 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -47,7 +47,7 @@ We don't need another slice type: the slicing operation can be implemented like:
 
 ```
 take :: Int -> PrimArray Word8 -> PrimArray Word8
-take (PrimArray gaddr len) (I# n) | n <=# len = PrimArray (gaddr +# n) (len -# n)
+take (PrimArray gaddr len) (I# n) | n <=# len = PrimArray (gaddr `plusGAddr#` n) (len -# n)
                                   | otherwise = error "..."
 ```
 
@@ -57,9 +57,9 @@ The new slice type could:
 + Save a closure length word.
 + Save an offset word.
 
-Which would be `3*8 = 16` bytes a 64bit machine!
+Which would be `3*8 = 16` bytes on a 64bit machine!
 
-For FFI code, we should be able write:
+For FFI code, we should be able to write:
 
 ```
 memcpy :: GAddr# -> GAddr# -> Int# -> IO ()
@@ -67,7 +67,7 @@ memcpy :: GAddr# -> GAddr# -> Int# -> IO ()
 
 ## Costs and Drawbacks
 
-It seems we already have a slab allocator for the older generation in low pause GC work, so the extra work is adding new primitive types mainly.
+It seems we already have a slab allocator for the older generation in low pause GC work, so the extra work is adding new primitive types mainly, but I'm not sure.
 
 A drawback of `GAddr#` is that the allocation cost compared with `ByteArray#` may be higher, we have to find a suitable slab, and do some bit twiddling work.
 

--- a/proposals/0000-add-GC-traceable-pointers.md
+++ b/proposals/0000-add-GC-traceable-pointers.md
@@ -6,8 +6,6 @@ implemented: ""
 ---
 
 This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/414).
-**After creating the pull request, edit this file again, update the number in
-the link, and delete this bold sentence.**
 
 # Add GC traceable pointers backed by a threaded slab allocator
 


### PR DESCRIPTION
We propose adding a new primitive type `GAddr#`, which is:

+ Allocated from a threaded local slab allocator, here slab means memory pool classified by size(16, 32, 64...).
+ It's GC traceable.
+ It can be added or substracted with offset, the result is still a `GAddr#`, which is traceable.
+ It can be passed to FFI like a pointer type, such as `char*` or `int16_t*` depend on types.


[Rendered](https://github.com/ZHaskell/ghc-proposals/blob/gaddr/proposals/0000-add-GC-traceable-pointers.md)