### PR TITLE
Standalone deriving clauses grouped by strategy

### DIFF
--- a/proposals/0000-multiple-standalone-deriving.md
+++ b/proposals/0000-multiple-standalone-deriving.md
@@ -36,7 +36,7 @@ deriving via Generically (Foo a)
 ## Motivation
 
 Being able to write a deriving strategy once and use it multiple times
-can save a considerable amount of typing, especially when types get long
+can save a considerable amount of typing, especially when types get long.
 For example, one might wish to do something like
 
 ```haskell


### PR DESCRIPTION
Add support for multiple standalone `deriving` clauses for
each deriving strategy. This can considerably reduce boilerplate
for `DerivingVia`.

[Rendered](https://github.com/treeowl/ghc-proposals/blob/multi-standalone/proposals/0000-multiple-standalone-deriving.md)