### PR TITLE
Deep Subsumption (under review)

### DIFF
--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -40,8 +40,10 @@ Proposed Change Specification
 -----------------------------
 
 We propose to add a language extension ``DeepSubsumption`` which provides a best
-effort attempt to restore the previous deep subsumption behaviour. The extension
-will implement the 4 subsumption rules which were removed by simplified subsumption.
+effort attempt to restore the previous deep subsumption behaviour.
+The extension will implement deep skolemisation and the co/contra subtyping
+rules, which were removed by simplified subsumption. It will not re-introduce
+deep instantiation.
 
 * The extension will be **on** by default, as-if it was added to the Haskell2010 extension set.
 * The extension will be **off** in the GHC2021 extension set.

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -1,0 +1,224 @@
+Deep Subsumption
+==============
+
+.. author:: Matthew Pickering, Simon Peyton Jones, Jaro Reinders
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. contents::
+
+``DeepSubsumption`` is a languge extension which allows users to opt-into deep
+subsumption as it existed before GHC-9.0.
+
+
+Motivation
+----------
+
+The `simplified subsumption proposal <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst>`_
+argued to simplify GHC's type system by removing 4 cases from the subsumption judgement.
+The change was motivated by wanting to simplify both the implementation and language
+semantics.
+
+Unfortunately the breakage study failed to accurately predict how annoying this
+change would be to users. Some common patterns found it libraries now require
+"pointless" eta-expansion where the compiler used to automatically insert the
+appropiate casts due to the 4 removed subsumption rules.
+
+This proposal is about adding ``DeepSubsumption`` language extentsion which can
+be enabled to add back the removed subsumption rules to allow users to opt-in to
+deep subsumption as it was before GHC-9.0.
+
+
+Proposed Change Specification
+-----------------------------
+
+We propose to add a language extension ``DeepSubsumption`` which provides a best
+effort attempt to implement the restore the deep subsumption behaviour. The extension
+will implement the 4 subsumption rules which were removed by simplified subsumption.
+The extension is off by default and must be enabled in client code if they want
+the subsumption rules and associated eta-expansion.
+
+It is not recommended that people use this extension as it makes type inference
+less predictable and the language semantics more confusing. However, in a manner
+similar to ``NoMonoLocalBinds``, if the user really wants this then they are free to
+enable the extension with the understanding that they take responsibility if things
+go wrong!
+
+Example 1
+---------
+
+The example given by ParetoOptimalDev on `Discourse <https://discourse.haskell.org/t/r-haskell-was-simplified-subsumption-worth-it-for-industry-haskell/4486>`_ was analysed carefully by
+Jaro R.
+
+Certain libraries such as `pipes <https://hackage.haskell.org/package/pipes>`_ define a general data type but also
+export specialised type synonyms with universally quantified type variables. It
+is key to use a type synonym rather than a newtype so that the the specialised
+versions can still work with more general combinators.
+
+For example, pipes defines the following data types::
+
+  data Proxy x' x a b m r = ....
+
+  type Producer' b m r = forall x' x . Proxy x' x () b m r
+
+and also provides the ``fromHandle`` function, which uses the ``Producer'`` type synonym::
+
+  fromHandle :: MonadIO m => Handle -> Producer' ByteString m ()
+
+using the ``fromHandle`` function can lead to compilation failures with simplified
+subsumption::
+
+  readFreqSumFile file = readFreqSumProd $ withFile file ReadMode fromHandle
+
+
+Solution 1: Eta-expansion
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As described in the simplfied subsumption proposal, the simplest fix is to eta-expand
+the call to ``fromHandle`` in the definition of ``readFreqSumFile``::
+
+  readFreqSumFile file = readFreqSumProd $ withFile file ReadMode (\x -> fromHandle x)
+
+However, ParetoOptimalDev isn't so satisfied by this solution because
+
+1. It required many such "pointless" changes to the code base.
+2. It seems "random" when you need to eta-expand or not, Haskell programmers expect
+   eta-equivalence to hold (even though it does not and never has).
+3. They view the benefits (simpler language, simpler semantics) as something that
+   this breaking change is not worth it. We have lived with deep subsumption for
+   many years.
+
+This led Jaro to explore some other alteratives.
+
+Solution 2: Newtype Wrapper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Simon PJ suggests making these type synonyms into newtypes::
+
+  newtype Producer' b m r = MkProducer' (forall x' x. Proxy x' x () b m r)
+
+If you implement all the required constraints for this type then you can just write the original::
+
+  readFreqSumFile file = readFreqSumProd $ withFile file ReadMode PB.fromHandle
+
+But this is not quite a good solution here, because you can't
+automatically derive all the instances and you cannot compose these producers
+with other pipes.
+
+This interoperability could probably be restored by using the same tricks that
+the ``optics`` library uses to get their lenses to compose, but that seems like
+quite a big change here.
+
+Solution 3: Rewrite type synonyms in place
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Another simple change to resolve this is to just rewrite the type synonyms in-place::
+
+  fromHandle :: MonadIO m => Handle -> Proxy x' x () ByteString m ()
+
+Then you can also just write the original non-eta-expanded version. But a
+problem is that it is harder understand that the ``Proxy`` in this case really
+must be a producer. It is also another invasive change to rewrite all the type
+signatures of all downstream libraries which use this pattern.
+
+Solution 4: Deep Subsumption
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With this proposal, the user enables ``DeepSubsumption`` and the program continues
+to typecheck as before::
+
+  {-# LANGUAGE DeepSubsumption #-}
+
+  ...
+
+  readFreqSumFile file = readFreqSumProd $ withFile file ReadMode PB.fromHandle
+
+
+Example 2
+---------
+
+Another consumer hit hard by the change is the `Integrated Haskell Platform<https://github.com/digitallyinduced/ihp/pull/1342>`_.
+
+In particular they define a type synonym which contains an implicit parameter::
+
+  type Html = (?context :: ControllerContext) => Html5.Html
+
+which is used to create the ``renderUser`` combinator::
+
+  renderUser :: User -> Html
+  renderUser user = [hsx|<li>{get #name user}</li>|]
+
+but now ``renderUser`` fails to typecheck in ``renderUsers`` without eta-expansion::
+
+  renderUsers :: [User] -> Html
+  renderUsers users = [hsx|
+    <ul>
+      {forEach users renderUser}
+    </ul>
+  |]
+
+the "solution" is to eta-expand the call to ``renderUser``::
+
+  renderUsers :: [User] -> Html
+  renderUsers users = [hsx|
+    <ul>
+      {forEach users (\x -> renderUser x)}
+    </ul>
+  |]
+
+But Marc Scholten is `not happy<https://github.com/digitallyinduced/ihp/pull/1342#issuecomment-1058870639>`_ with this proposal as
+
+  All of them break existing IHP apps / require a lot of changes when updating.
+
+So it seems the arguments for simplified subsumption are not persuasive enough for
+him to accept the breakage. This points to a solution where we can have the best of
+both worlds by adding a ``DeepSubsumption`` extension which can be enabled by
+clients such as IHP if they desire this behaviour.
+
+
+
+Effect and Interactions
+-----------------------
+
+* The ``DeepSubsumption`` language pragma has all the drawbacks identified in
+  the simplified subsumption proposal, but crucially allows users to opt-in to
+  the drawbacks if their value judgement is different to that of the steering committee.
+
+
+Costs and Drawbacks
+-------------------
+
+* We really do not recommend that people use this feature. It makes the language
+  more complicated and type inference less predictable.
+* Alejandro Serrano `suggests <https://github.com/ghc-proposals/ghc-proposals/pull/287#issuecomment-1128134798>`_ that reintroducing this feature will not alleviate any pain because
+  by the time it's introduced then everyone will have already felt it as all
+  libraries will be upgraded to the 9.0 series.
+
+
+
+Alternatives
+------------
+
+* The alternative is to do nothing, users must accept that simplified subsumption
+  is here to stay and update their code appropiately.
+
+Unresolved Questions
+--------------------
+
+* We need to decide whether we would want to backport this feature to the 9.2 branch.
+
+
+Implementation Plan
+-------------------
+
+* A draft patch has been prepared by Simon PJ. `!8210 <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8210>`_.
+
+Endorsements
+-------------

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -34,7 +34,7 @@ semantics, as well as being a stepping-stone to the implementation of Quick-look
 Unfortunately, the breakage study failed to accurately predict how annoying this
 change would be to users. Some common patterns found in libraries now require
 eta-expansion, when the compiler used to automatically insert the
-appropiate lambdas.
+appropriate lambdas.
 
 This proposal suggests adding a new language extension, ``DeepSubsumption``,
 enabled by default in the common case when the language is set to ``-XHaskell2010``,

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -49,7 +49,7 @@ We propose to add a language extension ``DeepSubsumption`` which restores the pr
 
 * The extension implements deep skolemisation and the co/contra subtyping rules, which were removed by simplified subsumption.
 * It does not re-introduce deep instantiation.  Doing only shallow instantation is not a cause of breakage: it changes only some types reported in error messages and in GHCi.  Moreover, deep instantiation is fundamentally incompatible with the widely used ``TypeApplications`` extension.
-* It makes no changes to the Quick Look algorithm, which implements `ImpredicativeTypes`.  As its name suggests, Quick Look takes a quick look at an application, searching for opportunities for impredicative instantiation, but leaves the main type inference algorithm unaffected.
+* It makes no changes to the Quick Look algorithm, which implements `ImpredicativeTypes`.  That is, Quick Look treats function arrows as invariant, even if ``DeepSubsumption`` is on. As its name suggests, Quick Look takes a quick look at an application, searching for opportunities for impredicative instantiation, but leaves the main type inference algorithm unaffected.
 
 When ``DeepSubsumption`` is on by default:
 
@@ -68,7 +68,7 @@ the two features came out in the same GHC release.
 
 The ``DeepSubsumption`` extension is not recommended:
 
-* In makes the runtime semantics (including performance) of Haskell programs
+* It makes the runtime semantics (including performance) of Haskell programs
   less predictable (due to silent eta-expansion), as the original proposal describes.
   The situation is even more complicated when type classes are involved.  You can find some intricate discussion on the `Simplified subsumption proposal discussion thread <https://github.com/ghc-proposals/ghc-proposals/pull/287>`_, especially towards the end.
 

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -89,7 +89,10 @@ enable ``DeepSubsumption``, with the understanding that doing so might
 introduce changes to type inference or runtime behaviour that are
 difficult to predict.
 
-2.3 Warnings
+Despite not being recommended, there is no deprecation plan for ``DeepSubsumption``, it will
+be available as an extension indefinitely.
+
+2.2 Warnings
 ^^^^^^^^^^^^
 
 Given that we don't think that using ``DeepSubsumption`` is a good idea, we also

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -83,6 +83,7 @@ difficult to predict.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Under this proposal:
+
 * ``DeepSubsumption`` will be part of the ``Haskell2010`` and ``Haskell98`` extension sets.
 * ``DeepSubsumption`` will not be part of ``GHC2021``.
 

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -59,9 +59,11 @@ library change would require using CPP to add ``DeepSubsumption`` for specific G
 The ``DeepSubsumption`` extension is not recommended:
 
 * In makes the runtime semantics (including performance) of Haskell programs
-less predictable (due to silent eta-expansion), as the original proposal describes.
-The situation is even more complicated when type classes are involved.  You can find some intricate discussion on the `Simplified subsumption proposal discussion thread <https://github.com/ghc-proposals/ghc-proposals/pull/287>`_, especially towards the end.
+  less predictable (due to silent eta-expansion), as the original proposal describes.
+  The situation is even more complicated when type classes are involved.  You can find some intricate discussion on the `Simplified subsumption proposal discussion thread <https://github.com/ghc-proposals/ghc-proposals/pull/287>`_, especially towards the end.
+
 * The interaction between ``DeepSubsumption`` and ``ImpredicativeTypes`` is hard to predict.  Quick Look treats function arrow as invariant, which is different to ``DeepSubsumption``, but it is hard to come up with concrete examples that show strange behaviour.  Perhaps surprisingly, the two different treatments of function arrow, while infelicitous, do not seem to have an immediately bad effects.
+
 * ``DeepSubsumption`` (notably deep skolemisation) seems to be fundamentally incompatible with the accepted proposal 155: `Binding type variables in lambda expressions <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0155-type-lambda.rst>`_. Consider::
 
       f :: Int -> forall a. a -> a

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -62,7 +62,7 @@ together with specialised type synonyms with universally quantified type variabl
 is key to use a type synonym rather than a newtype, so that the specialised
 versions can still work with more general combinators.
 
-For example, `pipes` defines the following data types::
+For example, ``pipes`` defines the following data types::
 
   data Proxy x' x a b m r = ....
 
@@ -149,7 +149,7 @@ change would require adding CPP.
 Example 2
 ---------
 
-Another consumer hit hard by the change is the `Integrated Haskell Platform<https://github.com/digitallyinduced/ihp/pull/1342>`_.
+Another consumer hit hard by the change is the `Integrated Haskell Platform <https://github.com/digitallyinduced/ihp/pull/1342>`_.
 
 In particular they define a type synonym which contains an implicit parameter::
 
@@ -178,7 +178,7 @@ the "solution" is to eta-expand the call to ``renderUser``::
     </ul>
   |]
 
-But such changes were `deemed unsatisfactory<https://github.com/digitallyinduced/ihp/pull/1342#issuecomment-1058870639>`_ 
+But such changes were `deemed unsatisfactory <https://github.com/digitallyinduced/ihp/pull/1342#issuecomment-1058870639>`_
 by the maintainers:
 
   All of them break existing IHP apps / require a lot of changes when updating.

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -57,6 +57,7 @@ library change would require using CPP to add ``DeepSubsumption`` for specific G
 ^^^^^^^^^^^^^^^^^^^
 
 The ``DeepSubsumption`` extension is not recommended:
+
 * In makes the runtime semantics (including performance) of Haskell programs
 less predictable (due to silent eta-expansion), as the original proposal describes.
 The situation is even more complicated when type classes are involved.  You can find some intricate discussion on the `Simplified subsumption proposal discussion thread <https://github.com/ghc-proposals/ghc-proposals/pull/287>`_, especially towards the end.

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -22,47 +22,47 @@ Motivation
 ----------
 
 The `simplified subsumption proposal <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst>`_
-argued to simplify GHC's type system by removing 4 cases from the subsumption judgement.
+argued in favour of simplifying GHC's type system by removing 4 cases from the subsumption judgement.
 The change was motivated by wanting to simplify both the implementation and language
-semantics.
+semantics, as well as being a stepping-stone to the implementation of Quick-look impredicativity.
 
-Unfortunately the breakage study failed to accurately predict how annoying this
-change would be to users. Some common patterns found it libraries now require
-"pointless" eta-expansion where the compiler used to automatically insert the
-appropiate casts due to the 4 removed subsumption rules.
+Unfortunately, the breakage study failed to accurately predict how annoying this
+change would be to users. Some common patterns found in libraries now require
+"pointless" eta-expansion, when the compiler used to automatically insert the
+appropiate lambdas.
 
-This proposal is about adding ``DeepSubsumption`` language extentsion which can
-be enabled to add back the removed subsumption rules to allow users to opt-in to
-deep subsumption as it was before GHC-9.0.
+This proposal suggests adding a new language extension, ``DeepSubsumption``,
+which can be enabled to recover the previous subsumption rules. This would allow
+users to opt-in to deep subsumption as it was before GHC-9.0.
 
 
 Proposed Change Specification
 -----------------------------
 
 We propose to add a language extension ``DeepSubsumption`` which provides a best
-effort attempt to implement the restore the deep subsumption behaviour. The extension
+effort attempt to restore the previous deep subsumption behaviour. The extension
 will implement the 4 subsumption rules which were removed by simplified subsumption.
-The extension is off by default and must be enabled in client code if they want
+The extension is off by default, and must be enabled in client code if they want
 the subsumption rules and associated eta-expansion.
 
 It is not recommended that people use this extension as it makes type inference
 less predictable and the language semantics more confusing. However, in a manner
-similar to ``NoMonoLocalBinds``, if the user really wants this then they are free to
-enable the extension with the understanding that they take responsibility if things
-go wrong!
+similar to ``NoMonoLocalBinds``, users who really want such a feature are free to
+enable the extension, with the understanding that doing so might introduce changes
+to type inference or runtime behaviour that are difficult to predict.
 
 Example 1
 ---------
 
-The example given by ParetoOptimalDev on `Discourse <https://discourse.haskell.org/t/r-haskell-was-simplified-subsumption-worth-it-for-industry-haskell/4486>`_ was analysed carefully by
-Jaro R.
+The example given by ParetoOptimalDev on `Discourse <https://discourse.haskell.org/t/r-haskell-was-simplified-subsumption-worth-it-for-industry-haskell/4486>`_
+was carefully analysed by Jaro R.
 
-Certain libraries such as `pipes <https://hackage.haskell.org/package/pipes>`_ define a general data type but also
-export specialised type synonyms with universally quantified type variables. It
-is key to use a type synonym rather than a newtype so that the the specialised
+Certain libraries such as `pipes <https://hackage.haskell.org/package/pipes>`_ define a general data type
+together with specialised type synonyms with universally quantified type variables. It
+is key to use a type synonym rather than a newtype, so that the specialised
 versions can still work with more general combinators.
 
-For example, pipes defines the following data types::
+For example, `pipes` defines the following data types::
 
   data Proxy x' x a b m r = ....
 
@@ -92,7 +92,7 @@ However, ParetoOptimalDev isn't so satisfied by this solution because
 2. It seems "random" when you need to eta-expand or not, Haskell programmers expect
    eta-equivalence to hold (even though it does not and never has).
 3. They view the benefits (simpler language, simpler semantics) as something that
-   this breaking change is not worth it. We have lived with deep subsumption for
+   is not worth breaking. We have lived with deep subsumption for
    many years.
 
 This led Jaro to explore some other alteratives.
@@ -109,22 +109,24 @@ If you implement all the required constraints for this type then you can just wr
   readFreqSumFile file = readFreqSumProd $ withFile file ReadMode PB.fromHandle
 
 But this is not quite a good solution here, because you can't
-automatically derive all the instances and you cannot compose these producers
+automatically derive all the instances, and you cannot compose these producers
 with other pipes.
 
-This interoperability could probably be restored by using the same tricks that
+This interoperability could possibly be restored by using the same tricks that
 the ``optics`` library uses to get their lenses to compose, but that seems like
 quite a big change here.
 
 Solution 3: Rewrite type synonyms in place
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Another simple change to resolve this is to just rewrite the type synonyms in-place::
+Another simple change to resolve this is to avoid using type synonyms altogether,
+by inlining their definition in-place::
 
   fromHandle :: MonadIO m => Handle -> Proxy x' x () ByteString m ()
 
-Then you can also just write the original non-eta-expanded version. But a
-problem is that it is harder understand that the ``Proxy`` in this case really
+Then the original non-eta-expanded implementation of ``readFreqSumFile``
+typechecks without issues. However, this worsens the usability of the library, as
+it becomes harder to understand that the ``Proxy`` in this case really
 must be a producer. It is also another invasive change to rewrite all the type
 signatures of all downstream libraries which use this pattern.
 
@@ -140,6 +142,9 @@ to typecheck as before::
 
   readFreqSumFile file = readFreqSumProd $ withFile file ReadMode PB.fromHandle
 
+This change is not backwards-compatible, as the ``DeepSubsumption`` extension won't be
+available on earlier versions of GHC (in particular GHC-9.0). A backwards-compatible
+change would require adding CPP.
 
 Example 2
 ---------
@@ -173,15 +178,14 @@ the "solution" is to eta-expand the call to ``renderUser``::
     </ul>
   |]
 
-But Marc Scholten is `not happy<https://github.com/digitallyinduced/ihp/pull/1342#issuecomment-1058870639>`_ with this proposal as
+But such changes were `deemed unsatisfactory<https://github.com/digitallyinduced/ihp/pull/1342#issuecomment-1058870639>`_ 
+by the maintainers:
 
   All of them break existing IHP apps / require a lot of changes when updating.
 
-So it seems the arguments for simplified subsumption are not persuasive enough for
-him to accept the breakage. This points to a solution where we can have the best of
-both worlds by adding a ``DeepSubsumption`` extension which can be enabled by
-clients such as IHP if they desire this behaviour.
-
+In this situation too, the benefits of simplified subsumption are deemed to not be worth the costs
+in terms of usability and user-friendliness. This too suggests re-instating the old behaviour as
+an opt-in by adding a ``DeepSubsumption`` extension.
 
 
 Effect and Interactions
@@ -197,16 +201,17 @@ Costs and Drawbacks
 
 * We really do not recommend that people use this feature. It makes the language
   more complicated and type inference less predictable.
-* Alejandro Serrano `suggests <https://github.com/ghc-proposals/ghc-proposals/pull/287#issuecomment-1128134798>`_ that reintroducing this feature will not alleviate any pain because
-  by the time it's introduced then everyone will have already felt it as all
-  libraries will be upgraded to the 9.0 series.
-
-
+* In situations where the eta-expansion behaviour is desired for its user-friendliness,
+  the requirement to enable a strange ``DeepSubsumption`` extension might just lead to even more confusion.
+* Alejandro Serrano `suggests <https://github.com/ghc-proposals/ghc-proposals/pull/287#issuecomment-1128134798>`_
+  that reintroducing this feature will not alleviate any pain, because by the time it's introduced
+  maintainers will have already updated their libraries to account for the changes, and will not want to
+  introduce more churn by enabling ``DeepSubsumption`` and removing the eta-expansions they recently added.
 
 Alternatives
 ------------
 
-* The alternative is to do nothing, users must accept that simplified subsumption
+* The alternative is to do nothing. Users will have to accept that simplified subsumption
   is here to stay and update their code appropiately.
 
 Unresolved Questions

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -1,5 +1,5 @@
 Deep Subsumption
-==============
+================
 
 .. author:: Matthew Pickering, Simon Peyton Jones, Jaro Reinders
 .. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
@@ -19,10 +19,11 @@ subsumption as it existed before GHC-9.0.
 
 
 1. Motivation
-----------
+-------------
 
 The `simplified subsumption proposal <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst>`_
 argued in favour of simplifying the subsumption judgement in GHC's type system, by removing:
+
 * Covariance and contravariance of function types
 * Deep skolemisation
 * Deep instantiation.
@@ -42,9 +43,10 @@ users to opt-in to deep subsumption as it was before GHC-9.0.
 
 
 2. Proposed Change Specification
------------------------------
+--------------------------------
 
 We propose to add a language extension ``DeepSubsumption`` which restores the previous deep subsumption behaviour:
+
 * The extension implements deep skolemisation and the co/contra subtyping rules, which were removed by simplified subsumption.
 * It does not re-introduce deep instantiation.  Doing only shallow instantation is not a cause of breakage: it changes only some types reported in error messages and in GHCi.  Moreover, deep instantiation is fundamentally incompatible with the widely used ``TypeApplications`` extension.
 * It makes no changes to the Quick Look algorithm, which implements `ImpredicativeTypes`.  As its name suggests, Quick Look takes a quick look at an application, searching for opportunities for impredicative instantiation, but leaves the main type inference algorithm unaffected.
@@ -62,7 +64,7 @@ Note that any project using ``GHC2021`` must also have upgraded to use shallow s
 the two features came out in the same GHC release.
 
 2.1 DeepSubsumption is not recommended
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``DeepSubsumption`` extension is not recommended:
 
@@ -88,7 +90,7 @@ introduce changes to type inference or runtime behaviour that are
 difficult to predict.
 
 2.3 Warnings
-^^^^^^^^
+^^^^^^^^^^^^
 
 Given that we don't think that using ``DeepSubsumption`` is a good idea, we also
 propose to improve diagnostics to help users migrate to simplified
@@ -111,7 +113,7 @@ In the text above, "eta-expansion" is a short-hand used in this proposal. The ac
 error message will be crafted to either avoid or introduce this terminology.
 
 3. Examples
---------
+-----------
 
 In this section we present two case studies about how migrating to simplified
 subsumption has been challenging for users.
@@ -257,14 +259,14 @@ an opt-in by adding a ``DeepSubsumption`` extension.
 
 
 4. Effect and Interactions
------------------------
+--------------------------
 
 The ``DeepSubsumption`` language pragma has all the drawbacks identified in
 the simplified subsumption proposal, but crucially allows users to opt-in to
 the drawbacks if their value judgement is different to that of the steering committee.
 
 5. Costs and Drawbacks
--------------------
+----------------------
 
 * We do not recommend that people use this feature. It makes the language
   more complicated and runtime performance less predictable.
@@ -278,13 +280,13 @@ the drawbacks if their value judgement is different to that of the steering comm
 
 
 6. Alternatives
-------------
+---------------
 
 * The alternative is to do nothing. Users will have to accept that simplified subsumption
   is here to stay and update their code appropiately.
 
 7. Unresolved Questions
---------------------
+-----------------------
 
 * We need to decide whether we would want to backport this feature to the 9.2 branch.
 
@@ -296,4 +298,4 @@ Fortunately, the implementation complexity of adding ``DeepSubsumption`` is mode
 localised.  We already have an MR that implements it: `!8210 <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8210>`_.
 
 9. Endorsements
--------------
+---------------

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -44,10 +44,10 @@ effort attempt to restore the previous deep subsumption behaviour. The extension
 will implement the 4 subsumption rules which were removed by simplified subsumption.
 
 * The extension will be **on** by default, as-if it was added to the Haskell2010 extension set.
-* The extension will be **off** in the Haskell2021 extension set.
+* The extension will be **off** in the GHC2021 extension set.
 
-As the Haskell2021 extension was introduced in GHC 9.0, the same release as simplified
-subsumption, any user who has upgraded and is already specifying the Haskell2021 extension
+As the GHC2021 extension was introduced in GHC 9.0, the same release as simplified
+subsumption, any user who has upgraded and is already specifying the GHC2021 extension
 set will have had to update their code to work with deep subsumption.
 Otherwise, older programs which are still using Haskell2010 should continue to work
 as before, because DeepSubsumption will be enabled until the user updates to the

--- a/proposals/0000-deep-subsumption.rst
+++ b/proposals/0000-deep-subsumption.rst
@@ -49,9 +49,17 @@ We propose to add a language extension ``DeepSubsumption`` which restores the pr
 * It does not re-introduce deep instantiation.  Doing only shallow instantation is not a cause of breakage: it changes only some types reported in error messages and in GHCi.  Moreover, deep instantiation is fundamentally incompatible with the widely used ``TypeApplications`` extension.
 * It makes no changes to the Quick Look algorithm, which implements `ImpredicativeTypes`.  As its name suggests, Quick Look takes a quick look at an application, searching for opportunities for impredicative instantiation, but leaves the main type inference algorithm unaffected.
 
-This change is not backwards-compatible, as the ``DeepSubsumption`` extension won't be
-available on earlier versions of GHC (in particular GHC-9.0). A backwards-compatible
-library change would require using CPP to add ``DeepSubsumption`` for specific GHC versions.
+When ``DeepSubsumption`` is on by default:
+
+* ``DeepSubsumption`` will be part of the ``Haskell2010`` and ``Haskell98`` extension sets.
+* ``DeepSubsumption`` will not be part of ``GHC2021``.
+
+Like any other extension, ``DeepSubsumption`` can be turned on or off with a ``LANGUAGE`` pragma
+or in a ``.cabal`` file. Because ``DeepSubsumption`` is part of ``Haskell2010`` and ``Haskell98``,
+projects compiled with ``.cabal`` files that declare either of these to be the ``default-language``
+will get the benefits of deep subsumption, much like it was implemented prior to GHC-9.0.
+Note that any project using ``GHC2021`` must also have upgraded to use shallow subsumption, because
+the two features came out in the same GHC release.
 
 2.1 DeepSubsumption is not recommended
 ^^^^^^^^^^^^^^^^^^^
@@ -78,22 +86,6 @@ Despite these shortcomings, in a manner similar to
 enable ``DeepSubsumption``, with the understanding that doing so might
 introduce changes to type inference or runtime behaviour that are
 difficult to predict.
-
-2.2 When DeepSubsumption is on by default
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Under this proposal:
-
-* ``DeepSubsumption`` will be part of the ``Haskell2010`` and ``Haskell98`` extension sets.
-* ``DeepSubsumption`` will not be part of ``GHC2021``.
-
-As the ``GHC2021`` language was introduced in GHC 9.0, the same release as simplified
-subsumption, any user who has upgraded and is already specifying the GHC2021 extension
-set will have had to update their code to work with deep subsumption.
-Otherwise, older programs which are still using Haskell2010 (as frequently set by a ``default-language``
-setting in a cabal file) should continue to work
-as before, because ``DeepSubsumption`` will be enabled until the user updates to the
-2021 extensions.
 
 2.3 Warnings
 ^^^^^^^^

--- a/proposals/0451-sized-literals.rst
+++ b/proposals/0451-sized-literals.rst
@@ -3,7 +3,7 @@ Sized primitive literals
 
 .. author:: Sylvain Henry
 .. date-accepted:: 2022-04-23
-.. ticket-url::
+.. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/21422
 .. implemented::
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/451>`_.


### PR DESCRIPTION
The [simplified subsumption proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst) argued in favour of simplifying the subsumption judgement in GHC's type system, by removing:

* Covariance and contravariance of function types
* Deep skolemisation
* Deep instantiation.

The change was motivated by wanting to simplify both the implementation and language semantics, as well as being a stepping-stone to the implementation of Quick-look impredicativity.

Unfortunately, the breakage study failed to accurately predict how annoying this change would be to users. Some common patterns found in libraries now require eta-expansion, when the compiler used to automatically insert the appropriate lambdas.

This proposal suggests adding a new language extension, `DeepSubsumption`, enabled by default in the common case when the language is set to `-XHaskell2010`, which recovers the previous subsumption rules. This would allow users to opt-in to deep subsumption as it was before GHC-9.0.

[Rendered](https://github.com/mpickering/ghc-proposals/blob/deep-subsumption/proposals/0000-deep-subsumption.rst)