### PR TITLE
Syntax for tuples, unboxed tuples, unboxed sums

### DIFF
--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -630,9 +630,9 @@ Syntax
 
    * ``[]`` as the list type constructor
    * ``()`` as the unit type
-   * ``[a]`` the syntax of a list type
-   * ``(,)`` as the pair type constructor
-   * ``(a, b)`` as the syntax of a pair type
+   * ``[a]`` as the syntax of the list type
+   * ``(,)`` as the pair type constructor (likewise for ``(,,)``, ``(,,,)``, and so on)
+   * ``(a, b)`` as the syntax of the pair type (likewise for ``(a, b, c)``, ``(a, b, c, d)``, and so on)
 
    When the extension is on, these constructs retain their Haskell 2010
    meaning, which depends on whether we are in a type-level or term-level
@@ -654,23 +654,41 @@ Syntax
 
    Export the following synonym from the ``Data.Tuple`` module::
 
-     type Unit = ()
+     type Unit = ()   -- Tuple0 has a special name
 
-   For tuples of higher arities, users may want to define their own
-   synonyms, such as::
+     type Tuple2 = (,)
+     type Tuple3 = (,,)
+     type Tuple4 = (,,,)
 
-     type TupleOf2 = (,)
-     type TupleOf3 = (,,)
-     type TupleOf4 = (,,,)
      ... -- up to the maximum tuple arity
-
-   We do not propose adding them to ``Data.Tuple`` for the time being,
-   as better APIs are possible (e.g. based on variadic data families)
-   but are blocked by other technical issues. We leave it as future work.
 
    This change allows the use of built-in lists and tuples without any
    disambugation syntax (the ``'`` promotion syntax at the type level or the
    ``type`` herald at the term level).
+
+   Under ``NoListTupleTypeSyntax``, the synonyms are also to be used when
+   printing inferred types.
+
+   This extension interacts with ``UnboxedTuples``, ``UnboxedSums``, which also
+   rely on punning. ``ListTupleTypeSyntax`` has a similar effect on ``(# #)``,
+   ``(# , #)``, ``(# | #)``, and so on.
+
+   Export the following names from ``GHC.Exts``::
+
+     type Unit#    -- Tuple0# has a special name
+
+     type Tuple1#
+     type Tuple2#
+     type Tuple3#
+     type Tuple4#
+
+     ... -- up to the maximum unboxed tuple arity
+
+     type Sum2#
+     type Sum3#
+     type Sum4#
+
+     ... -- up to the maximum unboxed sum arity
 
 5. When ``ViewPatterns`` are enabled, interpret ``f (a -> b) = ...``
    as a view pattern, otherwise as ``f ((->) a b) = ...``.
@@ -1040,7 +1058,7 @@ Corner Cases
    One way to change this is to use synonyms
    from ``Data.Tuple`` and ``Data.List``::
 
-     x1 = g (TupleOf2 Int Bool)
+     x1 = g (Tuple2 Int Bool)
      x2 = g (List Int)
 
    Another way is to use the ``type`` herald::
@@ -1061,8 +1079,8 @@ Corner Cases
    One way to resolve this is to use synonyms
    from ``Data.Tuple`` and ``Data.List``::
 
-      a = f @(TupleOf2 Int Bool)
-      b = g  (TupleOf2 Int Bool)
+      a = f @(Tuple2 Int Bool)
+      b = g  (Tuple2 Int Bool)
 
    Another way is to use the ``type`` herald::
 

--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -659,7 +659,6 @@ Syntax
      type Tuple2 = (,)
      type Tuple3 = (,,)
      type Tuple4 = (,,,)
-
      ... -- up to the maximum tuple arity
 
    This change allows the use of built-in lists and tuples without any
@@ -681,14 +680,13 @@ Syntax
      type Tuple2#
      type Tuple3#
      type Tuple4#
-
-     ... -- up to the maximum unboxed tuple arity
+     ... -- and so on
 
      type Sum2#
      type Sum3#
      type Sum4#
+     ... -- and so on
 
-     ... -- up to the maximum unboxed sum arity
 
 5. When ``ViewPatterns`` are enabled, interpret ``f (a -> b) = ...``
    as a view pattern, otherwise as ``f ((->) a b) = ...``.


### PR DESCRIPTION
When writing #281, I thought I could postpone specifying the treatment of tuples under `NoListTupleTypeSyntax`. However, what slipped my attention was that we need some syntax to report inferred types in GHCi and error messages:

```
ghci> :set -XNoListTupleTypeSyntax
ghci> :t ('x', True)
```

If we printed `(Char, Bool)` here, we’d be flat out wrong, because under this extension this syntax actually stands for a pair of types, not for the type of a pair. Instead, we should print something like:

```
ghci> :t ('x', True)
Tuple2 Char Bool
```

There are plenty of options besides `Tuple2`. We could go with a type family taking a list of types (i.e. `Tuple [Char, Bool]`), a variadic data family (`Tuple Char Bool`), magic names starting with numbers (`2-Tuple Char Bool`), or just a different naming convention (`TupleOf2 Char Bool`).

After having discussed this with @goldfirere and @simonpj, we decided against `Tuple [Char, Bool]` and variadic `Tuple Char Bool`. The former does not interact well with partial application (which is needed to define higher-kinded instances such as `Functor`), and the latter would require additional complexity in the compiler (special type inference rules for the wired-in `Tuple` tycon, type families in data family return kind, data family promotion).

This leaves us with `Tuple2`, `2-Tuple`, and `TupleOf2`.

* I like `2-Tuple` the most (as that’s how we say in out loud), but it would require an ad-hoc extension to the lexer to allow a name starting with a number and with a hyphen. I bet I could make it work, but I’m not sure what others think of the idea.

* The `Tuple2` name is the most straightforward solution, we already have other names with numeric suffixes (e.g. `zipWith3`, `zipWith4`, etc). However, the numeric suffix convention is also used by classes, such as `Eq1` and `Eq2` in `Data.Functor.Classes`, with the number indicating the arity of a higher-kinded type variable. So this interpretation would suggest that `Tuple2` is defined as `data Tuple2 f g x y = T2 (f x y) (g x y)` or similar.

* The `TupleOf2` resolves the potential confusion with the `Eq1` / `Eq2` notation, but the name is a bit longer and does not look as nice.

This should probably be decided by a vote.

<!-- probot = {"1313345":{"who":"goldfirere","what":"kick off the vote if the conversation has led to a good resting place","when":"2021-11-24T09:00:00.000Z"}} -->