### PR TITLE
Type vs Constraint proposal (under review)

### DIFF
--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -273,8 +273,11 @@ Accordingly:
   ``Data.Kind`` should have a stable API; the kinds of these type
   constructors will not change.
 
-* ``GHC.Prim`` exports ``SORT``, ``TypeOrConstraint``, ``IP``.
-  Users may import them from ``GHC.Prim``, but they should not complain if they change in future.
+* A module within ``ghc-prim`` exports: ``CONSTRAINT``, ``(=>)``, ``(==>)``, ``SORT``, ``TypeOrConstraint(..)``,
+  and ``IP``. If `#524`_ is accepted and implemented, importing the module from ``ghc-prim``
+  will require the user to enable ``-XUnstable``.
+
+.. _`#524`: https://github.com/ghc-proposals/ghc-proposals/pull/524
 
 Implementation notes
 :::::::::::::::::::::::::::::::::

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -249,7 +249,7 @@ making them apart is unsound in the presence of the current ``newtype`` optimiza
 one-element classes.
 Accordingly, under this proposal,
 
-* ``TypeLike`` and ``ConstraintLike`` will be considered not *apart*.
+* ``TYPE`` and ``CONSTRAINT`` will be considered not *apart*.
 
 As a consequence, ``Type`` and ``Constraint`` are also not *apart*, just as today.
 This a wart, but it is an *existing* wart, and one that is not easy to fix.
@@ -258,9 +258,9 @@ As before, nothing prevents writing instances like::
 
   instance C (Proxy @Type a) where ...
 
-In particular, ``SORT`` and ``TypeLike`` and ``ConstraintLike`` (and the synonyms ``TYPE``, ``CONSTRAINT`` etc)
+In particular, ``TYPE``, ``CONSTRAINT``, ``Type`` and ``Constraint``
 are all allowed in instance heads. It's just that
-``TypeLike`` is not apart from ``ConstraintLike``
+``TYPE`` is not apart from ``CONSTRAINT``
 so that instance would irretrievably overlap with::
 
   instance C (Proxy @Constraint a) where ...
@@ -273,8 +273,7 @@ Future stability
 In the past it has not been very clear which parts of GHC's API are stable and which
 are unstable:
 
-* By "stable" we mean that efforts will be made to avoid change, and any
-changes should require a GHC proposal.
+* By "stable" we mean that efforts will be made to avoid change, and any changes should require a GHC proposal.
 
 * By "unstable" we mean that the API should be considered part of GHC's internal
   implementation.  Changes may be made to the unstable API without a proposal.
@@ -290,15 +289,14 @@ this proposal makes a modest start on clarifying the distinction.  In particular
 
 * The unstable API includes:
 
-  * The new type constructors ``CONSTRAINT``, ``(=>)``, ``(==>)``, and ``(-=>)`` are
+  * The new type constructors ``CONSTRAINT``, ``(=>)``, ``(==>)``, and ``(-=>)``;
     exported by ``GHC.Types``.
 
-  * The existing type constructors ``FUN`` and ``IP``, also exported by ``GHC.Types``.
+  * The existing type constructors ``FUN`` and ``IP``; also exported by ``GHC.Types``.
 
 * The stable API includes:
 
