### PR TITLE
no-implicit-binds: Adjust defaulting of `-XPatternSignatureBinds`

### DIFF
--- a/proposals/0285-no-implicit-binds.rst
+++ b/proposals/0285-no-implicit-binds.rst
@@ -55,7 +55,8 @@ It is on by default for backwards compatibility.
 When using ``-XNoImplicitForAll``, all variables in regular signatures, instances, and data declarations must be explicitly bound.
 
 Create ``-XPatternSignatureBinds`` to allow the implicit binding of free variables in pattern signatures.
-It is also on by default for backwards compatibility.
+It is implied by ``-XScopeTypeVariables`` by default for backwards compatibility.
+(Without ``-XScopeTypeVariables`` it currently has no effect, so we are free to have it off by default.)
 When using ``-XNoPatternSignatureBinds``, all variables in pattern signatures must be explicitly bound.
 
 Examples


### PR DESCRIPTION
Today `-XPatternSignatureBinds` only matters when `-XScopeTypeVariables` is enabled, but proposal #238 would re-introduce `-XPatternSignatures`, with which `-XPatternSignatureBinds` would also be visible.

We cannot change the meaning of `-XScopeTypeVariables`, but I would rather `-XPatternSignatures` alone not cause any variables to be bound, as this is the more conservative, forwards compatible option, and one that I believe would best position `-XPatternSignatures` to become part of a future Haskell report even if the other extensions are hotly debated.

Finally, this means #238 can be a bit simpler and just assume the existence of `-XPatternSignatureBinds` without having to change any aspect of it.

[Rendered](https://github.com/Ericson2314/ghc-proposals/blob/no-implicit-forall/proposals/0285-no-implicit-binds.rst)

<!-- probot = {"1313345":{"who":"nomeata","what":"ping Simon","when":"2021-04-28T09:00:00.000Z"}} -->