### PR TITLE
Template Haskell quotes as patterns

### DIFF
--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -131,6 +131,27 @@ This is all accomplished without trying to minimize TH AST changes, which is qui
 Proposed Change Specification
 -----------------------------
 
+Quotes as patterns
+~~~~~~~~~~~~~~~~~~
+
+With the new extension ``TemplateHaskellQuotesAsPatterns``, slightly modified quotes are usable in pattern position.
+
+The first difference is that quotes as pattern match raw syntax, not (monadic) actions producing syntax.
+The tying rules are as follows:
+
+- ``[e| ... |]`` matches ``Exp``
+- ``[p| ... |]`` matches ``Pat``
+- ``[t| ... |]`` matches ``Type``
+- ``[d| ... |]`` matches ``Dec``
+
+The second differences is that splices within these quotes contain patterns instead of expressions::
+
+  p is in <pat>
+  --------------------------------
+  [| ... $(p) ... |] is in <apat>
+
+The third and final difference is that names in quotes must all be uses, never bindings.
+
 Optional: Fine-grained Quotation constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -142,23 +163,6 @@ Optional: Fine-grained Quotation constraints
 The ``Quote`` class has a ``newName`` method, and is just used when binding local variables.
 Relax the rules so that TH Quotes only impose a ``Quote`` constraint when ``newName`` is in fact needed.
 
-Quotes as patterns
-~~~~~~~~~~~~~~~~~~
-
-With the new extension ``TemplateHaskellQuotesAsPatterns``, quotes which do contain variable bindings are usable in pattern position.
-
-Quotes as pattern match raw syntax, not (monadic) actions producing syntax.
-The tying rules are as follows:
-
-- ``[e| ... |]`` matches ``Exp``
-- ``[p| ... |]`` matches ``Pat``
-- ``[t| ... |]`` matches ``Type``
-- ``[d| ... |]`` matches ``Dec``
-
-Splices in quotes are binding points for arbitrary sub-patterns.
-
-Names in patterns must be uses not bindingsresolved.
-Bindings
 
 Examples
 --------
@@ -185,7 +189,7 @@ Examples
 
      f [| \x -> x |] = ...
 
-   It is disallowed because ``x`` is bound in the quote.
+   It is disallowed because the first ``x`` in the quote is a binding not a use.
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -305,5 +305,10 @@ Implementation Plan
 
 I lack the time capacity to implement these changes all by myself, and would submit this to the Haskell Foundation as part of whatever fund as part of whatever https://discourse.haskell.org/t/pre-hftt-ongoing-focus-on-migration-tools/4626 becomes.
 
