### PR TITLE
Allow record wildcards for empty records (under review)

### DIFF
--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -1,22 +1,7 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
-
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
-Proposal title
+Allow record wildcards for empty records
 ==============
 
-.. author:: Your name
+.. author:: John Ericson (@Ericson2314)
 .. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
 .. ticket-url:: Leave blank. This will eventually be filled with the
                 ticket URL which will track the progress of the
@@ -29,108 +14,80 @@ Proposal title
             number in the link, and delete this bold sentence.**
 .. contents::
 
-Here you should write a short abstract motivating and briefly summarizing the proposed change.
-
+Allow record wild cards for empty records.
+This removes and artificial restriction, making the language simpler and more predictable.
 
 Motivation
 ----------
-Give a strong reason for why the community needs this change. Describe the use
-case as clearly as possible and give an example. Explain how the status quo is
-insufficient or not ideal.
 
-A good Motivation section is often driven by examples and real-world scenarios.
+Currently this is allowed::
 
+  data Foo = Foo { a :: Int }
+
+  f (Foo {..}) = 1
+
+But this is not::
+
+  data Foo = Foo { }
+
+  f (Foo {..}) = 1
+
+This doesn't seem good:
+
+#. It feels arbitrary and artificial.
+   Does anyone expect this behavior?
+
+#. It is a pitfall for generated code, which cannot uniformly use record wildcard syntax no matter how many fields there are.
 
 Proposed Change Specification
 -----------------------------
-Specify the change in precise, comprehensive yet concise language. Avoid words
-like "should" or "could". Strive for a complete definition. Your specification
-may include,
 
-* BNF grammar and semantics of any new syntactic constructs
-  (Use the `Haskell 2010 Report <https://www.haskell.org/onlinereport/haskell2010/>`_ or GHC's ``alex``\- or ``happy``\-formatted files
-  for the `lexer <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser/Lexer.x>`_ or `parser <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser.y>`_
-  for a good starting point.)
-* the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler
-  features, in case that is otherwise ambiguous
-
-Strive for *precision*. The ideal specification is described as a
-modification of the `Haskell 2010 report
-<https://www.haskell.org/definition/haskell2010.pdf>`_. Where that is
-not possible (e.g. because the specification relates to a feature that
-is not in the Haskell 2010 report), try to adhere its style and level
-of detail. Think about corner cases. Write down general rules and
-invariants.
-
-Note, however, that this section should focus on a precise
-*specification*; it need not (and should not) devote space to
-*implementation* details -- there is a separate section for that.
-
-The specification can, and almost always should, be illustrated with
-*examples* that illustrate corner cases. But it is not sufficient to
-give a couple of examples and regard that as the specification! The
-examples should illustrate and elucidate a clearly-articulated
-specification that covers the general case.
+Allow record wildcard syntax for empty variants.
+There are no (named) fields, so no variables are bound.
 
 Examples
 --------
-This section illustrates the specification through the use of examples of the
-language change proposed. It is best to exemplify each point made in the
-specification, though perhaps one example can cover several points. Contrived
-examples are OK here. If the Motivation section describes something that is
-hard to do without this proposal, this is a good place to show how easy that
-thing is to do with the proposal.
+
+The second example in the motivation is allowed.
+
+This is also allowed::
+
+  data Foo = Foo -- no {}
+
+  f (Foo {..}) = 1
+
+for it doesn't matter today whether empty variants are declared with ``{}``, and this should remain true.
 
 Effect and Interactions
 -----------------------
-Your proposed change addresses the issues raised in the motivation. Explain how.
 
-Also, discuss possibly contentious interactions with existing language or compiler
-features. Complete this section with potential interactions raised
-during the PR discussion.
+``Foo {..}`` has the same meaning as ``Foo {}`` for an empty record.
 
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects
-learnability of the language for novice users. Define and list any remaining
-drawbacks that cannot be resolved.
+
+Cannot think of any.
 
 
 Alternatives
 ------------
-List alternative designs to your proposed change. Both existing
-workarounds, or alternative choices for the changes. Explain
-the reasons for choosing the proposed change over these alternative:
-*e.g.* they can be cheaper but insufficient, or better but too
-expensive. Or something else.
 
-The PR discussion often raises other potential designs, and they should be
-added to this section. Similarly, if the proposed change
-specification changes significantly, the old one should be listed in
-this section.
+Do nothing.
+Can't think of anything else.
 
 Unresolved Questions
 --------------------
-Explicitly list any remaining issues that remain in the conceptual design and
-specification. Be upfront and trust that the community will help. Please do
-not list *implementation* issues.
 
-Hopefully this section will be empty by the time the proposal is brought to
-the steering committee.
-
+None at this time.
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other resources
-and prerequisites are required for implementation?
+
+This should be very easy.
+Perhaps we should use it as a mentoring exercise for new contributors.
 
 Endorsements
 -------------
-(Optional) This section provides an opportunity for any third parties to express their
-support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the more substantial
-the proposal is, the more desirable it is to offer evidence that there is
-significant demand from the community.  This section is one way to provide
-such evidence.
+
+There was positive feedback in https://github.com/ghc-proposals/ghc-proposals/issues/484 where this was previously brought up.

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -24,11 +24,15 @@ Currently this is allowed::
 
   f (Foo {..}) = 1
 
