### PR TITLE
Clean up and simplify the treatment of implicit binding

### DIFF
--- a/principles.rst
+++ b/principles.rst
@@ -47,6 +47,7 @@ Accepted principles
 
 .. _`#281`: proposals/0281-visible-forall.rst
 .. _`#378`: proposals/0378-dependent-type-design.rst
+.. _`#425`: proposals/0425-decl-invis-binders.rst
 .. _`#448`: proposals/0448-type-variable-scoping.rst
 
 Syntax
@@ -158,6 +159,68 @@ there is an absence of punning.
 Name resolution and scoping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Explicit Binding Principle (EBP)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _`Explicit Binding Principle`:
+
+**Principle**: Through the right combination of extensions, every implicit form of variable binding
+is must have an explicit equivalent that, regardless of the context, is unambiguously a binding site.
+
+Examples:
+
+#. Problem::
+
+     -- Assume no `a` in scope
+
+     id :: a -> a  -- The variable `a` has no explicit binding site.
+
+   Solution::
+
+     -- Assume no `a` in scope
+
+     id :: forall a. a -> a  -- The `a` in `forall a.` is an explicit binding site.
+
+   This is provided by ``-XExplicitForAll``, which predates the GHC proposal process.
+
+#. Problem::
+
+     -- Assume no `a` in scope
+
+     data Foo (a :: k)
+
+   Solution::
+
+     data Foo @k (a :: k)
+
+   This is provided by ``-XTypeAbstractions`` from `#425`_.
+
+#. Problem::
+
+     -- Assume no `b` in scope
+
+     f :: (Bool, Bool) -> Bool
+     f (x :: (b, b)) = ...   -- The variable `b` has no implicit binding site.
+
+   We could declare one or both of the ``b`` occurrences above a binding site,
+   as was the historical interpretation of this, but that doesn't help as this
+   syntax isn't unambiguously a binding site regardless of context (i.e.
+   regardless of whether there is a `b` already in scope).
+
+*Motivation:* The `Explicit Binding Principle`_ allows programmers to control exactly how variables come into
+scope.
+It ensures all short-hands can be explained in terms of an explicit, unambiguous equivalent that is easier to understand at the cost of being more verbose:
+
+- Positive-position signatures' free vars cause  implicit ``forall ... .``
+
+- Negative position free vars cause different sorts of binding:
+
+  - Signatures on term patterns (pattern signatures) cause implicit ``let type ... = _ in``
+
+  - Signatures on type variables (kind signatures) case implicit ``@...``
+
+From `#425`_, `#448`_.
+
 Lexical Scoping Principle (LSP)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -165,25 +228,39 @@ Lexical Scoping Principle (LSP)
 
 **Principle**:
 
-a. For every appearance of
-an identifier, it is possible to determine whether that appearance is a *binding site*
-or an *occurrence* without examining the context.
+a. For every appearance of an identifier, it is possible to determine whether that appearance is
+   a mere *occurrence*, and thus must be bound elsewhere for the program to be valid.
+   or the variable is a *binding site* (or causes an implicit binding site, basically the same thing).
+
+without examining the context.
 
 b. For every *occurrence* of an
 identifier, it is possible to uniquely identify its *binding site*, without
 involving the type system.
 
+This builds upon the `Explicit Binding Principle`_:
+whereas that former principle ensures that explicit alternatives to implicit binding constructs *exist at all*,
+this latter principle makes those explicit alternatives *compulsory*, because we must not have implicit binding in order to uphold this principle.
+
 The `Lexical Scoping Principle`_ is almost true today, with the following nuances:
 
-1. Template Haskell splices may need to be run before completing name resolution (and running those splices requires type-checking them).
+#. Template Haskell splices may need to be run before completing name resolution (and running those splices requires type-checking them).
 
-2. The `deprecated mechanism <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/duplicate_record_fields.html#selector-functions>`_ for disambiguating duplicate record fields violates the `Lexical Scoping Principle`_ by requiring the type system.
+#. The `deprecated mechanism <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/duplicate_record_fields.html#selector-functions>`_ for disambiguating duplicate record fields violates the `Lexical Scoping Principle`_ by requiring the type system.
 
-3. In a pattern signature, if we have ``f (x :: Maybe a)``, the ``a``
-   is an occurrence if ``a`` is already in scope, and it is a binding site otherwise.
+#. In a pattern signature, if we have ``f (x :: Maybe a)``, the ``a``
+   is an occurrence if ``a`` is already in scope, and is implicitly bound otherwise.
 
