### PR TITLE
New syntax for tuples and lists to remove punning

### DIFF
--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -6,7 +6,7 @@ Non-punning list and tuple syntax
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell
-.. header::
+.. header::  This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/475>`_.
 .. contents::
 .. sectnum::
 

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -218,7 +218,7 @@ Proposed Change Specification
 
    #. An unapplied occurrence of ``GHC.Types.List`` is pretty-printed as ``[]``.
 
-   #. An occurrence of ``GHC.Types.List ty`` is pretty-printed as ``[ty]]`.
+   #. An occurrence of ``GHC.Types.List ty`` is pretty-printed as ``[ty]``.
 
    #. An occurrence of ``GHC.Tuple.Prim.Unit`` is pretty-printed as ``()``.
 

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -190,7 +190,7 @@ Proposed Change Specification
       is expected to be of kind ``Constraint`` and either none of the ``tyi`` are inferred to have kind ``Constraint``
       or there exists a ``tyi`` inferred to kind ``Type`` and none of the ``tyj`` (with j < i) are inferred to have
       kind ``Constraint``, is
-      a synonym for ``GHC.Tuple.Prim.Tuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+      a synonym for ``GHC.Tuple.Prim.Tuple``\ *n* ``ty1 ty2 ... tyn-1 tyn``.
 
    #. An occurrence of ``(# #)`` in type-syntax is a synonym for ``GHC.Prim.Unit#``.
 
@@ -210,11 +210,11 @@ Proposed Change Specification
       is a synonym for ``GHC.Classes.CUnit``.
 
    #. An occurrence of ``(ty1, ty2, ..., tyn-1, tyn)`` (for *n* ≧ 2) in type-syntax, where the type is
-      expected to be of kind ``Constraint``, is a synonym for ``GHC.Classes.CTuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+      expected to be of kind ``Constraint``, is a synonym for ``GHC.Classes.CTuple``\ *n* ``ty1 ty2 ... tyn-1 tyn``.
 
    #. An occurrence of ``(ty1, ty2, ..., tyn-1, tyn)`` (for *n* ≧ 2) in type-syntax, where the first
       ``tyi`` inferred to have kind ``Type`` or ``Constraint`` has kind ``Constraint``, is a synonym
