### PR TITLE
Multiline string literals

### DIFF
--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -1,0 +1,307 @@
+Multiline strings
+=================
+
+.. author:: Brandon Chinn
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/569>`_.
+.. sectnum::
+.. contents::
+
+Most languages have native support for writing strings with newlines. Rust supports it out of the box with the normal ``"`` syntax, Python and Scala have ``"""`` syntax, and Javascript/Typescript has backticks. This proposal recommends adding ``"""`` as a delimiter which starts and ends a multiline string that automatically ignores whitespace up to the same column as the initial double quote.
+
+Motivation
+----------
+
+Currently you could do this with ``unlines`` (more commonly) or line continuations:
+
+::
+
+  s1 = unlines
+    [ "line 1"
+    , "line 2"
+    , "line 3"
+    ]
+
+  s1_2 = "line 1\n\
+         \line 2\n\
+         \line 3\n"
+
+Using ``unlines`` is decent, but it's a bit verbose. The verbosity becomes more visible when printing out Haskell code, especially when there are double quotes involved:
+
+::
+
+  s2 = unlines
+    [ "x :: String"
+    , "x = a ++ b"
+    , "  where"
+    , "    a = \"Hello \""
+    , "    b = \"world!\""
+    ]
+
+Compare with multiline strings:
+
+::
+
+  s1' =
+    """
+    line 1
+    line 2
+    line 3
+    """
+
+  s2' =
+    """
+    x :: String
+    x = a ++ b
+      where
+        a = "Hello "
+        b = "world!"
+    """
+
+Third party libraries also provide this functionality with quasiquoters, e.g. ``heredoc`` or libraries that also do interpolation like ``neat-interpolation``. But a lot of people try to avoid Template Haskell in general, and it's a bit overkill anyway.
+
+Proposed Change Specification
+-----------------------------
+
+#. Add ``"""`` as an `additional string delimiter <https://gitlab.haskell.org/ghc/ghc/-/blob/8c0ea25fb4a27d4729aabf73f4c00b912bb0c58d/compiler/GHC/Parser/Lexer.x#L577>`_
+
+#. Store the column that the ``"""`` start-delimiter starts on
+
+#. After parsing everything up to the ``"""`` end-delimiter, remove at most ``$COLUMN`` space characters. If using tabs, remove all leading tab characters (assuming people use the tabs-for-indentation, spaces-for-alignment rule).
+
+   * Escaping characters with ``\`` is still valid
+
+   * Line continuations are still respected
+
+#. In parsing, it should be converted to the equivalent single-quoted string (with appropriate annotations for the new exact-printing framework)
+
+I don't have enough knowledge to know if (2) is possible. If it's not, remove common whitespace prefix between lines, e.g.
+
+::
+
+  x =
+    """
+      a
+        b
+       c
+    """
+
+  -- equivalent to:
+  x' = "a\n  b\n c\n"
+
+Examples
+--------
+
+Escaped characters
+~~~~~~~~~~~~~~~~~~
+
+::
+
+  x =
+    """
+    name\tage
+    Alice\t20
+    Bob\t30
+    """
+
+Trailing newline
+~~~~~~~~~~~~~~~~
+
+A trailing newline is implied by the above specification. This is the most straightforward implementation of the spec, and there's no obvious reason to deviate. It's also what ``unlines`` does, which is a nice symmetry. To avoid a trailing newline, put the closing ``"""`` immediately after the last line, or use a line continuation:
+
+::
+
+  x =
+    """
+    a
+    b
+    c"""
+
+  x2 =
+    """
+    a
+    b
+    c\
+    \"""
+
+Characters before start of delimiter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Characters before the starting ``"""`` will be treated the same as characters on the same column as ``"""``.
+
+::
+
+  x =
+    """
+    a
+  b
+    c
+      d
+    """
+
+  -- equivalent to:
+  x' = "a\nb\nc\n  d\n"
+
+Escaping triple quotes
+~~~~~~~~~~~~~~~~~~~~~~
+
+Only three literal ``"""`` characters in a row will end the multiline string, so escaping any or all of the quote characters will not terminate the string:
+
+::
+
+  x =
+    """
+    This is a literal multiline string:
+    \"\"\"
+    Hello
+      world!
+    \"""
+    """
+
+Real world code
+~~~~~~~~~~~~~~~
+
+Example from Fourmolu (`link <https://github.com/fourmolu/fourmolu/blob/0b228e12872be8f8e97daf24e82632321fff947f/config/ConfigData.hs#L230-L242>`_):
+
+::
+
+  adtParseJSON =
+    unlines
+      [ "\\v -> case v of",
+        "  Aeson.Null -> pure PrintStyleInherit",
+        "  Aeson.String \"\" -> pure PrintStyleInherit",
+        "  _ -> PrintStyleOverride <$> Aeson.parseJSON v"
+      ],
+
+  adtParsePrinterOptType =
+    unlines
+      [ "\\s -> case s of",
+        "  \"\" -> pure PrintStyleInherit",
+        "  _ -> PrintStyleOverride <$> parsePrinterOptType s"
+      ]
+
+With multiline strings:
+
+::
+
+  adtParseJSON =
+    """
+    \\v -> case v of
+      Aeson.Null -> pure PrintStyleInherit
+      Aeson.String "" -> pure PrintStyleInherit
+      _ -> PrintStyleOverride <$> Aeson.parseJSON v
+    """
+
+  adtParsePrinterOptType =
+    """
+    \\s -> case s of
+      "" -> pure PrintStyleInherit
+      _ -> PrintStyleOverride <$> parsePrinterOptType s
+    """
+
+While the double backslash is still required, I think the overall style is much better.
+
+Another example using ``printf`` (`link <https://github.com/fourmolu/fourmolu/blob/0b228e12872be8f8e97daf24e82632321fff947f/config/Generate.hs#L146-L165>`_):
+
+::
+
+  [ printf "instance Aeson.FromJSON %s where" fieldTypeName,
+    printf "  parseJSON =",
+    printf "    Aeson.withText \"%s\" $ \\s ->" fieldTypeName,
+    printf "      either Aeson.parseFail pure $",
+    printf "        parsePrinterOptType (Text.unpack s)",
+    printf "",
+    printf "instance PrinterOptsFieldType %s where" fieldTypeName,
+    printf "  parsePrinterOptType s =",
+    printf "    case s of",
+    unlines_
+      [ printf "      \"%s\" -> Right %s" val con
+        | (con, val) <- enumOptions
+      ],
+    printf "      _ ->",
+    printf "        Left . unlines $",
+    printf "          [ \"unknown value: \" <> show s",
+    printf "          , \"Valid values are: %s\"" (renderEnumOptions enumOptions),
+    printf "          ]",
+    printf ""
+  ]
+
+With multiline strings:
+
+::
+
+  printf
+    """
+    instance Aeson.FromJSON %s where
+      parseJSON =
+        Aeson.withText "%s" $ \\s ->
+          either Aeson.parseFail pure $
+            parsePrinterOptType (Text.unpack s)
+
+    instance PrinterOptsFieldType %s where
+      parsePrinterOptType s =
+        case s of
+    %s
+          _ ->
+            Left . unlines $
+              [ "unknown value: " <> show s
+              , "Valid values are: %s"
+              ]
+    """
+    fieldTypeName
+    fieldTypeName
+    fieldTypeName
+    ( unlines_
+        [ printf "      "%s" -> Right %s" val con
+          | (con, val) <- enumOptions
+        ]
+    )
+    (renderEnumOptions enumOptions)
+
+Effect and Interactions
+-----------------------
+
+A multiline string should be the same as a normal string after parsing, so ``OverloadedStrings`` and any other language features should work as usual.
+
+Should not break existing code, unless someone is actually using ``"""a"""`` to mean ``"" "a" ""``. Since it doesn't break existing code, I am not recommending to hide behind an extension.
+
+Costs and Drawbacks
+-------------------
+
+Since this only affects lexing and parsing, I expect development and maintenance costs to be low. This feature is common in other languages, so there shouldn't be any learning curve for new developers coming from another language. If anything, the auto-stripping of leading whitespace might be a source of confusion, but a one-line explanation should be sufficient.
+
+Alternatives
+------------
+
+* Status quo, e.g. using ``unlines``
+
+  * As mentioned in the Motivation, it's not great ergonomics, but it works.
+
+* Third party libraries, using quasiquoters
+
+  * Template Haskell is overkill for this
+
+* No stripping of leading whitespace
+
+  * This probably comes from one of two concerns: more complex implementation, conceptually adds automagic. It does make the implementation a bit harder, but this is a small enough change that I don't think it makes the overall proposal much harder to implement. While it does add a bit more magic behind the scenes, I think the rule is simple enough (no more complex than do-block indentation rules) and the use-case common enough (I can't think of a single use-case that would want the indentation to be part of the string) that it warrants the bump in ergonomics.
+
+* Hide behind a ``MultilineStrings`` extension
+
+Unresolved Questions
+--------------------
+
+* Is it possible to store the column the starting ``"""`` delimiter is on?
+
+Implementation Plan
+-------------------
+
+I can implement
+
+Endorsements
+-------------

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -530,6 +530,8 @@ Alternatives
   * Everyone will use a different terminator, which I think would contribute to a reduction in overall readability
   * I think ``"""`` is an uncommon enough delimiter, and it can be escaped, that I don't think this is necessary
 