-  * ``Symbol``, ``Type``, ``TYPE``, ``Constraint``,
-  ``RuntimeRep``, ``Multiplicity``, ``Levity``, and ``(->)``; all exported by ``Data.Kind``
+  * ``Symbol``, ``Type``, ``TYPE``, ``Constraint``, ``RuntimeRep``, ``Multiplicity``, ``Levity``, and ``(->)``; all exported by ``Data.Kind``
 
 We keep ``CONSTRAINT`` in the unstable API for now, exposing it only though the possiblity
 of having unlifted implicit paramters.

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -1,0 +1,280 @@
+Separating Type from Constraint
+==============================
+
+tmp/Unlifted Constraints
+====================
+
+.. author:: Richard Eisenberg and Simon Peyton Jones
+.. date-accepted:: 
+.. ticket-url:: 
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. contents::
+
+Since version 8.0, GHC has supported a rich structure of inhabited types through the
+new primitive ``TYPE``, allowing
+unlifted types to be treated as first-class citizens, leading to the possibility
+of unlifted datatypes and newtypes, already available.
+
+This proposal extends this treatment to constraints, whose inhabitants
+can usefully be viewed as implicit parameters (typically type class dictionaries).
+Just like how the existence of ``TYPE`` directly opened the door to new innovations
+in datatype and newtype definitions, we expect the similar treatment of constraints
+to allow for strict classes and unlifted and unboxed implicit parameters.
+
+In addition, the new treatment proposes here allows GHC's internal language, Core,
+to more properly tell the difference between types and constraints, eliminating a
+troubling class of bugs that keeps recurring.
+
+Motivation
+----------
+
+1. With this proposal, we immediately allow unlifted and unboxed implicit parameters
+   using the existing ``(?x :: Int#)`` syntax. This allows programs to abstract over
+   implicit parameters without suffering inefficiencies due to boxing.
+
+2. This proposal allows a fix to several type-checker bugs that is otherwise elusive.
+   With this proposal, we can eliminate this entire class of bugs, that we otherwise
+   believe will continue to haunt GHC.  Currently in GHC, `Type` and `Constraint` are
+   *distinct* in the typechecker, but *identical* in Core.  That leads to massive duplication;
+   many, many functions over types have two versions, one for the typechecker and one for Core.
+   It also leads to intellectual complexity, with two subtly-different forms of type equality.
+   Worse, nothing maintains the separation, which leads to those elusive bugs.
+
+3. Although we do not propose unlifted constraints in this proposal, we believe that
+   this paves the way toward new innovations in constraint representations.
+
+Background
+----------
+
+This section describes key aspects of the status quo.
+
+The current type structure
+:::::::::::::::::::::::::::
+
+The current root of our type system contains these definitions::
+
+  -- Primitive type constructors
+  type TYPE       :: RuntimeRep -> Type
+  type Constraint :: Type    -- The kind of constraints
+  type Symbol     :: Type    -- The kind of compile-time strings
+  type IP         :: Symbol -> Type -> Constraint   -- Implicit parameters
+
+  type FUN :: forall (m :: Multiplicity) ->
+              forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
+              TYPE r1 -> TYPE r2 -> Type
+  -- (=>) is not something that can be written unsaturated;
+  --      it's just some concrete syntax
+
+  -- Data type declarations, used only at the type level
+  data Multiplicity = Many | One
+  data Levity       = Lifted | Unlifted
+  data RuntimeRep   = BoxedRep Levity | IntRep | FloatRep | ...
+
+  -- Type synonyms
+  type LiftedRep   = BoxedRep Lifted
+  type UnliftedRep = BoxedRep Unlifted
+  type Type        = TYPE LiftedRep
+
+NB: in GHC, implicit parameters are internally represented as a special class,
+but that is not user-visible.
+
+Type and Constraint are not apart
+:::::::::::::::::::::::::::::::::::
+
+GHC has an optimization for one-element classes (where the element
+is either a superclass or a method), defining these in like a newtype, not a datatype.
+For example, if we have ::
+
+  class Default a where
+    def :: a
+
+the Core of the program will have a definition like ::
+
+  newtype Default a = MkDefault a
+
+In turn, this newtype gives rise to an axiom (coercion), like so::
+
+  axDefault :: Default a ~R# a
+
+where ``~R#`` represents primitive representational equality. Note that
+``axDefault`` is *heterogeneous*: the kind of ``Default a`` is ``Constraint``,
+whereas the kind of ``a`` is ``Type``.
+
+GHC allows us to extract out an equality relationship between *kinds* from an
+equality relationship on *types* -- and kind equalities are always nominal. To
+wit, Core allows ::
+
+  KindCo axDefault :: Constraint ~# Type
+
+For this reason, the type system must treat ``Constraint`` and ``Type`` as
+not *apart*. For this reason, the following is not allowed::
+
+  type family F a
+  type instance F Type = Int
+  type instance F Constraint = Bool
+
+If these instances were allowed, GHC could
+produce a coercion between ``Int`` and ``Bool``, thus::
+
+  Bool  ~#  F Constraint   -- By type instance F Constraint (backwards)
+        ~#  F Type         -- By KindCo axDefault
+        ~#  Int            -- By type instance F Type
+
+That would be Very, Very Bad.  So, although `Type` and `Constraint` are built
+with different (un-equal) primitive type constructors, GHC's type checker nevertheless
+treats them as *not apart*; that in turn makes GHC complain that the above
+instances overlap, and are hence illegal.
+
+
+Proposed Change Specification
+-----------------------------
+
+We propose the following new setup, not repeating any types that remains unchanged::
+
+  -- Primitive type constructors
+  type SORT :: TypeOrConstraint -> RuntimeRep -> Type
+  type IP   :: formal (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
+
+  -- Data types
+  data TypeOrConstraint = TypeLike | ConstraintLike
+
+  -- Synonyms
+  type TYPE       = SORT TypeLike
+  type CONSTRAINT = SORT ConstraintLike
+  type Constraint = CONSTRAINT LiftedRep
+
+  type (=>)  :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
+                CONSTRAINT r1 -> TYPE r2 -> Type  -- primitive
+  type (==>) :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
+                CONSTRAINT r1 -> CONSTRAINT r2 -> Constraint
+
+  -- Implicit parameters
+  class IP name ty | name -> ty where ...  -- Special case to allow with unusual kind
+
+Changes to the type structure
+:::::::::::::::::::::::::::::
+
+This proposal introduces ``(=>)`` and ``(==>)`` as proper type constructors, just like
+any other. Just like ``(->)``, they have kinds and can be abstracted over.
+Unlike ``FUN``, they do not take a ``Multiplicity`` argument; implicity, it is ``Many``.
+
+The ``==>`` arrow is used in two places:
+
+* In instance heads, like ``instance Eq a => Eq (Maybe a)``
+* In quantified constraints, like ``forall x. c x => Eq x``
+
+In order to be backward compatible,
+we allow writing ``=>`` instead of ``==>`` in instance heads and in quantified constraints.
+That is, the *concrete* syntax for the type construtor ``==>`` can still use ``=>``.
+However, users may also choose to write ``==>`` (imported from ``GHC.Exts``) if they choose.
+
+Implicit parameters
+:::::::::::::::::::::::::::::
+
+Now that constraints can have varying runtime representation (via ``CONSTRAINT rep``),
+the door is open to having unlifted constraints, or constraints whose representation is
+an unboxed type like ``Int#``.  In this proposal we exploit this opportunity only in a
+limited way, by generalising the kind of ``IP``, thus::
+
+  type IP   :: formal (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
+
+So now this is accepted::
+
+  f :: (?x :: Int#) => Int# -> Int#
+  f y = ?x +# y
+
+
+Type and Constraint are not apart
+:::::::::::::::::::::::::::::::::
+
+It remains the case that ``Type`` is not be apart from ``Constraint``, because
+this proposal has no effect on the ``newtype`` optimization for one-element classes.
+Accordingly, under this proposal,
+
+  * ``TypeLike`` and ``ConstraintLike`` will be considered not *apart*.
+
+As a consequence, ``Type`` and ``Constraint`` are also not *apart*, just as today.
+
+Future stability
+:::::::::::::::::::::::::::::::::
+
+We anticipate that the kind of ``SORT`` may change again, for example to accommodate the ideas
+of `Kinds are calling conventions <https://simon.peytonjones.org/kinds-are-calling-conventions/>`_.
+So:
+
+* ``Type``, ``TYPE``, ``Constraint``, ``CONSTRAINT``, ``RuntimeRep`` are exported by ``Data.Kind``;
+  their kinds will not change.
+
+* ``SORT``, ``TypeOrConstraint`` are exported only by ``GHC.Prim``.
+  Users may import them from ``GHC.Prim``, but they should not complain if they change in future.
+
+Implementation notes
+:::::::::::::::::::::::::::::::::
+
+The fully-applied types ``FUN m r1 r2 t1 t2``, ``(=>) r1 r2 t1 t2``, and ``(==>) r1 r2 t1 t2`` can
+all be represented inside GHC by ``FunTy m t1 t2`` (where ``m`` is ``Many`` for ``(=>)`` and ``(==>)``),
+just as today.  That is, the proposal does not impose
+a new burden on GHC's internal representations.
+
+Examples
+--------
+This is now accepted::
+
+  f :: (?x :: Int#) => Int# -> Int#
+  f y = ?x +# y
+
+So is this::
+
+  g :: (=>) (Eq a) (a -> Bool)
+  g x = x == x
+
+along with other abstractions over ``(=>)``.
+
+Effect and Interactions
+-----------------------
+* We can fix type-checker tickets that have proved resistant to principled fixes.
+
+* The door is open to new innovations in strict classes.
+
+* This proposal is fully backward compatible.
+
+* This proposal is forward compatible with more glorious updates to the type/constraint
+  system we might imagine in the future, as detailed at TODO.
+
+Costs and Drawbacks
+-------------------
+* This adds complexity to the root of our type system. However, we have learned
+  how to manage this complexity and protect users from seeing it. We do not expect
+  routine users to notice this change, but users who specify ``-fprint-explicit-runtime-reps``
+  will see some changes.
+
+Alternatives
+------------
+* This seems to be the best way to support unlifted and unboxed constraints.
+
+* We have another putative fix to the type-checker bugs, but it would take a
+  major sea-change to the compiler, requiring a full separation between Haskell
+  types and Core types.
+  (Currently, GHC uses the same representation for both,
+  a considerable simplification, as only one type needs to be e.g. written to
+  interface files.) This other fix would likely require several solid weeks
+  of implementation work, and would have consequences (both implementation and end-user) that are hard to anticipate.
+  In constrast, the one presented here is simple, and we have a clear grasp of its consequences.
+
+Unresolved Questions
+--------------------
+* How should unlifted or unboxed constraints interact with constraint tuples?
+  Right now, we simply wouldn't allow unlifted constraints (implicit parameters only)
+  in a tuple.
+
+Implementation Plan
+-------------------
+* Simon or Richard will implement.
+
+Endorsements
+-------------
+

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -163,15 +163,34 @@ This proposal introduces ``(=>)`` and ``(==>)`` as proper type constructors, jus
 any other. Just like ``(->)``, they have kinds and can be abstracted over.
 Unlike ``FUN``, they do not take a ``Multiplicity`` argument; implicitly, it is ``Many``.
 
-The ``==>`` arrow is used in two places:
-
-* In instance heads, like ``instance Eq a => Eq (Maybe a)``
-* In quantified constraints, like ``forall x. c x => Eq x``
-
 In order to be backward compatible,
-we allow writing ``=>`` instead of ``==>`` in instance heads and in quantified constraints.
-That is, the *concrete* syntax for the type construtor ``==>`` can still use ``=>``.
-However, users may also choose to write ``==>`` (imported from ``GHC.Exts``) if they choose.
+we allow programmers to use infix ``=>`` instead of ``==>`` in instance heads
+and in quantified constraints:
+
+* In instance heads:
+  ```
+  instance Eq a => Eq (Maybe a) where ...
+  ```
+  means
+  ```
+  instance Eq a ==> Eq (Maybe a) where ...
+  ```
+  
+* In quantified constraints:
+  ```
+  f :: (forall x. Eq x => Eq (c x)) => c Int -> c Bool
+  ```
+  means
+  ```
+  f :: (forall x. Eq x ==> Eq (c x)) => c Int -> c Bool
+  ```
+
+If you choose, you can also write the latter forms,
+using ``==>``  (imported from ``GHC.Exts``), in these two places.
+
+However, if you want to use ``==>`` in any other syntactic context, you *must* use ``==>``.
+For example ``x :: T (==>)`` applies ``T`` to ``==>``.
+
 
 Implicit parameters
 :::::::::::::::::::::::::::::
@@ -197,7 +216,7 @@ making them apart is unsound in the presence of the current ``newtype`` optimiza
 one-element classes.
 Accordingly, under this proposal,
 
-  * ``TypeLike`` and ``ConstraintLike`` will be considered not *apart*.
+* ``TypeLike`` and ``ConstraintLike`` will be considered not *apart*.
 
 As a consequence, ``Type`` and ``Constraint`` are also not *apart*, just as today.
 This a wart, but it is an *existing* wart, and one that is not easy to fix.

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -297,17 +297,17 @@ Two different type constructors
 We considered having two distinct primitive type constructors, ``TYPE`` exactly as now, and ``Constraint :: Type``.
 Indeed that was our first plan. But
 
-* In Core we would have to say "If ``e :: ty :: ki`` then ``ki`` must be ``TYPE rr`` or ``Constraint``.
+* In Core we would have to say that if ``e :: ty :: ki`` then ``ki`` must be ``TYPE rr`` or ``Constraint``.
   Similarly for the types of binders. That "or" isn't fatal, but it's inelegant.
 
 * We anticipate that it will not be long before people want unlifted constraints. So then we'd add ``CONSTRAINT``, thus::
 
-    TYPE :: RuntimeRep -> Type
+    TYPE       :: RuntimeRep -> Type
     CONSTRAINT :: RuntimeRep -> Type
 
-  And now we have something isomorphic to what we propose (two types, vs one with a flag), except that our proposal allows all value-level terms with runtime rep rr to be treated uniformly. E.g. ``isUnliftedType`` has one case rather than two.
+  And now we have something isomorphic to what we propose (two types *vs* one with a flag), except that our proposal allows the types of all value-level terms with runtime rep rr to be treated uniformly. E.g. ``isUnliftedType`` has one case rather than two.
 
-* Collapsing the two into one SORT is witnessing the idea that types and constraints are the same thing at runtime.
+* Collapsing the two into one SORT witnesses the idea that types and constraints are the same thing at runtime.
 
 * We anticipate further movement in this area, perhpas via "Kinds are Calling Conventions". If so, ``SORT`` gives us wiggle room to do that; and (even more important) we don't want to duplicate any such changes across two distinct type constructors, ``SORT`` and ``CONSTRAINT``.
 
@@ -358,7 +358,8 @@ Unresolved Questions
 
 Implementation Plan
 -------------------
-* Simon or Richard will implement.
+
+Simon or Richard will implement.
 
 Endorsements
 -------------

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -269,7 +269,7 @@ of `Kinds are calling conventions <https://simon.peytonjones.org/kinds-are-calli
 Accordingly:
 
 * ``Data.Kind`` exports: ``Symbol``, ``Type``, ``TYPE``, ``Constraint``,
-  ``CONSTRAINT``, ``RuntimeRep``, ``Multiplicity``, ``Levity``, ``(->)``, ``(=>)``, and ``(==>)``.
+  ``CONSTRAINT``, ``RuntimeRep``, ``Multiplicity``, ``Levity``, and ``(->)``.
   ``Data.Kind`` should have a stable API; the kinds of these type
   constructors will not change.
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -269,7 +269,7 @@ of `Kinds are calling conventions <https://simon.peytonjones.org/kinds-are-calli
 Accordingly:
 
 * ``Data.Kind`` exports: ``Symbol``, ``Type``, ``TYPE``, ``Constraint``,
-  ``CONSTRAINT``, ``RuntimeRep``, ``Multiplicity``, ``Levity``, and ``(->)``.
+  ``RuntimeRep``, ``Multiplicity``, ``Levity``, and ``(->)``.
   ``Data.Kind`` should have a stable API; the kinds of these type
   constructors will not change.
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -167,23 +167,22 @@ In order to be backward compatible,
 we allow programmers to use infix ``=>`` instead of ``==>`` in instance heads
 and in quantified constraints:
 
-* In instance heads:
-  ```
-  instance Eq a => Eq (Maybe a) where ...
-  ```
-  means
-  ```
-  instance Eq a ==> Eq (Maybe a) where ...
-  ```
+* In instance heads::
+
+     instance Eq a => Eq (Maybe a) where ...
+
+  means::
+
+     instance Eq a ==> Eq (Maybe a) where ...
+
   
-* In quantified constraints:
-  ```
-  f :: (forall x. Eq x => Eq (c x)) => c Int -> c Bool
-  ```
-  means
-  ```
-  f :: (forall x. Eq x ==> Eq (c x)) => c Int -> c Bool
-  ```
+* In quantified constraints::
+
+     f :: (forall x. Eq x => Eq (c x)) => c Int -> c Bool
+
+  means::
+
+     f :: (forall x. Eq x ==> Eq (c x)) => c Int -> c Bool
 
 If you choose, you can also write the latter forms,
 using ``==>``  (imported from ``GHC.Exts``), in these two places.

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -2,14 +2,14 @@ Separating Type from Constraint
 ==============================
 
 .. author:: Richard Eisenberg and Simon Peyton Jones
-.. date-accepted:: 
-.. ticket-url:: 
+.. date-accepted::
+.. ticket-url::
 .. implemented::
 .. highlight:: haskell
 .. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
             **After creating the pull request, edit this file again, update the
             number in the link, and delete this bold sentence.**
-.. secnum::
+.. sectnum::
 .. contents::
 
 Since version 8.0, GHC has supported a rich structure of inhabited types through the
@@ -275,4 +275,3 @@ Implementation Plan
 
 Endorsements
 -------------
-

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -6,9 +6,7 @@ Separating Type from Constraint
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/518>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -128,7 +128,7 @@ produce a coercion between ``Int`` and ``Bool``, thus::
 That would be Very, Very Bad.  So, although ``Type`` and ``Constraint`` are built
 with different (un-equal) primitive type constructors,
 
-* **GHC's type checker nevertheless treats ``Type`` and ``Constraint`` as *not apart* **
+* **GHC's type checker nevertheless treats ``Type`` and ``Constraint`` as *not apart*.**
 
 That in turn makes GHC complain that the above instances overlap, and are hence illegal.
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -112,8 +112,7 @@ wit, Core allows ::
 
   KindCo axDefault :: Constraint ~# Type
 
-For this reason, the type system must treat ``Constraint`` and ``Type`` as
-not *apart*. For this reason, the following is not allowed::
+Now, suppose that you could write this::
 
   type family F a
   type instance F Type = Int
@@ -126,10 +125,12 @@ produce a coercion between ``Int`` and ``Bool``, thus::
         ~#  F Type         -- By KindCo axDefault
         ~#  Int            -- By type instance F Type
 
-That would be Very, Very Bad.  So, although `Type` and `Constraint` are built
-with different (un-equal) primitive type constructors, GHC's type checker nevertheless
-treats them as *not apart*; that in turn makes GHC complain that the above
-instances overlap, and are hence illegal.
+That would be Very, Very Bad.  So, although ``Type`` and ``Constraint`` are built
+with different (un-equal) primitive type constructors,
+
+* **GHC's type checker nevertheless treats ``Type`` and ``Constraint`` as *not apart* **
+
+That in turn makes GHC complain that the above instances overlap, and are hence illegal.
 
 
 Proposed Change Specification

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -1,9 +1,6 @@
 Separating Type from Constraint
 ==============================
 
-tmp/Unlifted Constraints
-====================
-
 .. author:: Richard Eisenberg and Simon Peyton Jones
 .. date-accepted:: 
 .. ticket-url:: 
@@ -12,6 +9,7 @@ tmp/Unlifted Constraints
 .. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
             **After creating the pull request, edit this file again, update the
             number in the link, and delete this bold sentence.**
+.. secnum::
 .. contents::
 
 Since version 8.0, GHC has supported a rich structure of inhabited types through the

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -128,7 +128,7 @@ produce a coercion between ``Int`` and ``Bool``, thus::
 That would be Very, Very Bad.  So, although ``Type`` and ``Constraint`` are built
 with different (un-equal) primitive type constructors,
 
-* **GHC's type checker nevertheless treats ``Type`` and ``Constraint`` as *not apart*.**
+* **GHC's type checker treats `Type` and `Constraint` as *not apart*.**
 
 That in turn makes GHC complain that the above instances overlap, and are hence illegal.
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -78,8 +78,7 @@ The current root of our type system contains these definitions::
   type Type        = TYPE LiftedRep
   type (->)        = FUN Many
 
-  -- (=>) is not something that can be written unsaturated;
-  --      rat
+  -- (=>) is not something that can be written unsaturated
 
 NB: in GHC, implicit parameters are internally represented as a special class,
 but that is not user-visible.
@@ -88,7 +87,7 @@ Type and Constraint are not apart
 :::::::::::::::::::::::::::::::::::
 
 GHC has an optimization for one-element classes (where the element
-is either a superclass or a method), defining these in like a newtype, not a datatype.
+is either a superclass or a method), defining these like a newtype, not a datatype.
 For example, if we have ::
 
   class Default a where
@@ -308,7 +307,7 @@ Effect and Interactions
 * This proposal is fully backward compatible.
 
 * This proposal is forward compatible with more glorious updates to the type/constraint
-  system we might imagine in the future, as detailed at TODO.
+  system we might imagine in the future, as we've [detailed elsewhere](https://gitlab.haskell.org/ghc/ghc/-/issues/21623).
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -142,6 +142,11 @@ We propose the following new setup, not repeating any types that remains unchang
   type SORT :: TypeOrConstraint -> RuntimeRep -> Type
   type IP   :: formal (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
 
+  type (=>)  :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
+                CONSTRAINT r1 -> TYPE r2 -> Type  -- primitive
+  type (==>) :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
+                CONSTRAINT r1 -> CONSTRAINT r2 -> Constraint
+
   -- Data types
   data TypeOrConstraint = TypeLike | ConstraintLike
 
@@ -150,10 +155,6 @@ We propose the following new setup, not repeating any types that remains unchang
   type CONSTRAINT = SORT ConstraintLike
   type Constraint = CONSTRAINT LiftedRep
 
-  type (=>)  :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
-                CONSTRAINT r1 -> TYPE r2 -> Type  -- primitive
-  type (==>) :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
-                CONSTRAINT r1 -> CONSTRAINT r2 -> Constraint
 
 Changes to the type structure
 :::::::::::::::::::::::::::::

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -21,7 +21,7 @@ Just like how the existence of ``TYPE`` directly opened the door to new innovati
 in datatype and newtype definitions, we expect the similar treatment of constraints
 to allow for strict classes and unlifted and unboxed implicit parameters.
 
-In addition, the new treatment proposes here allows GHC's internal language, Core,
+In addition, the new treatment proposed here allows GHC's internal language, Core,
 to more properly tell the difference between types and constraints, eliminating a
 troubling class of bugs that keeps recurring.
 
@@ -32,7 +32,7 @@ Motivation
    using the existing ``(?x :: Int#)`` syntax. This allows programs to abstract over
    implicit parameters without suffering inefficiencies due to boxing.
 
-2. This proposal allows a fix to several type-checker bugs that is otherwise elusive.
+2. This proposal allows a fix to several type-checker bugs that are otherwise elusive.
    With this proposal, we can eliminate this entire class of bugs, that we otherwise
    believe will continue to haunt GHC.  Currently in GHC, `Type` and `Constraint` are
    *distinct* in the typechecker, but *identical* in Core.  That leads to massive duplication;
@@ -161,7 +161,7 @@ Changes to the type structure
 
 This proposal introduces ``(=>)`` and ``(==>)`` as proper type constructors, just like
 any other. Just like ``(->)``, they have kinds and can be abstracted over.
-Unlike ``FUN``, they do not take a ``Multiplicity`` argument; implicity, it is ``Many``.
+Unlike ``FUN``, they do not take a ``Multiplicity`` argument; implicitly, it is ``Many``.
 
 The ``==>`` arrow is used in two places:
 

--- a/proposals/0000-type-vs-constraint.rst
+++ b/proposals/0000-type-vs-constraint.rst
@@ -140,7 +140,7 @@ We propose the following new setup, not repeating any types that remains unchang
 
   -- Primitive type constructors
   type SORT :: TypeOrConstraint -> RuntimeRep -> Type
-  type IP   :: formal (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
+  type IP   :: forall (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
 
   type (=>)  :: forall (r1 :: RuntimeRep) (r2 :: RuntimeRep).
                 CONSTRAINT r1 -> TYPE r2 -> Type  -- primitive
@@ -181,7 +181,7 @@ the door is open to having unlifted constraints, or constraints whose representa
 an unboxed type like ``Int#``.  In this proposal we exploit this opportunity only in a
 limited way, by generalising the kind of ``IP``, thus::
 
-  type IP   :: formal (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
+  type IP   :: forall (r :: RuntimeRep). Symbol -> TYPE r -> CONSTRAINT r
 
 So now this is accepted::
 


### PR DESCRIPTION
This GHC proposal refines the type structure of `Type` and `Constraint`, to 
* allow unboxed and unlifed constraints
* solve a long-standing source of (still-unsolved) bugs in GHC

[Rendered proposal here](https://github.com/ghc-proposals/ghc-proposals/blob/spj/type-vs-constraint/proposals/0000-type-vs-constraint.rst)