+  x = Foo {..}
+
 But this is not::
 
   data Foo = Foo { }
 
   f (Foo {..}) = 1
+
+  x = Foo {..}
 
 Prohibiting this doesn't seem good:
 
@@ -41,7 +45,7 @@ Proposed Change Specification
 -----------------------------
 
 Allow record wildcard syntax for empty variants.
-There are no (named) fields, so no variables are bound.
+There are no (named) fields, so no variables are bound in patterns, and no variables are used in expressions.
 
 Examples
 --------
@@ -53,6 +57,8 @@ This is also allowed::
   data Foo = Foo -- no {}
 
   f (Foo {..}) = 1
+
+  x = Foo {..}
 
 for it doesn't matter today whether empty variants are declared with ``{}``, and this should remain true.
 

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -41,6 +41,16 @@ Prohibiting this doesn't seem good:
 
 #. It is a pitfall for generated code, which cannot uniformly use record wildcard syntax no matter how many fields there are.
 
+Furthermore this is allowed ::
+
+  data Foo = Foo { a :: Int }
+
+  f (Foo { a = 1, ..}) = 1
+
+  x = Foo { a = 1, ..}
+
+So we see ``..`` binding or using no fields isn't even consistently prohibited!
+
 Proposed Change Specification
 -----------------------------
 

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -9,9 +9,7 @@ Allow record wildcards for empty records
 .. implemented:: Leave blank. This will be filled in with the first GHC version which
                  implements the described feature.
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/496>`_.
 .. contents::
 
 Allow record wild cards for empty records.

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -30,7 +30,7 @@ But this is not::
 
   f (Foo {..}) = 1
 
-This doesn't seem good:
+Prohibiting this doesn't seem good:
 
 #. It feels arbitrary and artificial.
    Does anyone expect this behavior?

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -1,0 +1,136 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Proposal title
+==============
+
+.. author:: Your name
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. contents::
+
+Here you should write a short abstract motivating and briefly summarizing the proposed change.
+
+
+Motivation
+----------
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
+
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
+
+* BNF grammar and semantics of any new syntactic constructs
+  (Use the `Haskell 2010 Report <https://www.haskell.org/onlinereport/haskell2010/>`_ or GHC's ``alex``\- or ``happy``\-formatted files
+  for the `lexer <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser/Lexer.x>`_ or `parser <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser.y>`_
+  for a good starting point.)
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
+
+Strive for *precision*. The ideal specification is described as a
+modification of the `Haskell 2010 report
+<https://www.haskell.org/definition/haskell2010.pdf>`_. Where that is
+not possible (e.g. because the specification relates to a feature that
+is not in the Haskell 2010 report), try to adhere its style and level
+of detail. Think about corner cases. Write down general rules and
+invariants.
+
+Note, however, that this section should focus on a precise
+*specification*; it need not (and should not) devote space to
+*implementation* details -- there is a separate section for that.
+
+The specification can, and almost always should, be illustrated with
+*examples* that illustrate corner cases. But it is not sufficient to
+give a couple of examples and regard that as the specification! The
+examples should illustrate and elucidate a clearly-articulated
+specification that covers the general case.
+
+Examples
+--------
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
+
+Effect and Interactions
+-----------------------
+Your proposed change addresses the issues raised in the motivation. Explain how.
+
+Also, discuss possibly contentious interactions with existing language or compiler
+features. Complete this section with potential interactions raised
+during the PR discussion.
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List alternative designs to your proposed change. Both existing
+workarounds, or alternative choices for the changes. Explain
+the reasons for choosing the proposed change over these alternative:
+*e.g.* they can be cheaper but insufficient, or better but too
+expensive. Or something else.
+
+The PR discussion often raises other potential designs, and they should be
+added to this section. Similarly, if the proposed change
+specification changes significantly, the old one should be listed in
+this section.
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to
+the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?
+
+Endorsements
+-------------
+(Optional) This section provides an opportunity for any third parties to express their
+support for the proposal, and to say why they would like to see it adopted.
+It is not mandatory for have any endorsements at all, but the more substantial
+the proposal is, the more desirable it is to offer evidence that there is
+significant demand from the community.  This section is one way to provide
+such evidence.

--- a/proposals/0000-empty-record-wildcards.rst
+++ b/proposals/0000-empty-record-wildcards.rst
@@ -25,6 +25,7 @@ Currently this is allowed::
   f (Foo {..}) = 1
 
   x = Foo {..}
+    where a = 1
 
 But this is not::
 
@@ -76,7 +77,17 @@ Effect and Interactions
 -----------------------
 
 ``Foo {..}`` has the same meaning as ``Foo {}`` for an empty record.
+Note that means that::
 
+  data Foo = Foo
+  f (Foo {..}) = 42
+
+is newly accepted just as::
+
+  data Foo = Foo
+  f (Foo {}) = 42
+
+is today
 
 Costs and Drawbacks
 -------------------


### PR DESCRIPTION
Allow record wild cards for empty records. This removes and artificial restriction, making the language simpler and more predictable.

[Rendered](https://github.com/Ericson2314/ghc-proposals/blob/empty-record-wildcards/proposals/0000-empty-record-wildcards.rst)