### PR TITLE
Articulate principles for GHC evolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ GHC.
 * `≡ List of rejected proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Rejected%22>`_
 * `≡ List of implemented proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_
 * `≡ List of all proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=>`_
-  
+
 What is a proposal?
 -------------------
 
@@ -41,6 +41,10 @@ Should the GHC maintainers deem a change significant or controversial enough to
 warrant that, they may, at their discretion, involve the committee and ask the
 contributor to write a formal proposal.
 
+Proposals may contain amendments to our principles_, which serve as a guideline
+for future proposals and for the general evolution of GHC.
+
+.. _principles: principles.rst
 
 The life cycle of a proposal
 -----------------------------------
@@ -504,6 +508,13 @@ and any other relevant considerations, appropriately.
    with other new features. In the common case the original implementor of
    a feature moves on to other things after a few years, and this
    maintenance burden falls on others.
+
+* *It should conform to existing principles*. This repository contains
+  a principles_ document that lays out various principles guiding future
+  directions for GHC. Proposals should seek to uphold these principles
+  in new features, as much as possible. Note that these principles are not
+  absolutes, and regressions against the principles are possible, if a
+  proposal is otherwise very strong.
 
 How to build the proposals?
 ---------------------------

--- a/principles.rst
+++ b/principles.rst
@@ -24,9 +24,11 @@ a change to GHC.
 
 We urge proposers to resist the temptation to propose principles without an
 accompanying concrete change to GHC. Debating principles in the abstract does
-not seem a productive use of time, though it is possible to imagine exceptions. 
+not seem a productive use of time, though it is possible to imagine exceptions.
 For example, the justification for the rejection of a proposal may be distilled into
-a new principle here.
+a new principle here. Accordingly, this document is not (and presumably never will be)
+comprehensive: it contains the articulated prinicples guiding GHC's development
+but lacks the unarticulated principles, which will be added over time.
 
 All principles in this document are linked back to the PR that introduce them,
 so that readers can learn the context in which they were written.

--- a/principles.rst
+++ b/principles.rst
@@ -23,7 +23,9 @@ a change to GHC.
 
 We urge proposers to resist the temptation to propose principles without an
 accompanying concrete change to GHC. Debating principles in the abstract does
-not seem a productive use of time, though it is possible to imagine exceptions.
+not seem a productive use of time, though it is possible to imagine exceptions. 
+For example, the justification for the rejection of a proposal may be distilled into
+a new principle here.
 
 All principles in this document are linked back to the PR that introduce them,
 so that readers can learn the context in which they were written.

--- a/principles.rst
+++ b/principles.rst
@@ -80,5 +80,5 @@ not be affected by it.
 
 This principle is violated in various ways today: it is easy for GHC to generate error messages that refer to
 advanced features even when writing simple code. In addition, the existence of advanced features likely slow
-down GHC even when those features are not active. Yet this principle is an important to keep in mind going forward,
+down GHC even when those features are not active. Yet this principle is important to keep in mind going forward,
 as we hope not to make the current situation worse.

--- a/principles.rst
+++ b/principles.rst
@@ -1,0 +1,82 @@
+Principles for GHC
+==================
+
+This document lays out high-level principles for the evolution of GHC
+and the language it compiles. In much the way that we like to write
+*properties* of our functions -- instead of just writing down individual
+test cases -- this document strives to write *principles* of our proposals.
+
+Articulating these principles helps to guide future proposals: proposals
+that maintain the principles in this document are more likely to be accepted,
+while proposals that work against these principles are more likely to be rejected.
+Note that neither direction is (at all) a guarantee: there will be excpetions
+in both directions. Yet by writing down the principles, we can have an informed
+discussion of the tradeoffs of accepted or rejecting an individual proposal.
+
+How to update these principles
+------------------------------
+
+When making a proposal, following the `usual guidelines <https://github.com/ghc-proposals/ghc-proposals/#how-to-start-a-new-proposal>`_,
+feel free to include a diff against this listing of principles. We can then
+discuss the validity of the new principle(s) alongside the concrete proposal for
+a change to GHC.
+
+We urge proposers to resist the temptation to propose principles without an
+accompanying concrete change to GHC. Debating principles in the abstract does
+not seem a productive use of time, though it is possible to imagine exceptions.
+
+All principles in this document are linked back to the PR that introduce them,
+so that readers can learn the context in which they were written.
+
+Accepted principles
+-------------------
+
+.. _`#378`: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0378-dependent-type-design.rst
+
+Syntax
+~~~~~~
+
+.. _SUP:
+
+**Syntactic Unification Principle (SUP).** (From `#378`_.) In the absence of punning, there is
+no difference between type-syntax and term-syntax.
+
+The SUP_ is a *long term* goal; today, there are many, many violations of this principle. (For example,
+``case`` can never appear in types, and ``Int -> Bool`` is meaningless in a term.) However, this principle
+should direct future proposals not to make the situation worse, and proposals that bring us closer to
+the SUP_ are to be valued.
+
+Name resolution
+~~~~~~~~~~~~~~~
+
+.. _LSP:
+
+**Lexical Scoping Principle (LSP)**. (From `#378`_.) For every *occurrence* of an
+identifier, it is possible to uniquely identify its *binding site*, without
+involving the type system.
+
+The LSP_ is true today, though Template Haskell splices may need to be run before
+completing name resolution (and running those splices requires type-checking them).
+
+Semantics
+~~~~~~~~~
+
+.. _PEP:
+
+**Predictable Erasure Principle (PEP)**. (From `#378`_.) The programmer knows, for sure, which bits of the program will be
+retained at runtime, and which will be erased.
+
+The PEP_ is true today: types are erased, while terms are retained.
+
+User experience
+~~~~~~~~~~~~~~~
+
+.. _OIP:
+
+**The Opt-In Principle (OIP):** (From `#378`_, slightly generalized.) Users who do not opt into an advanced feature will
+not be affected by it.
+
+This principle is violated in various ways today: it is easy for GHC to generate error messages that refer to
+advanced features even when writing simple code. In addition, the existence of advanced features likely slow
+down GHC even when those features are not active. Yet this principle is an important to keep in mind going forward,
+as we hope not to make the current situation worse.

--- a/principles.rst
+++ b/principles.rst
@@ -4,7 +4,8 @@ Principles for GHC
 This document lays out high-level principles for the evolution of GHC
 and the language it compiles. In much the way that we like to write
 *properties* of our functions -- instead of just writing down individual
-test cases -- this document strives to write *principles* of our proposals.
+test cases -- this document strives to write *principles* that our proposals
+ought to maintain (or build towards).
 
 Articulating these principles helps to guide future proposals: proposals
 that maintain the principles in this document are more likely to be accepted,

--- a/principles.rst
+++ b/principles.rst
@@ -1,3 +1,6 @@
+.. sectnum::
+.. highlight:: haskell
+
 Principles for GHC
 ==================
 


### PR DESCRIPTION
This PR is an attempt to create a central place in the proposals repo for *principles*. We can then use these principles to guide our responses to individual proposals.

The principles written in the current document are just taken from #378. I do not wish to debate these principles in this PR -- that happened in #378. Instead, let's use this PR to debate whether articulating these principles centrally is a good idea, and whether the document in the form here is the best way to do so.

Concrete motivation: once this PR is accepted, then I will rephrase #448 to update it with all the principles in that proposal. Accepting #448 will thus change our set of principles.

[Rendered](https://github.com/goldfirere/ghc-proposals/blob/principles/principles.rst)