+* Use some delimiter to start the string, but use layout indentation rules to dictate when the string ends
+
 * Strip trailing whitespace in post-processing
 
   * Nice to have, but not necessary. I think it would be better to keep post-processing as minimal as possible, and it doesn't seem as common as removing leading whitespace.

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -89,6 +89,8 @@ Third party libraries also provide this functionality with quasiquoters, e.g. ``
 Proposed Change Specification
 -----------------------------
 
+A working prototype is available at `brandonchinn178/string-syntax <https://github.com/brandonchinn178/string-syntax>`_.
+
 #. Lex ``"""`` as an `additional string delimiter <https://gitlab.haskell.org/ghc/ghc/-/blob/8c0ea25fb4a27d4729aabf73f4c00b912bb0c58d/compiler/GHC/Parser/Lexer.x#L577>`_ when the ``MultilineStrings`` language extension is enabled
 
 #. Post-process the string in the following steps:

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -98,7 +98,7 @@ Proposed Change Specification
    #. Remove common whitespace prefix in every line
 
       * Ignore any characters preceding the first newline
-      * Blank lines should not be included in this calculation
+      * Blank lines and lines with only whitespace should not be included in this calculation
 
    #. Remove exactly one newline from the beginning of the string (if one exists)
 
@@ -131,62 +131,37 @@ Line continuations are collapsed first and not included in the whitespace calcul
 Remove common whitespace
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+In the below examples, leading spaces will be marked as ``.`` for visibility.
+
 ::
 
   s =
         """
-        a b c
+  ......a b c
 
-        d e f
-
-      g h i
-        """
+  ......d e f
+  ..
+  ....g h i
+  ......"""
 
   -- equivalent to
-  s' = "  a b c\n\n  d e f\n\ng h i\n  "
+  s' = "..a b c\n\n..d e f\n\ng h i\n.."
 
 After lexing, the initial multiline above is parsed as
 
 ::
 
-  -- spaces marked as . for visibility
   [ "......a.b.c"
   , ""
   , "......d.e.f"
-  , ""
+  , ".."
   , "....g.h.i"
   , "......"
   ]
 
-The blank lines are excluded from the calculation, and we calculate 4 spaces as the shared whitespace prefix, which are removed from every line.
+The blank line + the whitespace-only line are excluded from the calculation, and we calculate 4 spaces as the shared whitespace prefix, which are removed from every line.
 
-Note that the whitespace preceding the closing ``"""`` is included. This implies that there will be a trailing newline (see the "Trailing newline" example for more information). This also implies that you could change the leading whitespace on every line simply by moving the closing ``"""`` delimiter (although in practice, it'd be recommended to keep the starting/closing delimiters aligned).
-
-::
-
-  -- "a\nb\nc\n"
-  s1 =
-      """
-      a
-      b
-      c
-      """
-
-  -- "  a\n  b\n  c\n"
-  s2 =
-      """
-      a
-      b
-      c
-    """
-
-  -- "a\nb\nc\n  "
-  s3 =
-    """
-    a
-    b
-    c
-      """
+Note that the whitespace preceding the closing ``"""`` is included. This implies that there will be a trailing newline (see the "Trailing newline" example for more information).
 
 Ignore leading characters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,6 +251,38 @@ As mentioned in the "Remove common whitespace" example, trailing newlines are na
     b
     c\
     \"""
+
+Indent every line
+~~~~~~~~~~~~~~~~~
+
+To indent every line, use the ``\&`` escape character
+
+::
+
+  s1 =
+    """
+      a
+      b
+      c
+    """
+
+  s1' = "a\nb\nc"
+
+  s2 =
+    """
+    \&  a
+      b
+      c
+    """
+
+  s2_2 =
+    """
+    \&  a
+    \&  b
+    \&  c
+    """
+
+  s2' = "  a\n  b\n  c"
 
 Escaping triple quotes
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -2,14 +2,11 @@ Multiline strings
 =================
 
 .. author:: Brandon Chinn
-.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
-.. ticket-url:: Leave blank. This will eventually be filled with the
-                ticket URL which will track the progress of the
-                implementation of the feature.
-.. implemented:: Leave blank. This will be filled in with the first GHC version which
-                 implements the described feature.
+.. date-accepted:: 2020-01-27
+.. ticket-url:: 
+.. implemented:: 
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/569>`_.
+.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/569>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -97,6 +97,8 @@ A working prototype is available at `brandonchinn178/string-syntax <https://gith
 
    #. Collapse line continuations
 
+   #. Convert leading tabs into spaces (See "Mixing tabs and spaces" example)
+
    #. Remove common whitespace prefix in every line
 
       * Ignore any characters preceding the first newline
@@ -144,7 +146,7 @@ In the below examples, leading spaces will be marked as ``.`` for visibility.
   ......d e f
   ..
   ....g h i
-  ......"""
+  ..."""
 
   -- equivalent to
   s' = "..a b c\n\n..d e f\n\ng h i\n.."
@@ -158,7 +160,7 @@ After lexing, the initial multiline above is parsed as
   , "......d.e.f"
   , ".."
   , "....g.h.i"
-  , "......"
+  , "..."
   ]
 
 The blank line + the whitespace-only line are excluded from the calculation, and we calculate 4 spaces as the shared whitespace prefix, which are removed from every line.
@@ -199,22 +201,23 @@ This implies that normal strings could also be written using ``"""``
 Mixing tabs and spaces
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Per the `Haskell report <https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3>`_, tabs will be treated as 8 spaces in the calculation. If the common prefix is in the middle of a tab (which would only happen if mixing spaces and tabs), the tab will be converted to 8 spaces first. But don't do this.
-
-In the following example, two ``-`` characters will represent 1 tab, and 1 ``.`` character will represent 4 spaces.
+Leading tabs will be immediately converted into spaces per the `Haskell report <https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3>`_: "A tab character causes the insertion of enough spaces to align the current position with the next tab stop."
 
 ::
 