-4. In a type signature, any out-of-scope variable is implicitly bound. This is not
-   technically a violation of this principle (the seemingly-unbound identifier in the type signature
+#. In a type signature, if we have ``f :: a -> a``, the ``a``
+   is an occurrence if ``a`` is already in scope, and it implicitly bound otherwise.
+
+#. In a kind signature, if we have ``data Foo (a :: k)``, the ``k``
+   is an occurrence if ``k`` is already in scope (historically impossible), and it implicitly bound otherwise.
+
+   Technically this might be a violation of this principle as the ``k`` is in fact always a use with the implicit bind coming before,
+   but implicit foot-gun behavior
+
+   (the seemingly-unbound identifier in the type signature
    is always an occurrence), but it's worth noting here.
 
 *Motivation:* These principles mean that we can understand the binding
@@ -196,31 +273,6 @@ of mixing the term-level and type-level namespaces (`#270`_) and need to think a
 variables and imported term variables.
 
 (a) from `#448`_; (b) from `#378`_.
-
-Explicit Binding Principle (EBP)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _`Explicit Binding Principle`:
-
-**Principle**: Through the right combination of extensions and/or warning flags, it is possible
-for a Haskell programmer to ensure that all identifiers in a program have an explicit binding site.
-
-Examples::
-
-   id :: a -> a    -- the variable `a` has no explicit binding site, but we can write `forall a.` to provide one
-
-   f :: (Bool, Bool) -> Bool
-   f (x :: (b, b)) = ...   -- the variable `b` is bound to `Bool` by this
-                           -- pattern signature. But either the first b is a binding
-                           -- site, in violation of the Lexical Scoping Principle (a),
-                           -- or there is no explicit binding site, in violation of
-                           -- the Explicit Binding Principle.
-
-*Motivation:* The `Explicit Binding Principle`_ allows programmers to control exactly how variables come into
-scope. It also prevents the possibility of typos that accidentally introduce new
-variables.
-
-From `#448`_.
 
 Contiguous Scoping Principle (CSP)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/proposals/0425-decl-invis-binders.rst
+++ b/proposals/0425-decl-invis-binders.rst
@@ -621,6 +621,15 @@ The proposed changes provide the programmer with a more principled way of
 brining type variables into scope in certain corner cases, simplify arity
 inference and scoping rules.
 
+This gets us closer to upholding two principles:
+
+- The `Explicit Binding Principle`_, because the new ``@``-binders is explicit unlike previous alternatives
+
+- The `Lexical Scoping Principle`_, because the new simplified rules about variables needing to occur on the LHS in certain situations.
+
+.. _`Explicit Binding Principle`: ../principles.rst#explicit-binding-principle
+.. _`Lexical Scoping Principle`: ../principles.rst#lexical-scoping-principle
+
 Costs and Drawbacks
 -------------------
 


### PR DESCRIPTION
The review process of #448, to be quite frank, felt lacking. Some last minute changes (which @goldfirere said elsewhere were done based on others unwritten concerns, i.e. weren't even something he was himself championing!) weakened the story around implicit binding, and when I had brought this up I didn't get much by way of replies.

Lest this appear too theoretical, I was also helping @tek implement some of this stuff, and the lack of clear story around implicit binding got in the way there too. One of the reasons variable binding is so inconsistent in GHC Haskell is that the implementation contains lots of repetitive and poorly abstracted code --- in such a situation there are few impediments to stop the various instances of should-have-been abstractions "drifting apart". @tek and I were able to do a great job deduplicate things, but the few remaining places were implicit variables could never be turned off meant we couldn't go all the way. Bummer!

But that's enough grumbling, here are the changes I would have liked to see happen. I have editing the existing proposals for my sanity; I new proposal atop the old one which is atop others is too much and would melt my brain. As such, the motivations are editted and should be self-contained, but I will provide an extra "meta-motivation here".

If it is better that this go in the repo, sure, I suppose I could make a rump all-motivation proposal for it instead. Just let me know.

--------

### Principles

A positive (to me) thing I appreciated near the end of the #448 review process was that @gridaphobe agreed with my assessment that some of the principles were insufficiently distinct. We were thus able to reach an agreement with @goldfirere to axe the "local lexical scoping principle", and fold it in to the "lexical scoping principle".

This was a great start, but upon rereading the principles (in order to connect the amended proposals to them), I realized that the "lexical scoping principle" an "explicit binding principle" still felt too close, and awkwardly dividing the labor between them.

I thus flipped their order ("explicit binding principle" first) and gave them the following roles (pithily summarized):

1. **Explicit Binding Principle**: Every implicit binding form needs an explicit equivalent.
2. **lexical scoping principle**: Must be possible to turn off implicit binding forms so only the explicit ones remain. 

I think this is much simpler and easy to understand.

### #425

I just updated to refer to principles. Most of this is about very nuanced arity, but the "easy parts" are very much part of the 448 story and thus relate to the same principle.

### #448

#### A single unified `-XImplicitBinds`

Originally this is how #285 was. Then someone convinced me pattern synonym binding and and implicit foralls are quite different. More recently, we realized some of the #285 examples were not covered by *either* extension. Too bad! Because those examples are of things people wanting the other restricted behavior would also want.

One solution was to make a *third* `-XNo` relating to binds, to pick up the missing things. Believe me, I was tempted! But, I know everyone is getting weary of type variable extensions :).

