### PR TITLE
Fix date-accepted on proposal 0366

### DIFF
--- a/proposals/0366-no-ambiguous-field-access.rst
+++ b/proposals/0366-no-ambiguous-field-access.rst
@@ -2,7 +2,7 @@ DuplicateRecordFields without ambiguous field access
 ====================================================
 
 .. author:: Adam Gundry
-.. date-accepted:: 2011-11-16
+.. date-accepted:: 2020-11-16
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell


### PR DESCRIPTION
Seems like a typo, as the proposal was accepted on 2020 (see https://github.com/ghc-proposals/ghc-proposals/pull/366#issuecomment-727981091).