-      for ``GHC.Classes.CTuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+      for ``GHC.Classes.CTuple``\ *n* ``ty1 ty2 ... tyn-1 tyn``.
 
    #. An unapplied occurrence of ``GHC.Types.List`` is pretty-printed as ``[]``.
 

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -1,0 +1,324 @@
+Non-punning list and tuple syntax
+=================================
+
+.. author:: Richard Eisenberg (with much influence from collaborators)
+.. date-accepted::
+.. ticket-url::
+.. implemented::
+.. highlight:: haskell
+.. header::
+.. contents::
+.. sectnum::
+
+Introduce new names for the list type and tuple types to allow for users
+to write pun-free code. In addition, add a new extension that disables
+the built-in syntax for these types, thus requiring users to use the new
+names.
+
+.. _`#270`: https://github.com/ghc-proposals/ghc-proposals/pull/270
+.. _`#281`: https://github.com/ghc-proposals/ghc-proposals/pull/281
+.. _`#378`: https://github.com/ghc-proposals/ghc-proposals/pull/378
+.. _`#473`: https://github.com/ghc-proposals/ghc-proposals/pull/473
+
+Motivation
+----------
+Proposals `#270`_, `#281`_, `#378`_, and `#473`_ all struggle when faced
+with *puns*, the use of an identifier that can be interpreted either in the
+type-level namespace or the term-level namespace (but with different meanings).
+
+Furthermore, puns can be hard for newcomers to Haskell. It is not hard to jump
+from ::
+
+  single :: [Int]
+  single = [5]
+
+to ::
+
+  just :: Maybe Int
+  just = Maybe 5
+
+even though the latter is nonsense.
+
+Puns also cause trouble when describing what we are talking about: conversations
+around these features invariably require people to say "``[]``-the-type" or
+"``[]``-the-empty-list" or similar.
+
+This proposal thus allows for a common way to refer to tuples and lists without
+punning. It is entirely opt-in, though we expect the new phrasing to become popular
+over time.
+
+Proposed Change Specification
+-----------------------------
+
+1. Add the following definitions to a new module ``GHC.Tuple.Prim``::
+
+     data Unit = ()
+     data Solo a = MkSolo a    -- this is a change from today's `data Solo a = Solo a`
+
+     type Tuple0 = Unit
+     type Tuple1 = Solo
+     data Tuple2 a b = (a, b)
+     data Tuple3 a b c = (a, b, c)
+     -- ...
+     data Tuple64 ... = (...)
+
+#. Add the following definitions to ``GHC.Classes`` (re-exported from ``GHC.Exts``). These
+   replace similar definitions today::
+
+     class CUnit
+     instance CUnit
+
+     class a => CSolo a
+     instance a => CSolo a
+
+     type CTuple0 = CUnit
+     type CTuple1 = CSolo
+
+     class (a, b) => CTuple2 a b
+     instance (a, b) => CTuple2 a b
+
+     -- ...
+
+     class (...) => CTuple64 ...
+     instance (...) => CTuple64 ...
+
+#. Remove existing tuple definitions from ``GHC.Tuple``.
+
+#. Add the following definitions to ``GHC.Tuple``, which re-exports all of ``GHC.Tuple.Prim``::
+
+     type TupleNKind :: Nat -> Type     -- Nat is from GHC.TypeLits
+     type family TupleNKind n = r | r -> n where
+       TupleNKind 0 = Type
+       TupleNKind n = Type -> TupleNKind (n-1)   -- this fails the injectivity check, but a little magic will allow this
+
+     type TupleN :: forall (n :: Nat). TupleNKind n
+     type family TupleN @n where     -- using syntax from #425
+       TupleN @0 = Unit
+       TupleN @1 = Solo
+       TupleN @2 = Tuple2
+       TupleN @3 = Tuple3
+       TupleN @4 = Tuple4
+       -- ...
+       TupleN @64 = Tuple64
+
+     type Tuple :: List Type -> Type
+     type family Tuple ts where
+       Tuple []    = Unit
+       Tuple [a]   = Solo a
+       Tuple [a,b] = Tuple2 a b
+       -- ...
+       Tuple [...] = Tuple64 ...
+
+     type CTupleNKind :: Nat -> Type
+     type family CTupleNKind n = r | r -> n where
+       CTupleNKind 0 = Constraint
+       CTupleNKind n = Constraint -> CTupleNKind (n-1)
+
+     type CTupleN :: forall (n :: Nat). CTupleNKind n
+     type family CTupleN @n where
+       CTupleN @0  = CUnit
+       CTupleN @1  = CSolo
+       CTupleN @2  = CTuple2
+       CTupleN @3  = CTuple3
+       CTupleN @4  = CTuple4
+       -- ...
+       CTupleN @64 = CTuple64
+
+     type Constraints :: List Constraint -> Constraint
+     type family Constraints cs where
+       Constraints []    = CUnit
+       Constraints [a]   = CSolo a
+       Constraints [a,b] = CTuple2 a b
+       -- ...
+       Constraints [...] = CTuple64 ...
+
+#. Export the following pseudo-definitions from ``GHC.Prim``. Note that ``GHC.Prim`` defines
+   types that cannot be defined in Haskell, so we say that we just export these
+   from ``GHC.Prim``, not define them there. Note that ``GHC.Exts`` re-exports
+   ``GHC.Prim``::
+
+     type Unit# :: TYPE (TupleRep [])
+     data Unit# = (# #)
+
+     type Solo# :: TYPE rep -> TYPE (TupleRep [rep])
+     data Solo# a = MkSolo# a
+
+     type Tuple0# = Unit#
+     type Tuple1# = Solo#
+
+     type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE (TupleRep [r1, r2])
+     data Tuple2# a b = (# a, b #)
+
+     -- ...
+
+     type Tuple64# :: TYPE r1 -> ... -> TYPE r64 -> TYPE (TupleRep [r1, ..., r64])
+     data Tuple64# ... = (# ... #)
+
+     -- NB: There are no 0-sums or 1-sums in Haskell, today or tomorrow.
+
+     type Sum2# :: TYPE r1 -> TYPE r2 -> TYPE (SumRep [r1, r2])
+     data Sum2# a b = (# a | #) | (# | b #)
+
+     type Sum3# :: TYPE r1 -> TYPE r2 -> TYPE r3 -> TYPE (SumRep [r1, r2, r3])
+     data Sum3# a b c = (# a | | #) | (# | b | #) | (# | | c #)
+
+     -- ...
+
+     type Sum64# :: TYPE r1 -> ... -> TYPE r64 -> TYPE (SumRep [r1, ..., r64])
+     data Sum64# ... = ...
+
+#. Change ``GHC.Types`` to have the following definition::
+
+     data List a = [] | a : List a
+
+#. Introduce a new extension ``-XListTupleTypeSyntax``; this extension is on by default.
+
+#. With ``-XListTupleTypeSyntax``:
+
+   1. An occurrence of ``[]`` in type-syntax (as defined in `#378`_) is a synonym
+      for ``GHC.Types.List``.
+
+   #. An occurrence of ``[ty]`` in type-syntax is a synonym for ``GHC.Types.List ty``.
+
+   #. An occurrence of ``()`` in type-syntax, where the type is not expected to be of kind ``Constraint``,
+      is a synonym for ``GHC.Tuple.Prim.Unit``.
+
+   #. An occurrence of ``(,,...,,)`` where there are *n* commas (for *n* ≧ 1) in type-syntax
+      is a synonym for ``GHC.Tuple.Prim.Tuple``\ *n+1*.
+
+   #. An occurrence of ``(ty1,ty2,...,tyn-1,tyn)`` (for *n* ≧ 2) in type-syntax, where neither the type
+      is expected to be of kind ``Constraint`` and either none of the ``tyi`` are inferred to have kind ``Constraint``
+      or there exists a ``tyi`` inferred to kind ``Type`` and none of the ``tyj`` (with j < i) are inferred to have
+      kind ``Constraint``, is
+      a synonym for ``GHC.Tuple.Prim.Tuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+
+   #. An occurrence of ``(# #)`` in type-syntax is a synonym for ``GHC.Prim.Unit#``.
+
+   #. An occurrence of ``(#,,...,,#)`` where there are *n* commas (for *n* ≧ 1) in type-syntax
+      is a synonym for ``GHC.Prim.Tuple``\ *n+1*\ ``#``.
+
+   #. An occurrence of ``(# ty1, ty2, ... , tyn-1, tyn #)`` (for *n* ≧ 2) in type-syntax is a synonym
+      for ``GHC.Prim.Tuple``\ *n*\ ``# ty1 ty2 ... tyn-1 tyn``.
+
+   #. An occurrence of ``(# | | ... | | #)`` where there are *n* pipes (for *n* ≧ 1) in type-syntax
+      is a synonym for ``GHC.Prim.Sum``\ *n+1*\ ``#``.
+
+   #. An occurrence of ``(# ty1 | ty2 | ... | tyn-1 | tyn #)`` (for *n* ≧ 2) in type-syntax is a
+      synonym for ``GHC.Prim.Sum``\ *n*\ ``# ty1 ty2 ... tyn-1 tyn``.
+
+   #. An occurrence of ``()`` in type-syntax, where the type is expected to be of kind ``Constraint``,
+      is a synonym for ``GHC.Classes.CUnit``.
+
+   #. An occurrence of ``(ty1, ty2, ..., tyn-1, tyn)`` (for *n* ≧ 2) in type-syntax, where the type is
+      expected to be of kind ``Constraint``, is a synonym for ``GHC.Classes.CTuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+
+   #. An occurrence of ``(ty1, ty2, ..., tyn-1, tyn)`` (for *n* ≧ 2) in type-syntax, where the first
+      ``tyi`` inferred to have kind ``Type`` or ``Constraint`` has kind ``Constraint``, is a synonym
+      for ``GHC.Classes.CTuple``\ *n*\ `` ty1 ty2 ... tyn-1 tyn``.
+
+   #. An unapplied occurrence of ``GHC.Types.List`` is pretty-printed as ``[]``.
+
+   #. An occurrence of ``GHC.Types.List ty`` is pretty-printed as ``[ty]]`.
+
+   #. An occurrence of ``GHC.Tuple.Prim.Unit`` is pretty-printed as ``()``.
+
+   #. An occurrence of ``GHC.Tuple.Prim.Tuplen ty1 ty2 ... tyn`` is pretty-printed as ``(ty1, ty2, ..., tyn)``.
+
+   #. An occurrence of ``GHC.Tuple.Prim.Tuplen``, but not applied to a full *n* arguments, is pretty-printed as ``(,,...,,)``,
+      where there are *n-1* commas.
+
+   #. An occurrence of ``GHC.Prim.Unit#`` is pretty-printed as ``(# #)``.
+
+   #. An occurrence of ``GHC.Prim.Tuplen# ty1 ty2 ... tyn`` is pretty-printed as ``(# ty1, ty2, ..., tyn #)``.
+
+   #. An occurrence of ``GHC.Prim.Tuplen#``, but not applied to a full *n* arguments, is pretty-printed as ``(#,,...,,#)``,
+      where there are *n-1* commas.
+
+   #. An occurrence of ``GHC.Prim.Sumn# ty1 ty2 ... tyn`` is pretty-printed as ``(# ty1 | ty2 | ... | tyn #)``.
+
+   #. An occurrence of ``GHC.Prim.Sumn#``, but not applied to a full *n* arguments, is pretty-printed as ``(# | | ... | | #)``,
+      where there are *n-1* pipes.
+
+   #. An occurrence of ``GHC.Classes.CUnit`` is pretty-printed as ``()``.
+
+   #. An occurrence of ``GHC.Classes.CTuplen ty1 ty2 ... tyn`` is pretty-printed as ``(ty1, ty2, ..., tyn)``.
+
+#. With ``-XNoListTupleTypeSyntax``:
+
+   1. Uses of ``[]``, ``[...]``, ``()``, ``(,,...,,)``, ``(...,...,...)``, ``(# #)``, ``(#,,...,,#)``, ``(# ...,...,... #)``,
+      ``(# | | ... | | #)``, and ``(# ... | ... | ... #)`` are now unambiguous. They always refer to data constructors,
+      never types or type constructors.
+
+   #. An occurrence of ``GHC.Tuple.Prim.Tuplen ty1 ty2 ... tyn`` is pretty-printed as ``Tuple [ty1, ty2, ..., tyn]``.
+
+   #. An occurrence of ``GHC.Classes.CTuplen ty1 ty2 ... tyn`` is pretty-printed as ``Constraints [ty1, ty2, ..., tyn]``.
+
+Effect and Interactions
+-----------------------
+1. With ``-XListTupleTypeSyntax`` (which is on by default), all programs that are accepted today continue
+   to be accepted, and with the same meanings. Note that the peculiar dance around type tuples and constraint
+   tuples exists today; I have tried to describe the current implementation faithfully, above.
+
+#. With ``-XListTupleTypeSyntax`` (which is on by default), most pretty-printing will happen as it does
+   today. The exception is around unsaturated ``CTuplen``, which is not handled above. It is hard to have
+   an unsaturated constraint tuple, but possible by the use of a type family that decomposes one. Today's
+   GHC prints out e.g. ``ghc-prim-0.6.1:GHC.Classes.(%,%)``. Switching to ``GHC.Classes.CTuple2`` (which is
+   actually parseable) seems a positive improvement.
+
+#. With the definitions above, users can avoid puns in their lists and tuples.
+
+#. Note that the type syntax ``(ty1, ty2, ..., tyn) => ...`` is special syntax. The parser does *not*
+   parse a type to the left of the ``=>``. This syntax thus remains completely unaffected by ``-XListTupleTypeSyntax``
+   and will continue to work with ``-XNoListTupleTypeSyntax``. Furthermore, because a type like ``(ty1, ty2, ... tyn) => ...``
+   does not contain any uses of ``CTuplen``, it will also continue to pretty-print just as today.
+
+   On the other hand, collections of constraints occurring not to the left of a ``=>`` are affected by
+   this proposal, for example in ``Dict (Eq a, Show b)`` (which would be written ``Dict (Constraints [Eq a, Show b])``
+   under this proposal).
+
+#. An instance declaration like ``instance (C a, C b) => C (Tuple [a, b]) where ...`` would be
+   rejected because it uses a type family in the instance head. We might choose to relax
+   this restriction, by allowing type families in an instance head, as long as they can
+   reduce to a ground (i.e. type-family-free) type. This proposal does *not* include such
+   a lifting of the restriction, as the workaround is straightforward: just write
+   ``instance (C a, C b) => C (Tuple2 a b) where ...``. Still, we may decide to revisit
+   this in the future.
+
+#. In due course, we may wish to consider re-exporting some of the definitions
+   above from modules not in the ``GHC.`` namespace, perhaps even including the
+   ``Prelude``. This proposal does *not* make any such suggestions, and it does *not*
+   depend on any such ideas being adopted in the future. Any such idea would
+   be evaluated by the Core Library Committee independently of this proposal.
+
+Costs and Drawbacks
+-------------------
+1. This is one more feature to maintain, but the code would be pretty local.
+
+#. Having multiple ways of naming one thing may offer a boon to *writers* of code
+   (they can choose whichever way to name a tuple that they like), but it imposes
+   a burden on *readers* of code, who may need to be familiar with all possible
+   ways of describing a tuple (and that they are interchangeable). Careful
+   documentation of these ideas -- ideally, in the Haddock documentation for the
+   names introduced above -- will help to mitigate this problem.
+
+#. A particular class of code readers are beginners, and having multiple different
+   ways to say the same thing is particularly challenging for beginners. We should
+   thus think carefully about how to present these names to beginners, if
+   ``-XNoListTupleTypeSyntax`` catches on.
+
+Alternatives
+------------
+1. Instead of defining ``TupleN`` as a type family (as done here), it could be
+   a data family, effectively replacing the ``Tuple2``, ``Tuple3``, ..., definitions.
+   This design would seem to be too complicated to be the primitive definition
+   of tuples, however, when a very vanilla datatype like ``data Tuple2 a b = (a, b)``
+   suffices.
+
+#. Instead of introducing new names, we could use more mixfix bits of punctuation,
+   such as ``(~ ty1, ty2 ~)`` for normal tuples and ``(% ty1, ty2 %)`` for constraint
+   tuples. This was not as popular in a recent `straw poll <https://github.com/ghc-proposals/ghc-proposals/pull/458#issuecomment-982230541>`_.
+
+Unresolved Questions
+--------------------
+
+None at this time.

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -171,6 +171,8 @@ Proposed Change Specification
 
      data List a = [] | a : List a
 
+#. Re-export ``List`` from ``GHC.List``.
+
 #. Introduce a new extension ``-XListTupleTypeSyntax``; this extension is on by default.
 
 #. With ``-XListTupleTypeSyntax``:

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -468,7 +468,7 @@ Alternatives
    of ``Tuple [Int, Bool]``: that is, use tuples instead of a list to store the type
    arguments. This lends itself naturally to heterogeneity.
 
-   Concretely, this alternative would be to replace the definition for ``Tuple``and ``Constraints``
+   Concretely, this alternative would be to replace the definition for ``Tuple`` and ``Constraints``
    above with the following::
 
       type TupleArgKind :: Type -> Nat -> Type
@@ -534,27 +534,27 @@ Alternatives
         Sum# (a, b, ..., bk, bl) = Sum64# a b ... bk bl
         Sum# @reps _ = TypeError (ShowType (Length reps) :<>: Text " is too large; the maximum size of a sum is 64.")
 
-  This creates a uniform mixfix syntax for boxed tuples, constraint tuples, unboxed tuples, and unboxed sums.
-  Handling singletons is a bit interesting:
+   This creates a uniform mixfix syntax for boxed tuples, constraint tuples, unboxed tuples, and unboxed sums.
+   Handling singletons is a bit interesting:
 
-  ``TupleArgKind t_or_c 1`` is defined to be ``t_or_c``, *not* ``Solo t_or_c``, as you would
-  otherwise expect. This is because we expect to see e.g. ``Tuple (Int)``, not ``Tuple (MkSolo Int)``.
-  (Actually, we would probably not expect these at all, but the current design allows us to be forgiving
-  during refactoring.)
+   ``TupleArgKind t_or_c 1`` is defined to be ``t_or_c``, *not* ``Solo t_or_c``, as you would
+   otherwise expect. This is because we expect to see e.g. ``Tuple (Int)``, not ``Tuple (MkSolo Int)``.
+   (Actually, we would probably not expect these at all, but the current design allows us to be forgiving
+   during refactoring.)
 
-  In ``Tuple``, we see ``Tuple a = a``, which looks like a universally applicable equation. It is
-  not. Because ``a :: Type`` (resp. ``a :: Constraint``) we learn the invisible argument to ``Tuple``
-  (resp. ``Constraints``) must be ``1``, and thus this equation fires only when the argument to ``Tuple``
-  is not a tuple of types (resp. constraints).
+   In ``Tuple``, we see ``Tuple a = a``, which looks like a universally applicable equation. It is
+   not. Because ``a :: Type`` (resp. ``a :: Constraint``) we learn the invisible argument to ``Tuple``
+   (resp. ``Constraints``) must be ``1``, and thus this equation fires only when the argument to ``Tuple``
+   is not a tuple of types (resp. constraints).
 
-  A beautiful, unexpected consequence of this design is that it aids migration. Now, with or without
-  ``-XListTuplePuns``, a user can write e.g. ``Tuple (Int, Bool, Double)``, and this will be the types
-  of e.g. ``(1, True, 3.14)``. With ``-XListTuplePuns``, the argument to ``Tuple`` will be the tuple
-  type, of kind ``Type``. That is, the type will really be understood as ``Tuple (Tuple3 Int Bool Double)``.
-  The "``1``" equation fires, reducing to ``Tuple3 Int Bool Double``. On the other hand, with
-  ``-XNoListTuplePuns``, the user's type is understood as ``Tuple @3 (Int, Bool, Double)``, and the "``3``"
-  equation fires, reducing to ``Tuple3 Int Bool Double`` -- the same answer! And so, all users
-  can write ``Tuple`` before their tuples and not get hurt.
+   A beautiful, unexpected consequence of this design is that it aids migration. Now, with or without
+   ``-XListTuplePuns``, a user can write e.g. ``Tuple (Int, Bool, Double)``, and this will be the types
+   of e.g. ``(1, True, 3.14)``. With ``-XListTuplePuns``, the argument to ``Tuple`` will be the tuple
+   type, of kind ``Type``. That is, the type will really be understood as ``Tuple (Tuple3 Int Bool Double)``.
+   The "``1``" equation fires, reducing to ``Tuple3 Int Bool Double``. On the other hand, with
+   ``-XNoListTuplePuns``, the user's type is understood as ``Tuple @3 (Int, Bool, Double)``, and the "``3``"
+   equation fires, reducing to ``Tuple3 Int Bool Double`` -- the same answer! And so, all users
+   can write ``Tuple`` before their tuples and not get hurt.
 
 Unresolved Questions
 --------------------

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -249,7 +249,8 @@ Proposed Change Specification
 
    1. Uses of ``[]``, ``[...]``, ``()``, ``(,,...,,)``, ``(...,...,...)``, ``(# #)``, ``(#,,...,,#)``, ``(# ...,...,... #)``,
       ``(# | | ... | | #)``, and ``(# ... | ... | ... #)`` are now unambiguous. They always refer to data constructors,
-      never types or type constructors.
+      never types or type constructors. (Note that ``(...) =>`` is special syntax, not an occurrence of any of the types
+      listed above. See `below <#constraints-special-syntax>`_.)
 
    #. An occurrence of ``GHC.Tuple.Prim.Tuplen ty1 ty2 ... tyn`` is pretty-printed as ``Tuple [ty1, ty2, ..., tyn]``.
 
@@ -268,6 +269,8 @@ Effect and Interactions
    actually parseable) seems a positive improvement.
 
 #. With the definitions above, users can avoid puns in their lists and tuples.
+
+   .. _constraints-special-syntax:
 
 #. Note that the type syntax ``(ty1, ty2, ..., tyn) => ...`` is special syntax. The parser does *not*
    parse a type to the left of the ``=>``. This syntax thus remains completely unaffected by ``-XListTupleTypeSyntax``

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -94,7 +94,7 @@ Proposed Change Specification
      -- ...
      data Tuple64 ... = (...)
 
-#. Export the following definitions from ``GHC.Exts`` and ``GHC.Prelude``. These
+#. Export the following definitions from ``GHC.Exts`` and ``GHC.Prelude``. These replace
    the existing tuple definitions (in ``GHC.Classes``) today. (Note that ``(...) =>`` is special syntax, and does not
    construct tuples. See more on this point `below <#constraint-special-syntax>`_.)::
 
@@ -270,7 +270,7 @@ Proposed Change Specification
    #. With ``-XUnboxedTuples``, an occurrence of ``(# ty #)`` in type-syntax is a synonym for ``GHC.Exts.Solo# ty``.
 
    #. With ``-XUnboxedTuples``, an occurrence of ``(#,,...,,#)`` where there are *n* commas (for *n* ≧ 1) in type-syntax
-      is a synonym for ``GHC.Exts.Tuple<n+1>#.
+      is a synonym for ``GHC.Exts.Tuple<n+1>#``.
 
    #. With ``-XUnboxedTuples``, an occurrence of ``(# ty1, ty2, ... , ty<n-1>, ty<n> #)`` (for *n* ≧ 2) in type-syntax is a synonym
       for ``GHC.Exts.Tuple<n># ty1 ty2 ... ty<n-1> ty<n>``.
@@ -340,7 +340,7 @@ Effect and Interactions
    tuples exists today; I have tried to describe the current implementation faithfully, above.
 
 #. With ``-XListTuplePuns`` (which is on by default), most pretty-printing will happen as it does
-   today. The exception is around unsaturated ``CTuplen``, which is not handled above. It is hard to have
+   today. The exception is around unsaturated ``CTuple<n>``, which is not handled above. It is hard to have
    an unsaturated constraint tuple, but possible by the use of a type family that decomposes one. Today's
    GHC prints out e.g. ``ghc-prim-0.6.1:GHC.Classes.(%,%)``. Switching to ``GHC.Classes.CTuple2`` (which is
    actually parseable) seems a positive improvement.

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -517,7 +517,7 @@ Alternatives
       type Tuple# :: forall (reps :: List RuntimeRep). TupleArgKind# reps -> TYPE (TupleRep reps)
       type family Tuple# ts where
         Tuple# () = Unit#
-        Tuple# a = Solo# a     -- see below
+        Tuple# (a :: TYPE r) = TypeError (Text "Tuple# does not work for 1-tuples; use Solo#.")  -- see below
         Tuple# (a, b) = Tuple2# a b
         Tuple# (a, b, c) = Tuple3# a b c
         -- ...
@@ -527,7 +527,7 @@ Alternatives
       type Sum# :: forall (reps :: List RuntimeRep). TupleArgKind# reps -> TYPE (SumRep reps)
       type family Sum# ts where
         Sum# () = TypeError (Text "GHC does not support empty unboxed sums. Consider Data.Void.Void instead.")
-        Sum# a = TypeError (Text "GHC does not support unary unboxed sums. Consider Data.Tuple.Solo# instead.")
+        Sum# (a :: TYPE r) = TypeError (Text "GHC does not support unary unboxed sums. Consider Data.Tuple.Solo# instead.")
         Sum# (a, b) = Sum2# a b
         Sum# (a, b, c) = Sum3# a b c
         -- ...
@@ -555,6 +555,10 @@ Alternatives
    ``-XNoListTuplePuns``, the user's type is understood as ``Tuple @3 (Int, Bool, Double)``, and the "``3``"
    equation fires, reducing to ``Tuple3 Int Bool Double`` -- the same answer! And so, all users
    can write ``Tuple`` before their tuples and not get hurt.
+
+   For unboxed tuples (``Tuple#``), this non-uniformity is not as happy. For example, ``Tuple# (Int, Bool)``
+   means either ``Tuple2# Int Bool`` (with ``-XNoListTuplePuns``) or ``Solo# (Tuple2 Int Bool)`` (with
+   ``-XListTuplePuns``). Furthermore, ``Tuple# (Int#, Double#)`` would not kind-check with ``-XListTuplePuns``. So we avoid these problems by simply erroring in the 1-element case.
 
 Unresolved Questions
 --------------------

--- a/proposals/0000-tuple-syntax.rst
+++ b/proposals/0000-tuple-syntax.rst
@@ -524,7 +524,7 @@ Alternatives
         Tuple# (a, b, ..., bk, bl) = Tuple64# a b ... bk bl
         Tuple# @reps _ = TypeError (ShowType (Length reps) :<>: Text " is too large; the maximum size of a tuple is 64.")
 
-      type Sum# :: forall (reps :: List RuntimeRep). TupleArgKind# reps -> TYPE (TupleRep reps)
+      type Sum# :: forall (reps :: List RuntimeRep). TupleArgKind# reps -> TYPE (SumRep reps)
       type family Sum# ts where
         Sum# () = TypeError (Text "GHC does not support empty unboxed sums. Consider Data.Void.Void instead.")
         Sum# a = TypeError (Text "GHC does not support unary unboxed sums. Consider Data.Tuple.Solo# instead.")

--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -1012,10 +1012,10 @@ Corner Cases
    In ``a``, the argument is the pair type, in ``b`` it is a promoted pair.
 
    One way to resolve this is to use synonyms
-   from ``Data.Tuple`` and ``Data.List``::
+   from ``GHC.Tuple``::
 
-      a = f @(TupleOf2 Int Bool)
-      b = g  (TupleOf2 Int Bool)
+      a = f @(TupleN Int Bool)
+      b = g  (TupleN Int Bool)
 
    Another way is to use the ``type`` herald::
 

--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -625,57 +625,10 @@ Syntax
    This change applies to ``∀`` (the ``UnicodeSyntax`` rendition of ``forall``)
    as well.
 
-4. Introduce a new extension, ``ListTupleTypeSyntax``, on by default,
-   which enables:
-
-   * ``[]`` as the list type constructor
-   * ``()`` as the unit type
-   * ``[a]`` the syntax of a list type
-   * ``(,)`` as the pair type constructor
-   * ``(a, b)`` as the syntax of a pair type
-
-   When the extension is on, these constructs retain their Haskell 2010
-   meaning, which depends on whether we are in a type-level or term-level
-   context.
-
-   When the extension is off, all of the above are interpreted as in terms:
-
-   * ``[]`` is always an empty list
-   * ``()`` is always the unit data constructor
-   * ``[a]`` is always a singleton list (not the list type)
-   * ``(,)`` is always the pair data constructor (not the type constructor)
-   * ``(a, b)`` is always a pair (not the type of a pair)
-
-   Likewise for tuples of higher arities.
-
-   Export the following synonym from the ``Data.List`` module::
-
-     type List = []
-
-   Export the following synonym from the ``Data.Tuple`` module::
-
-     type Unit = ()
-
-   For tuples of higher arities, users may want to define their own
-   synonyms, such as::
-
-     type TupleOf2 = (,)
-     type TupleOf3 = (,,)
-     type TupleOf4 = (,,,)
-     ... -- up to the maximum tuple arity
-
-   We do not propose adding them to ``Data.Tuple`` for the time being,
-   as better APIs are possible (e.g. based on variadic data families)
-   but are blocked by other technical issues. We leave it as future work.
-
-   This change allows the use of built-in lists and tuples without any
-   disambugation syntax (the ``'`` promotion syntax at the type level or the
-   ``type`` herald at the term level).
-
-5. When ``ViewPatterns`` are enabled, interpret ``f (a -> b) = ...``
+4. When ``ViewPatterns`` are enabled, interpret ``f (a -> b) = ...``
    as a view pattern, otherwise as ``f ((->) a b) = ...``.
 
-6. ``case ... of x -> y -> z`` is an error. We require parentheses to
+5. ``case ... of x -> y -> z`` is an error. We require parentheses to
    disambiguate:
 
    * ``case ... of (x -> y) -> z``
@@ -684,7 +637,7 @@ Syntax
 Name resolution
 ~~~~~~~~~~~~~~~
 
-7. During name resolution,
+6. During name resolution,
 
    * Identifiers bound in term syntax populate the term namespace;
      identifiers bound in type syntax populate the type namespace.
@@ -709,7 +662,7 @@ Name resolution
 Implicit quantification
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-8. Implicit quantification is an existing feature that allows the programmer to
+7. Implicit quantification is an existing feature that allows the programmer to
    omit a ``forall``::
 
      g ::           a -> a    -- implicit
@@ -746,7 +699,7 @@ Implicit quantification
 Type checking
 ~~~~~~~~~~~~~
 
-9. Generalize the ``ITVDQ`` rule introduced earlier
+8. Generalize the ``ITVDQ`` rule introduced earlier
    by using ``t2t``::
 
      rho = t2t(e)
@@ -760,7 +713,7 @@ Type checking
    In other words, given ``f :: forall a -> t``, the ``x`` in ``f x`` is
    parsed and renamed as a term, but then mapped to a type.
 
-10. Any uses of terms in types are ill-typed:
+9.  Any uses of terms in types are ill-typed:
     ::
 
       a = 42; f :: Proxy a -> Proxy b   -- invalid occurrence of "a" in a type-level position
@@ -770,7 +723,7 @@ Type checking
 
       f _ = Int                         -- invalid occurrence of "Int" in a term-level position
 
-11. When in the checking mode of bidirectional type checking (e.g. in a function
+10. When in the checking mode of bidirectional type checking (e.g. in a function
     binding with an explicit type signature), allow a pattern to bind type
     variables in the term namespace, such as ``x`` here::
 
@@ -801,7 +754,7 @@ Type checking
 Namespaces vs Semantics
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-12. With the proposed changes, the namespace of an identifier is no longer tied
+11. With the proposed changes, the namespace of an identifier is no longer tied
     to whether it stands for a type variable or a term variable.
 
     Before this proposal, all term variables (retained, values, runtime) used

--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -991,9 +991,9 @@ Corner Cases
    is a promoted pair, and ``[Int]`` is a promoted singleton list.
 
    One way to change this is to use synonyms
-   from ``Data.Tuple`` and ``Data.List``::
+   from ``GHC.Tuple``::
 
-     x1 = g (TupleOf2 Int Bool)
+     x1 = g (TupleN Int Bool)
      x2 = g (List Int)
 
    Another way is to use the ``type`` herald::


### PR DESCRIPTION
The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0475-tuple-syntax.rst) has been accepted; the following discussion is mostly of historic interest.

--------------------------------------------

This proposal is informed by and supersedes #458 as a way to remove the punned list and tuple syntax.

For clarity, it is presented as a proposal distinct from #281 (and modifies the accepted #281 to avoid mention of this feature). However, note that rejecting this proposal *still* introduces `-XListTupleTypeSyntax`, as proposed in #281. It's just that accepting this proposal adds some more convenience, more details, and it changes the module structure slightly.

[Rendered](https://github.com/goldfirere/ghc-proposals/blob/tuple-syntax/proposals/0000-tuple-syntax.rst)