+That said, I would be happy to pair / code review / etc. with whoever does end up working on it.
+I likewise have been pitching in while @tek is leading the charge on `Proposal 285`_, and that process has felt very good to me.
+
+.. _`Proposal 285`: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0246-overloaded-bracket.rst
+
 Endorsements
 -------------

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -243,7 +243,7 @@ Quotes that bind local variables do in fact have an interpretation as non-linear
 
   f (LamE [VarP __x0] (VarE __x1) | nameBase __x0 == "x" && __x0 == __x1 = ...
 
-This gets especially interesting with multiple scope::
+This gets especially interesting with multiple scopes::
 
   f [| (\x -> x, \x -> x) |] = ...
 

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -1,4 +1,4 @@
-Template Haskell Quotes as patterns
+Template Haskell quotes as patterns
 ===================================
 
 .. author:: John Ericson
@@ -47,7 +47,7 @@ Here is a `recent change <https://github.com/reflex-frp/reflex/pull/472/files#di
 ``ConP`` got an additional parameter so I had to introduce some CPP and a `conPCompat` function.
 Even if such functions are changed to pattern synonyms and factored out into a library to avoid everyone reinventing the wheel (generally the best we can do for smoothing about data type changes), they is still an annoying source of boilerplate / chores for release management.
 
-But Template Haskell gives us a better option, which I used in a `subsequent commit <https://github.com/reflex-frp/reflex/commit/4cd322604596ac652f35bbe72c1ad8fe42f2efdc>`:
+But Template Haskell gives us a better option, which I used in a `subsequent commit <https://github.com/reflex-frp/reflex/commit/4cd322604596ac652f35bbe72c1ad8fe42f2efdc>`_:
 
 .. code-block:: diff
 

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -130,82 +130,145 @@ This is all accomplished without trying to minimize TH AST changes, which is qui
 
 Proposed Change Specification
 -----------------------------
-Specify the change in precise, comprehensive yet concise language. Avoid words
-like "should" or "could". Strive for a complete definition. Your specification
-may include,
 
-* BNF grammar and semantics of any new syntactic constructs
-  (Use the `Haskell 2010 Report <https://www.haskell.org/onlinereport/haskell2010/>`_ or GHC's ``alex``\- or ``happy``\-formatted files
-  for the `lexer <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser/Lexer.x>`_ or `parser <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser.y>`_
-  for a good starting point.)
-* the types and semantics of any new library interfaces
-* how the proposed change interacts with existing language or compiler
-  features, in case that is otherwise ambiguous
+Optional: Fine-grained Quotation constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Strive for *precision*. The ideal specification is described as a
-modification of the `Haskell 2010 report
-<https://www.haskell.org/definition/haskell2010.pdf>`_. Where that is
-not possible (e.g. because the specification relates to a feature that
-is not in the Haskell 2010 report), try to adhere its style and level
-of detail. Think about corner cases. Write down general rules and
-invariants.
+.. _`Proposal 246`: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0246-overloaded-bracket.rst
 
-Note, however, that this section should focus on a precise
-*specification*; it need not (and should not) devote space to
-*implementation* details -- there is a separate section for that.
+*This is optional but fits well with the rest.*
 
-The specification can, and almost always should, be illustrated with
-*examples* that illustrate corner cases. But it is not sufficient to
-give a couple of examples and regard that as the specification! The
-examples should illustrate and elucidate a clearly-articulated
-specification that covers the general case.
+`Proposal 246`_ made it so that quotes are polymorphic, e.g. ``[| 1 + 1 |] :: Quote m => m Exp``.
+The ``Quote`` class has a ``newName`` method, and is just used when binding local variables.
+Relax the rules so that TH Quotes only impose a ``Quote`` constraint when ``newName`` is in fact needed.
+
+Quotes as patterns
+~~~~~~~~~~~~~~~~~~
+
+With the new extension ``TemplateHaskellQuotes`` as patterns, quotes which do contain variable bindings are usable in pattern position.
+
+Quotes as pattern match raw syntax, not (monadic) actions producing syntax.
+The tying rules are as follows:
+
+- ``[e| ... |]`` matches ``Exp``
+- ``[p| ... |]`` matches ``Pat``
+- ``[t| ... |]`` matches ``Type``
+- ``[d| ... |]`` matches ``Dec``
+
+Splices in quotes are binding points for arbitrary sub-patterns.
+
+Names in patterns must be uses not bindingsresolved.
+Bindings
 
 Examples
 --------
-This section illustrates the specification through the use of examples of the
-language change proposed. It is best to exemplify each point made in the
-specification, though perhaps one example can cover several points. Contrived
-examples are OK here. If the Motivation section describes something that is
-hard to do without this proposal, this is a good place to show how easy that
-thing is to do with the proposal.
+
+#. This is allowed::
+
+     f [| $(x) $(y) |] = ...
+
+     =>
+
+     f (AppE x y) = ...
+
+#. This is conditionally allowed::
+
+     f [| name |] = ...
+
+     =>
+
+     f (VarE __n) | __n == 'name = ...
+
+   on ``'name`` being bound in the scope the bracket is written in (bound lexically, not dynamically at the splice site).
+
+#. This is not allowed::
+
+     f [| \x -> x |] = ...
+
+   It is disallowed because ``x`` is bound in the quote.
 
 Effect and Interactions
 -----------------------
-Your proposed change addresses the issues raised in the motivation. Explain how.
 
-Also, discuss possibly contentious interactions with existing language or compiler
-features. Complete this section with potential interactions raised
-during the PR discussion.
-
+The banned binding constructs are precisely those which would need ``newName`` in expression position.
+The relaxation of the expression position rules is supposed to make those restrictions more familiar to the reader.
 
 Costs and Drawbacks
 -------------------
-Give an estimate on development and maintenance costs. List how this effects
-learnability of the language for novice users. Define and list any remaining
-drawbacks that cannot be resolved.
 
+Action asymmetry
+~~~~~~~~~~~~~~~~
+
+The lack of symmetry where expression create actions but patterns only bind plain AST values is annoying.
+But the fixes for this might be too radical?
 
 Alternatives
 ------------
-List alternative designs to your proposed change. Both existing
-workarounds, or alternative choices for the changes. Explain
-the reasons for choosing the proposed change over these alternative:
-*e.g.* they can be cheaper but insufficient, or better but too
-expensive. Or something else.
 
-The PR discussion often raises other potential designs, and they should be
-added to this section. Similarly, if the proposed change
-specification changes significantly, the old one should be listed in
-this section.
+Pattern match on actions(!)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+I hypothesize that we could do better than the proposed actions vs no action asymmetry by meditating on the ways pattern matching relates to optics.
+For example::
+
+  [| a + $(x) |]
+
+could match any ``t Exp`` where ``t`` is an bind ``x :: t Expr`` with this desugaring::
+
+  f [| a + $(x) |] = ...
+
+  =>
+
+  f (Just x <- traverse __inner) = ...
+
+  __inner (AppE (VarE __a) x) | __a == 'a = Just x
+  __inner _                               = Nothing
+
+This behavior seems overwrought, as we are doing the as-proposed behavior *plus* an additional traversal.
+But this matches the fact that expression-position quotes are do what idiom brackets do (implicit ``Applicative``) in addition to base quoting.
+
+Support local variables
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Quotes that bind local variables do in fact have an interpretation as non-linear patterns::
+
+  f [| \x -> x |] = ...
+
+  =>
+
+  f (LamE [VarP __x0] (VarE __x1) | nameBase __x0 == "x" && __x0 == __x1 = ...
+
+This gets especially interesting with multiple scope::
+
+  f [| (\x -> x, \x -> x) |] = ...
+
+  =>
+
+  f (TupE [ Just (LamE [VarP __x0] (VarE __x1))
+          , Just (LamE [VarP __x2] (VarE __x3))
+          ])
+    | nameBase __x0 == "x" && __x0 == __x1
+    | nameBase __x0 == "x" && __x2 == __x3
+    = ...
+
+Note how ``__x0`` is related to ``__x1`` and  ``__x2`` likewise to ``__x3``, but the former two are *not* related to the latter two.
+This respects the two independent scopes.
+
+This is perhaps convenient, but it rather baroque.
+It is also unclear whether the ``nameBase _ == "x"`` is useful in practice, or whether it is better to just "bake in" alpha equivalence and not care whether the local variable is an "x" or not provided the usage lines up with the binding.
+
+Finally, the non-linear patterns trick is not a true dual because it merely checks whether the variables "ended up" being the same *once the action is run*, rather than pattern matching on the action *itself*.
+De Bruijn indices encode actions in a way that makes equality of the easily decidable, for example, and thus would be a less hacky solution.
+
+---------
+
+Both alternatives are tempting, but I rather wait for more research on patterns, optics, and "dualizing" ``Applicative`` and effects like ``Quote`` in general, so we can better understand the theory of what's going on.
+If and when we understand the lay-of-the-land better, we can make some new extensions and deprecate the old ones accordingly.
 
 Unresolved Questions
 --------------------
-Explicitly list any remaining issues that remain in the conceptual design and
-specification. Be upfront and trust that the community will help. Please do
-not list *implementation* issues.
 
-Hopefully this section will be empty by the time the proposal is brought to
-the steering committee.
+None at this time.
 
 Future Work
 -----------

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -1,0 +1,136 @@
+Notes on reStructuredText - delete this section before submitting
+==================================================================
+
+The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
+
+::
+
+ like this
+ and
+
+ this too
+
+To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
+
+
+Proposal title
+==============
+
+.. author:: Your name
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. contents::
+
+Here you should write a short abstract motivating and briefly summarizing the proposed change.
+
+
+Motivation
+----------
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
+
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
+
+* BNF grammar and semantics of any new syntactic constructs
+  (Use the `Haskell 2010 Report <https://www.haskell.org/onlinereport/haskell2010/>`_ or GHC's ``alex``\- or ``happy``\-formatted files
+  for the `lexer <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser/Lexer.x>`_ or `parser <https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/Parser.y>`_
+  for a good starting point.)
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
+
+Strive for *precision*. The ideal specification is described as a
+modification of the `Haskell 2010 report
+<https://www.haskell.org/definition/haskell2010.pdf>`_. Where that is
+not possible (e.g. because the specification relates to a feature that
+is not in the Haskell 2010 report), try to adhere its style and level
+of detail. Think about corner cases. Write down general rules and
+invariants.
+
+Note, however, that this section should focus on a precise
+*specification*; it need not (and should not) devote space to
+*implementation* details -- there is a separate section for that.
+
+The specification can, and almost always should, be illustrated with
+*examples* that illustrate corner cases. But it is not sufficient to
+give a couple of examples and regard that as the specification! The
+examples should illustrate and elucidate a clearly-articulated
+specification that covers the general case.
+
+Examples
+--------
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
+
+Effect and Interactions
+-----------------------
+Your proposed change addresses the issues raised in the motivation. Explain how.
+
+Also, discuss possibly contentious interactions with existing language or compiler
+features. Complete this section with potential interactions raised
+during the PR discussion.
+
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this effects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
+
+
+Alternatives
+------------
+List alternative designs to your proposed change. Both existing
+workarounds, or alternative choices for the changes. Explain
+the reasons for choosing the proposed change over these alternative:
+*e.g.* they can be cheaper but insufficient, or better but too
+expensive. Or something else.
+
+The PR discussion often raises other potential designs, and they should be
+added to this section. Similarly, if the proposed change
+specification changes significantly, the old one should be listed in
+this section.
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
+
+Hopefully this section will be empty by the time the proposal is brought to
+the steering committee.
+
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?
+
+Endorsements
+-------------
+(Optional) This section provides an opportunity for any third parties to express their
+support for the proposal, and to say why they would like to see it adopted.
+It is not mandatory for have any endorsements at all, but the more substantial
+the proposal is, the more desirable it is to offer evidence that there is
+significant demand from the community.  This section is one way to provide
+such evidence.

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -1,22 +1,7 @@
-Notes on reStructuredText - delete this section before submitting
-==================================================================
+Template Haskell Quotes as patterns
+===================================
 
-The proposals are submitted in reStructuredText format.  To get inline code, enclose text in double backticks, ``like this``.  To get block code, use a double colon and indent by at least one space
-
-::
-
- like this
- and
-
- this too
-
-To get hyperlinks, use backticks, angle brackets, and an underscore `like this <http://www.haskell.org/>`_.
-
-
-Proposal title
-==============
-
-.. author:: Your name
+.. author:: John Ericson
 .. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
 .. ticket-url:: Leave blank. This will eventually be filled with the
                 ticket URL which will track the progress of the
@@ -29,17 +14,119 @@ Proposal title
             number in the link, and delete this bold sentence.**
 .. contents::
 
-Here you should write a short abstract motivating and briefly summarizing the proposed change.
-
+The Template Haskell AST is inherently unstable.
+Let's make that less of an issue.
 
 Motivation
 ----------
-Give a strong reason for why the community needs this change. Describe the use
-case as clearly as possible and give an example. Explain how the status quo is
-insufficient or not ideal.
 
-A good Motivation section is often driven by examples and real-world scenarios.
+As is well known, the Template Haskell AST is inherently unstable.
+Changes that are backwards compatible in surface Haskell nonetheless compatibility issues with the TH AST.
 
+Here is a `recent change <https://github.com/reflex-frp/reflex/pull/472/files#diff-2c01379db9dd160bd3f212e3ce06c34bdeee89c19e08f41fdc94f7e66cca5aa8>`_ I made to support GHC 9.2 in a library illustrating the problem:
+
+.. code-block:: diff
+
+  --- a/src/Reflex/Dynamic/TH.hs
+  +++ b/src/Reflex/Dynamic/TH.hs
+  @@ -45,5 +45,12 @@ qDynPure qe = do
+     (e', exprsReversed) <- runStateT (gmapM f e) []
+     let exprs = reverse exprsReversed
+         arg = foldr (\a b -> ConE 'FHCons `AppE` snd a `AppE` b) (ConE 'FHNil) exprs
+  -      param = foldr (\a b -> ConP 'HCons [VarP (fst a), b]) (ConP 'HNil []) exprs
+  +      param = foldr (\a b -> conPCompat 'HCons [VarP (fst a), b]) (conPCompat 'HNil []) exprs
+     [| $(return $ LamE [param] e') <$> distributeFHListOverDynPure $(return arg) |]
+  +
+  +conPCompat :: Name -> [Pat] -> Pat
+  +#if MIN_VERSION_template_haskell(2, 18, 0)
+  +conPCompat name = ConP name []
+  +#else
+  +conPCompat = ConP
+  +#endif
+
+``ConP`` got an additional parameter so I had to introduce some CPP and a `conPCompat` function.
+Even if such functions are changed to pattern synonyms and factored out into a library to avoid everyone reinventing the wheel (generally the best we can do for smoothing about data type changes), they is still an annoying source of boilerplate / chores for release management.
+
+But Template Haskell gives us a better option, which I used in a `subsequent commit <https://github.com/reflex-frp/reflex/commit/4cd322604596ac652f35bbe72c1ad8fe42f2efdc>`:
+
+.. code-block:: diff
+
+  --- a/src/Reflex/Dynamic/TH.hs
+  +++ b/src/Reflex/Dynamic/TH.hs
+  @@ -44,15 +44,14 @@ qDynPure qe = do
+     (e', exprsReversed) <- runStateT (gmapM f e) []
+     let exprs = reverse exprsReversed
+  -      arg = foldr (\a b -> ConE 'FHCons `AppE` snd a `AppE` b) (ConE 'FHNil) exprs
+  -      param = foldr (\a b -> conPCompat 'HCons [VarP (fst a), b]) (conPCompat 'HNil []) exprs
+  -  [| $(return $ LamE [param] e') <$> distributeFHListOverDynPure $(return arg) |]
+  +      arg = foldr
+  +        (\(_, expr) rest -> [e| FHCons $(pure expr) $rest |])
+  +        [e| FHNil |]
+  +        exprs
+  +      param = foldr
+  +        (\(name, _) rest -> [p| HCons $(pure $ VarP name) $rest |])
+  +        [p| HNil |]
+  +        exprs
+  +  [| (\ $param -> $(pure e')) <$> distributeFHListOverDynPure $arg |]
+  -
+  -conPCompat :: Name -> [Pat] -> Pat
+  -#if MIN_VERSION_template_haskell(2, 18, 0)
+  -conPCompat name = ConP name []
+  -#else
+  -conPCompat = ConP
+  -#endif
+
+Notes that ``conPCompat`` is gone entirely!
+By using quotes and splices like this, one avoids the AST and its instability problems.
+Quotes and splices are much more stable for the same reason the surface language is.
+The overall method of this proposal is to allow using them to solve more problems, so the AST becomes less necessary to use, and thus TH code in practice is less likely to break.
+
+Just a few lines above, however, there was more TH AST usage I couldn't get rid of::
+
+  let f :: forall d. Data d => d -> StateT [(Name, Exp)] Q d
+      f d = case eqT of
+        Just (Refl :: d :~: Exp)
+          | AppE (VarE m) eInner <- d
+          , m == 'unqMarker
+          -> do n <- lift $ newName "dynamicQuotedExpressionVariable"
+                modify ((n, eInner):)
+                return $ VarE n
+        _ -> gmapM f d
+  (e', exprsReversed) <- runStateT (gmapM f e) []
+
+Perhaps we can take solace in a claim that ``AppE`` and ``VarE`` are less likely to change, but that isn't satisfactory --- what about more complex patterns?
+The fundamental problem here is that in *positive* position (expressions), we have a choice of either using regular syntax or quotes,
+but in *negative* position (patterns), we only have the option regular syntax.
+
+The solution is simple: let's allow quotes too!
+This would allow:
+
+.. code-block:: diff
+
+         Just (Refl :: d :~: Exp)
+  -        | AppE (VarE m) eInner <- d
+  +        | [e| $(VarE m) $eInner |] <- d
+           , m == 'unqMarker
+           -> do ...
+
+or even going further:
+
+.. code-block:: diff
+
+         Just (Refl :: d :~: Exp)
+  -        | AppE (VarE m) eInner <- d
+  -        , m == 'unqMarker
+  +        | [e| unqMarker $eInner |] <- d
+           -> do ...
+
+In this way, we also avoid the use of the AST.
+
+Note we do have quotes *of patterns* today (``[p| ... |]``), but that is orthogonal.
+This is quotes *as patterns*, the type of syntax being quoted doesn't matter and could be anything.
+The point is the quotes are in negative position.
+
+With this change put together, the hope is that a significant portion of TH out in the wild is going to be more stable across GHC versions.
+This is all accomplished without trying to minimize TH AST changes, which is quite a hopeless task and also a perverse incentive for the rest of language development.
 
 Proposed Change Specification
 -----------------------------
@@ -120,17 +207,34 @@ not list *implementation* issues.
 Hopefully this section will be empty by the time the proposal is brought to
 the steering committee.
 
+Future Work
+-----------
+
+Split or wrap the ``template-haskell`` library
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The previous change hopefully allows far less usage of the Template Haskell AST than today without loss of expressive power.
+But even if that's the case, users will just encounter another source of new GHC busywork.
+The ``template-haskell`` library contains more stable items and the AST alike, and the latter forces a major version bump every release.
+Even when one doesn't use the AST, or any other part of the library with a breaking change, they still need to adjust bounds to deal with this version bump.
+
+We should instead split or wrap the Template Haskell library so that more stable core functionality is accessible in a more stable library.
+Then users which no longer need the unstable bits don't have to pay their costs in the form of major version churn.
+
+The exact interface of such a library is more a Core Library Committee than GHC steering committee matter, so I defer any further details to a separate posting in that venue.
+
+More valid splice positions and quote types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There will still be a long tail of scenarios where the AST is needed, but over time we can add more flexible forms of quoting and splicing to shrink that tail.
+A goo ways to figure out what is needed could be trying to convert existing in-depth code generators like Alex and Happy, and seeing what is possible and what isn't.
+
+The goal is for the TH AST to increasingly be a historical artifact, or debugging aid, that doesn't unlock any additional expressive power.
 
 Implementation Plan
 -------------------
-(Optional) If accepted who will implement the change? Which other resources
-and prerequisites are required for implementation?
+
+I lack the time capacity to implement these changes all by myself, and would submit this to the Haskell Foundation as part of whatever fund as part of whatever https://discourse.haskell.org/t/pre-hftt-ongoing-focus-on-migration-tools/4626 becomes.
 
 Endorsements
 -------------
-(Optional) This section provides an opportunity for any third parties to express their
-support for the proposal, and to say why they would like to see it adopted.
-It is not mandatory for have any endorsements at all, but the more substantial
-the proposal is, the more desirable it is to offer evidence that there is
-significant demand from the community.  This section is one way to provide
-such evidence.

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -16,6 +16,7 @@ Template Haskell quotes as patterns
 
 The Template Haskell AST is inherently unstable.
 Let's make that less of an issue.
+We can do that by allowing Quotes to be used instead of Template Haskell AST data constructors in patterns.
 
 Motivation
 ----------

--- a/proposals/0000-th-quotes-as-patterns.rst
+++ b/proposals/0000-th-quotes-as-patterns.rst
@@ -145,7 +145,7 @@ Relax the rules so that TH Quotes only impose a ``Quote`` constraint when ``newN
 Quotes as patterns
 ~~~~~~~~~~~~~~~~~~
 
-With the new extension ``TemplateHaskellQuotes`` as patterns, quotes which do contain variable bindings are usable in pattern position.
+With the new extension ``TemplateHaskellQuotesAsPatterns``, quotes which do contain variable bindings are usable in pattern position.
 
 Quotes as pattern match raw syntax, not (monadic) actions producing syntax.
 The tying rules are as follows:
@@ -191,7 +191,8 @@ Effect and Interactions
 -----------------------
 
 The banned binding constructs are precisely those which would need ``newName`` in expression position.
-The relaxation of the expression position rules is supposed to make those restrictions more familiar to the reader.
+Through this, the optional propoposed relaxation of the expression position rules is supposed to make those restrictions more familiar to the programmer.
+Specifically, by distinguishing the same subset of quotes in two ways (they're the only ones allowed in pattern position, they get a more general type in expresssion position), we give programmers two different ways to learn the difference between them and quotes in general.
 
 Costs and Drawbacks
 -------------------


### PR DESCRIPTION
The Template Haskell AST is inherently unstable. Let's make that less of an issue. We can do that by allowing Quotes to be used instead of Template Haskell AST data constructors in patterns.