### PR TITLE
Meta-proposal: Require implementors before proposal submission (under review)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,7 @@ This section outlines what stages a proposal may go through. The stage is identi
 
    `How to submit a proposal <#how-to-start-a-new-proposal>`_
 
-3. (No label.)  The wider community discusses the proposal in the commit section of the pull
-   request, while the author refines the proposal. This phase lasts as long as necessary.
+3. (No label.) The wider community discusses the proposal in the commit section of the pull request, while the author refines the proposal. If the author does not plan to implement the proposal themselves, this is also the phase where they try to find someone motivated and able to do so. This phase lasts as long as necessary.
 
    `Discussion goals <#discussion-goals>`_ •
    `How to comment on a proposal <#how-to-comment-on-a-proposal>`_ •
@@ -84,7 +83,10 @@ This section outlines what stages a proposal may go through. The stage is identi
 
    Acceptance of the proposal implies that the implementation will be accepted
    into GHC provided it is well-engineered, well-documented, and does not
-   complicate the code-base too much.
+   complicate the code-base too much. Those mentioned in the proposal as likely
+   implementers should now open a ticekt in `GHC’s issue tracker
+   <https://gitlab.haskell.org/ghc/ghc/-/issues/new>`_, and update the proposal’s
+   metadata to point to that ticket.
 
    `≡ List of accepted proposals <https://github.com/ghc-proposals/ghc-proposals/tree/master/proposals>`_ •
    `≡ List of proposals being revised <https://github.com/ghc-proposals/ghc-proposals/pulls?q=label%3A%22Needs+revision%22>`_ •
@@ -97,10 +99,9 @@ This section outlines what stages a proposal may go through. The stage is identi
    `≡ List of dormant proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22dormant%22>`_
 
 
-8. Label: `Implemented <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_.   Once a proposal is accepted, it still has to be implemented.  The author
-   may do that, or someone else. We mark the proposal as “implemented” once it
-   hits GHC’s ``master`` branch (and we are happy to be nudged to do so by
-   email, GitHub issue, or a comment on the relevant pull request).
+8. Label: `Implemented <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_.
+
+   Once the implemenation hits GHC’s ``master`` branch, the implementors should update the metadata to indicate the version of GHC that will ship with this feature, and we label the PR as “implemented”.
 
    `≡ List of proposals pending implementation <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Accepted%22+-label%3A%22Implemented%22>`_ •
    `≡ List of implemented proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ This section outlines what stages a proposal may go through. The stage is identi
    Acceptance of the proposal implies that the implementation will be accepted
    into GHC provided it is well-engineered, well-documented, and does not
    complicate the code-base too much. Those mentioned in the proposal as likely
-   implementers should now open a ticekt in `GHC’s issue tracker
+   implementers should now open a ticket in `GHC’s issue tracker
    <https://gitlab.haskell.org/ghc/ghc/-/issues/new>`_, and update the proposal’s
    metadata to point to that ticket.
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ This section outlines what stages a proposal may go through. The stage is identi
 
    `How to submit a proposal <#how-to-start-a-new-proposal>`_
 
-3. (No label.) The wider community discusses the proposal in the commit section of the pull request, while the author refines the proposal. If the author does not plan to implement the proposal themselves, this is also the phase where they try to find someone motivated and able to do so. This phase lasts as long as necessary.
+3. (No label.) The wider community discusses the proposal in the conversation section of the pull request, while the author refines the proposal. If the author does not plan to implement the proposal themselves, this is also the phase where they try to find someone motivated and able to do so. This phase lasts as long as necessary.
 
    `Discussion goals <#discussion-goals>`_ •
    `How to comment on a proposal <#how-to-comment-on-a-proposal>`_ •

--- a/acceptance.rst
+++ b/acceptance.rst
@@ -30,7 +30,7 @@ Before accepting, the shepherd should check for the following
 3. Is the proposal sufficiently illustrated with examples? Examples help
    us understand the details that will be needed during implementation.
 
-4. Does the proposal indicate someone plans to implement it.
+4. Does the proposal indicate someone plans to implement it?
 
 Acceptance steps
 ----------------

