### PR TITLE
Add rows to syntax table for punned updates

### DIFF
--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -112,6 +112,8 @@ Expression              Equivalent
 ``e{lbl₁.lbl₂ = val}``  ``e{lbl₁ = (e.lbl₁){lbl₂ = val}}``
 ``e.lbl₁{lbl₂ = val}``  ``(e.lbl₁){lbl₂ = val}``
 ``e{lbl₁ = val₁}.val₂`` ``(e{lbl₁ = val₁}).val₂``
+``e{lbl₁}``             ``e{lbl₁ = lbl₁}`` [Note: requires ``NamedFieldUpdates``]
+``e{lbl₁.lbl₂}``        ``e{lbl₁.lbl₂ = lbl₂}`` [Note: requires ``NamedFieldUpdates``]
 ======================= ==================================
 
 [Note: ``e{lbl = val}`` is the syntax of a standard H98 record update.


### PR DESCRIPTION
Bug-fix: As pointed out by @adamgundry  in the ["Refactor RecordUpd"](https://gitlab.haskell.org/ghc/ghc/-/issues/19463#note_347206) ticket, punned field update syntax is missing in the syntax table of [Section 2.2.1](https://github.com/shayne-fletcher/ghc-proposals/blob/master/proposals/0282-record-dot-syntax.rst#211-syntax). This fixes it.