### PR TITLE
371-non-magical-eq: more graceful migration (under review)

### DIFF
--- a/proposals/0371-non-magical-eq.md
+++ b/proposals/0371-non-magical-eq.md
@@ -35,11 +35,17 @@ Let `n` be the GHC version that implements this proposal.
 
 Starting with GHC `n`, include a compatibility fallback:
 
-* When the lookup for `~` fails because it is not in scope,
-  assume it refers to `Data.Type.Equality.~`.
-  When this happens and `-Wcompat` is in effect, emit a warning.
+1. When the lookup for `~` fails because it is not in scope,
+   assume it refers to `Data.Type.Equality.~`.
+   When this happens and `-Wtype-equality-out-of-scope` (included in
+   `-Wcompat`) is in effect, emit a warning.
 
-Starting with GHC `n+2`, enable the warning by default.
+2. When the use of `~` would have been rejected because `TypeOperators` are not
+   enabled, accept the program regardless.
+   When this happens and `-Wtype-equality-requires-operators` (enabled by
+   default) is in effect, emit a warning.
+
+Starting with GHC `n+2`, enable both warnings by default.
 Either starting with GHC `n+8` or with the next major compiler version bump (GHC
 10), whichever comes first, remove the compatibility fallback.
 


### PR DESCRIPTION
While implementing this proposal, I noticed that there are quite a few packages (just to name some: primitive, containers, Cabal, haddock, exceptions) that use `~` without enabling `TypeOperators`.

The proposal already includes a compatibility fallback, but does not cover this particular problem. This amendment extends the proposed compatibility fallback by making the usage of `~` without `TypeOperators` a warning instead of an error. In due course, the special case will be removed, but maintainers won’t have to modify their code immediately.

<!-- probot = {"1313345":{"who":"goldfirere","what":"accept if there is no dissent from the committee.","when":"2021-12-24T09:00:00.000Z"}} -->