### PR TITLE
Succinct associated type instances

### DIFF
--- a/proposals/0521-succinct-associated-type-instances.md
+++ b/proposals/0521-succinct-associated-type-instances.md
@@ -31,7 +31,7 @@ instance C [a] where
 
 -- also before
 instance C (Maybe a) where
-  type F _ = () -- can't refer to `a` before this proposal
+  type F _ = () -- couldn't refer to `a` before this proposal
 
 -- now
 instance C [a] where


### PR DESCRIPTION
[Rendered](https://github.com/mlabs-haskell/ghc-proposals/blob/succinct-associated-type-instances/proposals/0521-succinct-associated-type-instances.md)

When declaring associated type family instances in Haskell,
you need to repeat the names of the arguments, unless
you don't use any of the type variables from the instance head.

In that case, you can replace the LHS with a `_`, which is
much more succinct and heavily reduces noise.

This proposal generalises this feature, allowing you to *also* refer
to the type variables bound in the instance head.
This allows you to make use of this succinct syntax no matter
the type instance you want to write:

```haskell
class C (a :: Type) where
  type F a :: Type

-- before
instance C [a] where
  type F [a] = a

-- also before
instance C (Maybe a) where
  type F _ = () -- couldn't refer to `a` before this proposal

-- now
instance C [a] where
  type F _ = a -- can refer to `a` now
```
While seemingly a small change, this can heavily reduce the amount of noise in code
with complex instance declarations.

In addition, this enables the same feature for *default type family instances*,
as reported in https://gitlab.haskell.org/ghc/ghc/-/issues/21702.