I think the better solution --- which I went with --- is just to recombine things. Yes, implicit foralls and implicit patern synonym binds are indeed *not* the same, but the *motivations* for why to disable them are. The same people that dislike one of them dislike all of them, and vice versa. Likewise, the same motivations around education and syntactic consistency that apply to one of them apply to all of them.

#### `-Werror=pattern-signature-binds` considered inadequate

Finally, note that `-XNoPatternSignatureBinds`, one of the former constituents of `-XNoImplicitBinds`, had been downgraded to a warning. This might seem fine (use `-Werror=...`!) but it really isn't, because it fails each step of the motivation:

##### Education

The point of disabling features with `-XNo` is so the student can be *completely unaware* they exist. But warnings must always be phrased in terms "that thing you did you might not have wanted to". That means making the student aware of the thing after all --- "that thing you did" is something the student was never taught and therefore should never be goaded by a warning into learning about after all.

Concretely, for educational purposes we want to get rid of implicit bindings, and get rid of the *concept* of implicit binding. We want the student to be *unable* to write them, and we want the compiler to *not* tell them with other configuration options feature exists, the same way a Haskell 98 users should not be told about "type families" or weather.

##### Single namespace syntactic uniformity

#270 has a very nice story about making single name-space code not fork-like by accepting fewer programs.
`-Werror=pattern-signature-binds` either breaks the "non fork-like" condition, or breaks the "single namespace" condition. Either is not acceptable.

This relates to the education case in that both are about being able to hide what "might have been" under other config settings.

### #523

This unmerged proposal is referenced in #448 (in PR form, with no implication that it is eventually accepted). The reason for this I think is worth elaborating on.

I think the reason we got into the confusing situations we have so far is because pattern signature binds are not obviously "syntactic sugar", in that there is no simple non-type-directed desugaring of what they do. I am steadfast that any such "weird" feature is "sugar in waiting" --- we simply need to create the much simpler primitives until it is sugar, but others are more "wait and see" and "by the book", and therefore don't want to ascribe to something the negative connotations of syntactic sugar until it is manifestly clear that it in fact is syntactic sugar.

#523 fixes this, by hinting at (it is not fully specified yet) the `let type var = _ in` syntax that can be used instead of pattern synonym binds. The desugaring is simple, not type directed, and only rename-directed in that we need to know what variables are as-of-yet not explicitly bound.

I don't call pattern signature binding "sugar" in the revised text, but I do call it "implicit', because any syntax that could be either a use or a binding based on the context (of in-scope variables) I define as "implicit". For those not comfortable with this yet, I suggest we hurry up and accept #523 so that it is also unambiguously "implicit" and "sugar" by having the explicit `let type var = _ in` syntax it can be desugared to.

--------------

Because the information is scattered around previous proposals and the baseline of what GHC implements, it was *very* difficult to right this proposal and keep everything in my brain.

I know I am a broken record about this, but please let's do something like the "aspirational users guide". The end goal of all this variable stuff is quite simple ---- simpler and more uniform than what we have before it! But the balkanized way we discuss and propose these things and (if need be) their migrations is extremely cognitively burdening.

I feel in writing this proposal, in discussing the weird interactions between proposals both unmerged and merged, code quality issues in GHC, etc., we are pushing against the limit of the complexity and nuance the current proposal process can deal with. And that's a real shame, because complexity we fail to deal with is not complexity that doesn't happen, but complexity that does happen, slipping by beneath our radar. I want to change the process to make there be *less* work and drudgery, not *more*.

I am *not at all confident* I got everything in my revisions correct, but I am quite exhausted thinking about it, and so I open this now in hopes that any lingering errors are easy to catch and fix with more eyeballs.

---------------

[Rendered Principles](https://github.com/Ericson2314/ghc-proposals/blob/type-variables/principles.rst)
[Rendered 425](https://github.com/Ericson2314/ghc-proposals/blob/type-variables/principles.rst)
[Rendered 448](https://github.com/Ericson2314/ghc-proposals/blob/type-variables/principles.rst)