-  s = """
-  ------a
-  ....b
-  .------c
-  ...."""
+  s =
+  ⇥"""
+  ⇥␣␣␣␣␣␣␣␣a
+  ⇥␣⇥b
+  ⇥␣␣␣␣⇥c
+  ⇥"""
 
   -- equivalent to
-  s' = "--a\nb\n.--c\n"
+  s' = "a\nb\nc"
 
-The common whitespace prefix is 16 spaces, so the first line will remove 2 tabs, the second line will remove 16 spaces, and the third line will remove 4 spaces, a tab, then convert the second tab to 8 spaces before removing 4 spaces from it.
+Each line will be considered to have 16 leading spaces which will all be stripped.
+
+Like normal strings, any tabs in the middle of a multiline string will be a lexical error.
 
 Leading newline
 ~~~~~~~~~~~~~~~
@@ -520,7 +523,7 @@ Alternatives
 
   * The first option involves hardcoding the delimiter in the compiler, which is Not Great. Plus, wanting to actually use the delimiter to start a line in the string would require escaping it.
 
-  * The second option requires adding new functions to ``Prelude`` and would trim the margins at run-time, instead of compile-time.
+  * The second option requires adding new functions to ``Prelude`` and would trim the margins at run-time, instead of compile-time. This would also not work with ``OverloadedStrings``
 
   * Furthermore, any use case that doesn't want to strip leading whitespace either:
     #. Is agnostic to the whitespace (e.g. HTML) so it doesn't matter if it's stripped or not, or

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -20,7 +20,7 @@ This proposal is heavily influenced by Java's text blocks in `JEP 378 <https://o
 Motivation
 ----------
 