--- a/acceptance.rst
+++ b/acceptance.rst
@@ -30,6 +30,8 @@ Before accepting, the shepherd should check for the following
 3. Is the proposal sufficiently illustrated with examples? Examples help
    us understand the details that will be needed during implementation.
 
+4. Does the proposal indicate someone plans to implement it.
+
 Acceptance steps
 ----------------
 
@@ -53,7 +55,7 @@ steps:
    where the word "proposal" links to the final rendered version, as found on https://github.com/ghc-proposals/ghc-proposals/tree/master/proposals
 
 4. If the PR title has "(under review)", remove it.
-   
+
 5. Set the PR to have the "Accepted" label.
 
 6. Comment on the PR that the proposal was accepted.

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -108,6 +108,6 @@ the steering committee.
 
 ## Implementation Plan
 
-If accepted who will implement the change? If its is not the proposal authors,
-the proposal authors should someone who is motivated and able to work on an
-implementation of this proposal.
+If accepted who will implement the change? Before the proposal is submitted,
+the proposal authors should identify someone who is motivated and able to work on an
+implementation of this proposal. This may or may not be the proposal authors themselves.

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -108,15 +108,6 @@ the steering committee.
 
 ## Implementation Plan
 
-(Optional) If accepted who will implement the change? Which other resources
-and prerequisites are required for implementation?
-
-## Endorsements
-
-(Optional) This section provides an opportunity for any third parties to express their
-support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the more substantial
-the proposal is, the more desirable it is to offer evidence that there is
-significant demand from the community.  This section is one way to provide
-such evidence.
-
+If accepted who will implement the change? If its is not the proposal authors,
+the proposal authors should someone who is motivated and able to work on an
+implementation of this proposal.

--- a/proposals/0000-template.rst
+++ b/proposals/0000-template.rst
@@ -123,14 +123,6 @@ the steering committee.
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other resources
-and prerequisites are required for implementation?
-
-Endorsements
--------------
-(Optional) This section provides an opportunity for any third parties to express their
-support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the more substantial
-the proposal is, the more desirable it is to offer evidence that there is
-significant demand from the community.  This section is one way to provide
-such evidence.
+If accepted who will implement the change? If its is not the proposal authors,
+the proposal authors should someone who is motivated and able to work on an
+implementation of this proposal.


### PR DESCRIPTION
This is a proposal to refine our proposal process, which came out of a discussion with @adamgundry at ZuriHac.

Currently we are happy to discuss and accept proposals that don't have an implementation plan, and we don't require proposal authors to do any implementation, to not raise the bar too high. But this leads to the odd situation that an ever growing list of proposals that are accepted, but nobody does anything about them.

So we wonder: is this useful? What is the value of proposing, discussing, refining and accepting a proposal if then nothing happens?

So here is a proposal to improve this situation: Before discussing a proposal, we require it to name someone (or somemany) who plan to implement it. Could be an established GHC developer, a new contributor, or even a paid consultant.

It does _not_ have to be the proposal author. But in that case, the proposal author is expected to rally support for the proposal and find someone able to implement who thinks it is good enough to join the effort.

Effects:

* Ideally, every accepted proposal has someone who will start implementing it in a timely manner.

* Since the first and easy step of implementing is to open a ticket in GHC's gitlab, accepted proposals will more likely show up in GHC’s issue tracker.

* The requirement to find an implementer (if the author’s does not do it themselves) means there is a higher incentive to beat the drum (mailing lists, twitter, forums…) which may lead to more general early community involvement, which would be great.

* This may attract new GHC developers.

* Of course, the implementors are still volunteers, who may lose interest, run out of time, or implementation may turn out to be too hard. That is ok. There is no repercussion for failing to implement a proposal you said you’d implement, no more than when you’d assign a GHC ticket to yourself and eventually unassign it.

* Some proposal authors may not be able to find an implementor, and then can’t be submitted to the committee. This may be a good thing: If there is not enough momentum behind it, it is probably not worth doing? And we'd spend our committee resources on the proposals that are more likely to actually go into GHC.