-Currently you could do this with ``unlines`` (more commonly) or line continuations (`"gaps" <https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-200002.6>`_):
+Currently you could do this with ``unlines`` (more commonly) or string gaps (`report <https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-200002.6>`_):
 
 ::
 
@@ -95,7 +95,7 @@ A working prototype is available at `brandonchinn178/string-syntax <https://gith
 
 #. Post-process the string in the following steps:
 
-   #. Collapse line continuations
+   #. Collapse string gaps
 
    #. Convert leading tabs into spaces (See "Mixing tabs and spaces" example)
 
@@ -114,23 +114,6 @@ Line terminators will match whatever line terminators the user is using in the f
 
 Examples
 --------
-
-Line continuations
-~~~~~~~~~~~~~~~~~~
-
-Line continuations are collapsed first and not included in the whitespace calculation
-
-::
-
-  s =
-      """
-        a b\
-    \ c d e
-        f g
-      """
-
-  -- equivalent to
-  s' = "a b c d e\nf g\n"
 
 Remove common whitespace
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,7 +153,7 @@ Note that the whitespace preceding the closing ``"""`` is included. This implies
 Ignore leading characters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The common prefix calculation ignores all characters preceding the first newline. This means that characters immediately after the ``"""`` delimiter will be included verbatim. The same would occur with a line continuation (since line continuations are collapsed before the prefix calculation).
+The common prefix calculation ignores all characters preceding the first newline. This means that characters immediately after the ``"""`` delimiter will be included verbatim. The same would occur with a string gap (since string gaps are collapsed before the prefix calculation).
 
 ::
 
@@ -197,6 +180,23 @@ This implies that normal strings could also be written using ``"""``
   -- the following are equivalent
   s = """hello world"""
   s' = "hello world"
+
+String gaps
+~~~~~~~~~~~
+
+String gaps are collapsed first and not included in the whitespace calculation
+
+::
+
+  s =
+      """
+        a b\
+    \ c d e
+        f g
+      """
+
+  -- equivalent to
+  s' = "a b c d e\nf g\n"
 
 Mixing tabs and spaces
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -240,7 +240,7 @@ The specification strips exactly one leading newline, which is the behavior of l
 Trailing newline
 ~~~~~~~~~~~~~~~~
 
-As mentioned in the "Remove common whitespace" example, trailing newlines are naturally included without any explicit rules. As a bonus, it does the same thing that ``unlines`` does. To avoid a trailing newline, put the closing ``"""`` immediately after the last line, or use a line continuation:
+As mentioned in the "Remove common whitespace" example, trailing newlines are naturally included without any explicit rules. As a bonus, it does the same thing that ``unlines`` does. To avoid a trailing newline, put the closing ``"""`` immediately after the last line, or use a string gap:
 
 ::
 
@@ -583,7 +583,7 @@ Comparisons with other languages
 
   * Java includes the line that the closing ``"""`` delimiter is on, so that the position of the closing delimiter is included in the common-prefix calculation. One motivation for this was to enable indenting every line. However, discussion on this proposal indicated that this was too magical and would be confusing behavior. Instead of this, we can reuse Haskell's existing ``\&`` escape character to add indentation to every line. See the "Indent every line" example and the "Only strip leading whitespaces with delimiter" alternative.
 
-  * This proposal also adds the addition of collapsing line continuations before any post-processing, which is a Haskell-specific syntax.
+  * This proposal also adds the addition of collapsing string gaps before any post-processing, which is a Haskell-specific syntax.
 
 * Python, Groovy, Kotlin, Scala, Swift
 

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -293,6 +293,12 @@ Alternatives
 
 * Hide behind a ``MultilineStrings`` extension
 
+* Enable any number of ``"""+`` quotes to delimit strings
+
+* Reuse single-quoted ``"`` for multiline syntax
+
+  * Would require escaping double quotes in the multiline string, which, while not a major part of the proposal, is a nice bonus
+
 Unresolved Questions
 --------------------
 

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -507,7 +507,9 @@ Alternatives
 
   * The downside of doing this is that generally speaking, developers will want to keep the multiline string at the same indentation level as surrounding code. Not doing any post processing means that reindenting code would change the string content. I would also posit that the common case is wanting leading whitespace stripped, which would lead to devs putting multiline strings at the 0th column or implementing their own deindenter.
 
-* Enable any number of ``"""+`` quotes to delimit strings
+* Use ``''`` to delimit multiline strings, which has the benefit of being a parse error without ``MultilineStrings``
+
+* Enable any number of ``"""+`` quotes to delimit multiline strings
 
 * Reuse single-quoted ``"`` for multiline syntax
 

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -93,13 +93,14 @@ Proposed Change Specification
 
 #. Post-process the string in the following steps:
 
-   #. If the string starts with a newline character, ignore it
-
    #. Collapse line continuations
 
    #. Remove common whitespace prefix in every line
 
+      * Ignore any characters preceding the first newline
       * Blank lines should not be included in this calculation
+
+   #. Remove exactly one newline from the beginning of the string (if one exists)
 
    #. Interpret escape sequences (occurs after removing whitespace prefix so that literal ``\n`` characters are not included)
 
@@ -187,6 +188,37 @@ Note that the whitespace preceding the closing ``"""`` is included. This implies
     c
       """
 
+Ignore leading characters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The common prefix calculation ignores all characters preceding the first newline. This means that characters immediately after the ``"""`` delimiter will be included verbatim. The same would occur with a line continuation (since line continuations are collapsed before the prefix calculation).
+
+::
+
+  s =
+    """Line 1
+       Line 2
+    Line 3
+    """
+
+  s_2 =
+    """\
+   \Line 1
+       Line 2
+    Line 3
+    """
+
+  -- equivalent to
+  s' = "Line 1\n   Line 2\nLine 3"
+
+This implies that normal strings could also be written using ``"""``
+
+::
+
+  -- the following are equivalent
+  s = """hello world"""
+  s' = "hello world"
+
 Mixing tabs and spaces
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -210,7 +242,7 @@ The common whitespace prefix is 16 spaces, so the first line will remove 2 tabs,
 Leading newline
 ~~~~~~~~~~~~~~~
 
-The specification explicitly calls for ignoring an initial newline, which is the behavior of least surprise for most devs used to multiline strings. To keep the initial newline, add a blank line before the first line:
+The specification strips exactly one leading newline, which is the behavior of least surprise for most devs used to multiline strings. To keep the initial newline, add a blank line before the first line:
 
 ::
 
@@ -224,32 +256,6 @@ The specification explicitly calls for ignoring an initial newline, which is the
 
   -- equivalent to
   s' = "\na\nb\nc\n"
-
-It only ignores the newline if it's the very first character, so putting characters immediately after the ``"""`` delimiter *will include that line in the common prefix calculation*. The same would occur with a line continuation.
-
-::
-
-  s =
-    """Start a line
-    Another line
-    """
-
-  -- equivalent to
-  s' = "Start a line\n    Another line\n"
-
-  s'' =
-    """\
-   \Start a line
-    Another line
-    """
-
-This implies that normal strings could also be written using ``"""``
-
-::
-
-  -- the following are equivalent
-  s = """hello world"""
-  s' = "hello world"
 
 Trailing newline
 ~~~~~~~~~~~~~~~~

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -190,23 +190,22 @@ Note that the whitespace preceding the closing ``"""`` is included. This implies
 Mixing tabs and spaces
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A tab and a space both count as a single whitespace character, so mixing the two is inconsequential. But don't do this.
+Per the `Haskell report <https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17800010.3>`_, tabs will be treated as 8 spaces in the calculation. If the common prefix is in the middle of a tab (which would only happen if mixing spaces and tabs), the tab will be converted to 8 spaces first. But don't do this.
 
-In the following example, two ``-`` characters will represent 1 tab, and ``.`` will represent 1 space.
+In the following example, two ``-`` characters will represent 1 tab, and 1 ``.`` character will represent 4 spaces.
 
 ::
 
   s = """
-  ----a
+  ------a
   ....b
-  --..c
-  ..--d
+  .------c
   ...."""
 
   -- equivalent to
-  s' = "a\n..b\n..c\n--d\n"
+  s' = "--a\nb\n.--c\n"
 
-The lexer will interpret the first line as ``"\t\ta"``, which has two leading whitespace characters, so two leading whitespace characters will be removed from every line.
+The common whitespace prefix is 16 spaces, so the first line will remove 2 tabs, the second line will remove 16 spaces, and the third line will remove 4 spaces, a tab, then convert the second tab to 8 spaces before removing 4 spaces from it.
 
 Leading newline
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #260.

Doesn't address QuasiQuote deprecation because ~~I disagree that QuasiQuotes are **only** useful for multiline strings; QuasiQuotes are being used for much more than multiline strings~~ that can be a separate proposal [^1].

[Rendered](https://github.com/brandonchinn178/ghc-proposals/blob/multiline-strings/proposals/0569-multiline-strings.rst)

[^1]: I originally didn't understand what the relation was; I now understand that it's due to the fact that `[foo|...|]` could be written with `$(foo """...""")`; the only thing restricting it before was lack of multiline support