### PR TITLE
Native string interpolation syntax

### DIFF
--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -101,7 +101,17 @@ This proposal introduces the ``-XStringInterpolation`` extension, with support f
 High-level Overview
 ~~~~~~~~~~~~~~~~~~~
 
-``-XStringInterpolation`` enables the following syntax:
+At its core, this proposal proposes the following system:
+
+* The syntax ``s"age: ${age}"`` expands to a built-in implementation hardcoded to ``IsString`` and a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
+
+* The syntax ``M.s"age: ${age}"`` expands to a user-defined implementation where the implementor of the module ``M`` has total control over the implementation
+
+    * Same technique as ``-XQualifiedStrings``
+
+* ``s"..."`` is exactly equivalent to ``Data.String.Interpolate.Experimental.s"..."``, where ``Data.String.Interpolate.Experimental`` is a new module in ``ghc-experimental``.
+
+Concretely, ``-XStringInterpolation`` enables the following syntax:
 
 ::
 
@@ -422,7 +432,7 @@ Alternatives
   * Pro: no more ``Interpolate`` class
   * Pro: more explicit, e.g. the way you have to explicitly convert before calling ``+``
   * Pro: less likely to encounter type inference issues
-  * Con: adds more noise to interpolate
+  * Con: adds more noise to interpolate non-string values
   * This is what ``neat-interpolation`` does
   * See *Section 10.1 Community Survey*
 
@@ -442,7 +452,7 @@ Alternatives
   * or like ``formatting``: ``s"a {text} b {int}" foo bar => (\x0 x1 -> "a " <> text x0 <> " b " <> int x1) foo bar``
   * This defeats the purpose of string interpolation making it easy to see the exact location a variable gets injected. If you're interpolating a lot of values into a large string (e.g. with multiline strings), it's extremely difficult to match up which expression to which interpolation position.
 
-* Allow passing a String representation of the interpolated expression to ``interpolate``, e.g. to support something like ``Dbg."foo | ${x + 1}"`` returning ``"foo | x + 1 = 11"``
+* Allow passing a String representation of the interpolated expression to ``interpolate``, e.g. to support something like ``Dbg.s"foo | ${x + 1}"`` returning ``"foo | x + 1 = 11"``
 
   * I don't think this has any uses outside of debugging; if it's just that one use-case, quasiquotation should be sufficient
   * https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/issues/8
@@ -454,6 +464,8 @@ Alternatives
 
 Expansion-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Also see *Section 10.9 Alternative - Polymorphic interpolable expansion*
 
 * Hardcode to Monoid's ``mappend`` and ``mempty``
 
@@ -829,7 +841,7 @@ And be able to use it in interpolated strings:
   let n = BigDecimal 123456 3
   s"123456 / 10^3 = ${n}" == "123456 / 10^3 = 123.456"
 
-If ``text`` is implemented as described in *Section 10.2 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text`` for free.
+If ``text`` is implemented as described in *Section 10.4 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text`` for free.
 
 Format specifiers
 ~~~~~~~~~~~~~~~~~
@@ -868,3 +880,130 @@ Where these would return the strings:
 
   Points earned:   -13.20
   Current total:  +127.98
+
+Alternative - Polymorphic interpolable expansion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Current proposal - built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsString``:
+
+::
+
+    -- Desugared expression for M.s"age: ${age}"
+    --
+    -- s"..." is equivalent to Data.String.Interpolate.s"..."
+    M.interpolateString $ \convert raw append empty ->
+               raw "age: "
+      `append` convert age
+      `append` empty
+
+    {----- Data.String.Interpolate -----}
+
+    -- Conceptually, think of this as a more performant version of:
+    --   fromString $ raw "age: " <> convert age
+    interpolateString f = mconcat $ f convert raw (:) []
+      where
+        convert = fromString . interpolate
+        raw = id
+
+    -- One instance for all user-defined types; e.g. the `url` library
+    -- would just need to implement
+    --   Interpolate URL
+    class Interpolate a where
+      interpolate :: a -> String
+
+    {----- Text library: s"..." :: Text -----}
+
+    -- Doesn't have to do anything; built-in works for free.
+    -- Could optionally implement a more performant interpolation with
+    -- qualified interpolation.
+
+    {----- User-defined SimpleText: SimpleText.s"..." -----}
+
+    -- | Text, except only support interpolating Text values
+    newtype SimpleText = SimpleText Text
+
+    interpolateString f = f convert raw mappend mempty
+      where
+        convert = SimpleText
+        raw = SimpleText . Text.pack
+
+Built-in ``s"..."`` with polymorphic builder:
+
+::
+
+    -- Desugared expression for M.s"age: ${age}"
+    --
+    -- s"..." is equivalent to Data.String.Interpolate.s"..."
+    M.finalize
+      (            M.raw "age: "
+        `M.append` M.convert age
+        `M.append` M.empty
+      )
+
+    {----- Data.String.Interpolate -----}
+
+    class Interpolable s where
+      type Builder s
+      raw      :: String -> Builder s
+      append   :: Builder s -> Builder s -> Builder s
+      empty    :: Builder s
+      finalise :: Builder s -> s
+
+    class Interpolate a builder where
+      convert :: a -> builder
+
+    instance Interpolable String where
+      type Builder String = String
+      raw = id
+      append = (++)
+      empty = []
+      finalise = id
+
+    instance Interpolate String String where
+      convert = id
+    instance Interpolate Int String where
+      convert = show
+    -- ...
+
+    {----- Text library: s"..." :: Text -----}
+
+    instance Interpolable Text where
+      type Builder Text = TextBuilder
+      raw = Text.Builder.fromText
+      append = mappend
+      empty = mempty
+      finalise = Text.toStrict . Text.Builder.toLazyText
+
+    instance Interpolate String Text where
+      convert = Text.pack
+    instance Interpolate Int Text where
+      convert = Text.pack . show
+    -- ...
+
+    {----- User-defined SimpleText: SimpleText.s"..." -----}
+
+    -- | Text, except ONLY support interpolating Text values.
+    -- Avoid `Interpolate` class, since we can't forbid someone
+    -- from adding a new `Interpolate Foo SimpleText` instance.
+    newtype SimpleText = SimpleText Text
+
+    convert = Text.Builder.fromText
+    raw = Text.Builder.fromText
+    append = mappend
+    empty = mempty
+    finalize = SimpleText . Text.toStrict . Text.Builder.toLazyText
+
+Downsides of alternative approach:
+
+* All types that can be interpolated (e.g. a ``URL`` type) must have an instance for each string-like type it can be interpolated within:
+
+    * ``Interpolate URL String``
+    * ``Interpolate URL Text``
+    * ``Interpolate URL ByteString``
+    * ...
+
+  The current proposal only needs to implement one ``Interpolate URL``. May be less performant, since we're always going via ``String`` instead of a potentially more efficient conversion (e.g. going straight to ``Text``), but it's a good default.
+
+* All string-like types _must_ implement their own instance, e.g. ``Interpolable Text``, and _must_ implement ``Interpolate`` instances for all built-in types.
+
+  The current proposal will automatically work for any ``IsString`` type. Types _may_ implement their own custom interpolation with qualified string interpolation, but that's not a requirement (although recommended, to monomorphize the default interpolation).

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -813,6 +813,38 @@ And gain access to safe string interpolation with HTML escaping by default:
   Html.s"<h1>${title}</h1>${raw body}"
     == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
 
+Custom interpolator: ShowS
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+String interpolation could also make it easier to implement `shows`, in a module potentially provided by `base`:
+
+::
+
+  module Data.ShowS.Interpolate (P (..), interpolateString) where
+
+  interpolateString ::
+    (  (forall a. Show a => a -> ShowS)
+      -> (String -> ShowS)
+      -> (ShowS -> ShowS -> ShowS)
+      -> ShowS
+      -> ShowS
+    )
+    -> ShowS
+  interpolateString f = f shows showString (.) id
+
+  data P a = P !Int !a
+  instance Show a => Show (P a) where
+    showsPrec _ (P p a) = showsPrec p a
+
+Users could then do
+
+::
+
+  instance Show a => Show (MyTree a) where
+    showsPrec d (MyTree l v r) =
+      showParen (d > 10) $
+        ShowS.s"MyTree ${ShowS.P 11 l} ${v} ${ShowS.P 11 r}"
+
 Custom interpolatable type: BigDecimal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -96,7 +96,7 @@ If Haskell had native string interpolation, it would have the benefit and safety
 Proposed Change Specification
 -----------------------------
 
-This proposal introduces the ``-XStringInterpolation`` extension, with support for ``-XOverloadedStrings`` and ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/698>`_).
+This proposal introduces the ``-XStringInterpolation`` extension, with support for ``-XOverloadedStrings`` and ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/723>`_).
 
 High-level Overview
 ~~~~~~~~~~~~~~~~~~~
@@ -108,16 +108,20 @@ High-level Overview
   s"a ${x + 1} b"
 
   -- Desugars to:
-  Data.String.Interpolate.Experimental.interpolateString $ \convert raw append empty ->
-             raw "a "
-    `append` convert (x + 1)
-    `append` raw " b"
-    `append` empty
+  Data.String.Interpolate.Experimental.interpolateString
+    ( \convert raw append empty ->
+                 raw "a "
+        `append` convert (x + 1)
+        `append` raw " b"
+        `append` empty
+    )
+    :: String
 
-The string literals are affected by ``-XOverloadedStrings`` as usual, if enabled. ``Data.String.Interpolate.Experimental`` will be initially provided by ``ghc-experimental``, containing the following:
+``Data.String.Interpolate.Experimental`` will be initially provided by ``ghc-experimental``, containing the following:
 
 ::
 
+  -- See *Section 2.4* for the type of this definition
   interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
 
   class Interpolate a where
@@ -128,32 +132,6 @@ The string literals are affected by ``-XOverloadedStrings`` as usual, if enabled
 
     interpolateS :: a -> ShowS
     interpolateS x s = interpolate x <> s
-
-When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation as well:
-
-::
-
-  Text.s"hello world"
-
-  -- Desugars to:
-  Text.interpolateString $ \_ raw _ _ -> raw "hello world"
-
-  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
-
-  -- Desugars to:
-  SQL.interpolateString $ \convert raw append empty ->
-             raw "select * from users where name = "
-    `append` convert (Text.toUpper name)
-    `append` raw " and age = "
-    `append` convert age
-    `append` empty
-
-It is highly recommended that any type with an ``IsString`` instance provide the below definition for use with ``-XQualifiedStrings``. This allows using locally-scoped string interpolation for non-String types without enabling it globally with ``-XOverloadedStrings``.
-
-::
-
-  interpolateString :: String -> MyString
-  interpolateString = Data.String.Interpolate.Experimental.interpolateString
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~
@@ -175,8 +153,6 @@ Add ``istring*`` patterns to ``lexeme`` (not ``literal``, because they're not li
           | istringMultilineRawStartLine
           | istringMultilineRawMidLine
           | istringMultilineEnd
-          | istringQualifiedBegin
-          | istringQualifiedMultilineBegin
 
   istringBegin → 's"' | modid . 's"'
   istringRaw → {graphic⟨'\' | '"' | '${'⟩ | space | escape | gap}
@@ -196,6 +172,8 @@ Also add ``$`` to ``charesc``:
   charesc → a | b | f | n | r | t | v | \ | " | ' | & | $
 
 With ``$`` added to ``charesc``, interpolation can be avoided by escaping the dollar sign; e.g. ``s"\${foo}" == "${foo}"``.
+
+This grammar enables interpolating expressions with nested braces. Concretely, ``istringExprOpen`` and ``istringExprClose`` are only lexed within the ``istring`` context, using Alex start codes. See *Section 3.1* for examples.
 
 Context-Free Syntax
 ~~~~~~~~~~~~~~~~~~~
@@ -226,15 +204,17 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Interpo
 
 ::
 
-  interpolateString ::
-    (IsString s, Monoid s) =>
-    ( (forall a. Interpolate a => a -> s)
+  type SimpleStringInterpolator s =
+    ( forall ss.
+      (forall a. Interpolate a => a -> s)
       -> (s -> s)
-      -> (s -> s -> s)
-      -> s
-      -> s
+      -> (s -> ss -> ss)
+      -> ss
+      -> ss
     )
     -> s
+
+  interpolateString :: (IsString s, Monoid s) => SimpleStringInterpolator s
   interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
   {-# INLINE interpolateString #-}
 
@@ -280,33 +260,66 @@ With the machinery defined above, the following interpolated string desugars to 
   s"foo ${f a b} bar ${g x} baz ${name}"
 
   -- desugared
-  Data.String.Interpolate.Experimental.interpolateString $ \convert raw append empty ->
-             raw "foo "
-    `append` convert (f a b)
-    `append` raw " bar "
-    `append` convert (g x)
-    `append` raw " baz "
-    `append` convert name
+  Data.String.Interpolate.Experimental.interpolateString
+    ( \convert raw append empty ->
+                 raw "foo "
+        `append` convert (f a b)
+        `append` raw " bar "
+        `append` convert (g x)
+        `append` raw " baz "
+        `append` convert name
+        `append` empty
+    )
+    :: String
+
+Namely:
+
+* An ``istringRaw <str>`` component expands to ``raw "<str>"``
+* An ``istringExprOpen exp istringExprClose`` component expands to ``convert (<exp>)``
+* The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``append`` as "list cons" and ``empty`` as "list nil".
+
+If ``-XOverloadedStrings`` is enabled, the string literals passed to ``raw`` are overloaded and the ``:: String`` annotation is removed. The ``:: String`` annotation is included when ``-XOverloadedStrings`` is disabled; it's redundant in most cases, since ``raw "..."`` would resolve the return type to ``String``, but it's necessary if there are no ``raw`` calls (e.g. ``s"${a}${b}"``).
+
+QualifiedStrings
+~~~~~~~~~~~~~~~~
+
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation as well:
+
+::
+
+  Text.s"hello world"
+
+  -- Desugars to:
+  Text.interpolateString $ \_ raw _ _ -> raw "hello world"
+
+  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
+
+  -- Desugars to:
+  SQL.interpolateString $ \convert raw append empty ->
+             raw "select * from users where name = "
+    `append` convert (Text.toUpper name)
+    `append` raw " and age = "
+    `append` convert age
     `append` empty
 
-The string literals there will be handled by ``-XOverloadedStrings`` as usual, if enabled, although it's recommended to use ``-XQualifiedStrings`` instead, for more granular overloading.
+The desugaring will NOT include a ``:: String`` annotation, whether ``-XOverloadedStrings`` is enabled or not.
+
+It is highly recommended that any type with an ``IsString`` instance provide the below definition for use with ``-XQualifiedStrings``. This allows using locally-scoped string interpolation for non-String types without enabling it globally with ``-XOverloadedStrings``.
+
+::
+
+  interpolateString :: SimpleStringInterpolator MyString
+  interpolateString = Data.String.Interpolate.Experimental.interpolateString
+
+The following laws should hold, if the expression typechecks:
+
+* ``M."str" == M.s"str"``
+* ``Data.String.fromString "str" == M.s"str"``
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
 
-Template Haskell will add the following definitions:
-
-::
-
-  data Exp
-    = ...
-    | InterStringE (Maybe ModuleName) [InterStringPart]
-
-  data InterStringPart
-    = InterStringRaw String
-    | InterStringExp Exp
-
-We won't use ``Either`` as it doesn't seem like ``Either`` is used in any other TH types.
+We are intentionally not adding anything to Template Haskell, as one could just build the expression themselves. String interpolation is still supported in quotes, which will be desugared when translating to TH.
 
 Examples
 --------
@@ -386,14 +399,7 @@ When ``-XQualifiedStrings`` is enabled, ``M.s"..."`` syntax is enabled, as descr
 
     import Data.String.Interpolate.Experimental qualified as S
 
-    interpolateString ::
-        ( (forall a. Interpolate a => a -> MyText)
-            -> (String -> MyText)
-            -> (MyText -> MyText -> MyText)
-            -> MyText
-            -> MyText
-        )
-        -> MyText
+    interpolateString :: S.SimpleStringInterpolator MyText
     interpolateString = S.interpolateString
 
 Interpolation is also supported with ``-XMultilineStrings``, as described in "Proposed Change Specification".
@@ -409,6 +415,69 @@ Alternatives
 ------------
 
 * Status quo (discussed in the "Motivation" section)
+
+* Don't implicitly convert values when interpolating
+
+  * ``s"a ${x}"`` would instead translate to ``fromBuilder (toBuilder "a " <> toBuilder x)``
+  * Pro: no more ``Interpolate`` class
+  * Pro: more explicit, e.g. the way you have to explicitly convert before calling ``+``
+  * Pro: less likely to encounter type inference issues
+  * Con: adds more noise to interpolate
+  * This is what ``neat-interpolation`` does
+  * See *Section 10.1 Community Survey*
+
+* Reuse ``PrintfArg``
+
+  * The bulk of its API deals with format specifiers, which is not applicable to this proposal. ``Interpolate`` is much simpler
+
+* Define ``Interpolate`` as a multi param type class, instead of only going to ``String``.
+
+  * More complex
+  * Introduces n^2 instances problem
+  * ``-XQualifiedStrings`` is available for any more advanced use cases
+
+* Desugar to a function
+
+  * like ``printf``: ``s"a %s b %s" foo bar => (\x0 x1 -> "a " <> interpolate x0 <> " b " <> interpolate x1) foo bar``
+  * or like ``formatting``: ``s"a {text} b {int}" foo bar => (\x0 x1 -> "a " <> text x0 <> " b " <> int x1) foo bar``
+  * This defeats the purpose of string interpolation making it easy to see the exact location a variable gets injected. If you're interpolating a lot of values into a large string (e.g. with multiline strings), it's extremely difficult to match up which expression to which interpolation position.
+
+* Allow passing a String representation of the interpolated expression to ``interpolate``, e.g. to support something like ``Dbg."foo | ${x + 1}"`` returning ``"foo | x + 1 = 11"``
+
+  * I don't think this has any uses outside of debugging; if it's just that one use-case, quasiquotation should be sufficient
+  * https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/issues/8
+
+* Do something like `Python's new t-string feature <https://peps.python.org/pep-0750/>`_
+
+  * This doesn't translate easily to Haskell, since the point of t-string is to return a list of strings and a list of "anything" that was interpolated
+  * The ``QualifiedStrings`` part of the proposal should be able to handle any functionality here
+
+Expansion-related Alternatives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Hardcode to Monoid's ``mappend`` and ``mempty``
+
+  * Would remove potential use-cases needing type-changing ``append``, e.g. ``a -> [a] -> [a]`` or ``f a -> f as -> f (a ': as)``
+  * Most custom ``interpolateString`` might simply use Monoid, but at least the default ``interpolateString`` does not, in order to use a potentially more efficient ``mconcat`` (e.g. for ``Text``)
+
+* Use ``M.fromString`` instead of ``raw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
+
+  * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementions *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
+  * Even if we hardcoded ``fromString``, one could still devise a custom ``M.interpolateString`` that's inconsistent with ``M.fromString``; e.g. a law-breaking ``Monoid`` instance such that ``x `mappend` mempty /= x``
+
+* Hardcode a wired-in ``Interpolate`` class with ``convert`` (and potentially ``raw``)
+
+  * Eliminates the whole benefit of a rebindable ``interpolateString``; having a blessed ``Interpolate`` class with a ``convert :: something`` function means everyone has to use that ``something`` type. The whole benefit of a rebindable ``interpolateString`` is, just like ``QualifiedDo``, as long as it typechecks, you can make its type whatever you want.
+
+* Replace the callback ``M.interpolateString $ \raw convert append empty -> raw "age: " `append` convert age `append` empty`` with the expression directly, e.g. ``M.fromString "age: " `M.mappend` M.convert age `M.mappend` M.mempty``.
+
+  * This would remove the major benefit of having one function to link to when clicking into an interpolated string, in an IDE / using a language server
+  * This would also remove the ability to add a "finalizer", where perhaps it's more efficient to append in one type, but the final type should be "compiled"/"built" in some fashion
+    * You could add ``M.finalizeInterpolatedString`` at the end, but then that's becoming more complicated than the current approach
+  * See also the other alternatives to hardcode the operations
+
+Delimiter-related Alternatives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Allow ``$foo`` in addition to ``${foo}``
 
@@ -431,45 +500,9 @@ Alternatives
 
   * Most languages use ``$``, and I see no reason to deviate
 
-* Don't implicitly convert values when interpolating
-
-  * ``s"a ${x}"`` would instead translate to ``fromBuilder (toBuilder "a " <> toBuilder x)``
-  * Pro: no more ``Interpolate`` class
-  * Pro: more explicit, e.g. the way you have to explicitly convert before calling ``+``
-  * Pro: less likely to encounter type inference issues
-  * Con: adds more noise to interpolate
-  * This is what ``neat-interpolation`` does
-  * See *Section 10.1 Community Survey*
-
-* Reuse ``PrintfArg``
-
-  * Would only allow converting to strings, see "Only allow interpolating string-like values"
-
-* Define ``Interpolate`` as a multi param type class, instead of only going to ``String``.
-
-  * More complex
-  * Introduces n^2 instances problem
-  * ``-XQualifiedStrings`` is available for any more advanced use cases
-
-* Desugar to a function
-
-  * like ``printf``: ``s"a %s b %s" foo bar => (\x0 x1 -> "a " <> interpolate x0 <> " b " <> interpolate x1) foo bar``
-  * or like ``formatting``: ``s"a {text} b {int}" foo bar => (\x0 x1 -> "a " <> text x0 <> " b " <> int x1) foo bar``
-  * This defeats the purpose of string interpolation making it easy to see the exact location a variable gets injected. If you're interpolating a lot of values into a large string (e.g. with multiline strings), it's extremely difficult to match up which expression to which interpolation position.
-
 * Allow custom delimiters, which could be defined with Template Haskell or some other approach
 
   * See *Section 10.1 Community Survey*
-
-* Allow passing a String representation of the interpolated expression to ``interpolate``, e.g. to support something like ``Dbg."foo | ${x + 1}"`` returning ``"foo | x + 1 = 11"``
-
-  * I don't think this has any uses outside of debugging; if it's just that one use-case, quasiquotation should be sufficient
-  * https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/issues/8
-
-* Do something like `Python's new t-string feature <https://peps.python.org/pep-0750/>`_
-
-  * This doesn't translate easily to Haskell, since the point of t-string is to return a list of strings and a list of "anything" that was interpolated
-  * The ``QualifiedStrings`` part of the proposal should be able to handle any functionality here
 
 Unresolved Questions
 --------------------

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -1,0 +1,837 @@
+Add native string interpolation syntax
+======================================
+
+.. author:: Brandon Chinn
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/570>`_.
+.. sectnum::
+.. contents::
+
+Most languages have support for interpolating variables and (usually) arbitrary expressions:
+
+* Python
+
+  .. code-block:: python
+
+    f"Expected: {x + y}, got: {result}"
+
+* Rust
+
+  .. code-block:: rust
+
+    format!("Expected: {sum}, got: {result}")
+
+* Scala
+
+  .. code-block:: scala
+
+    s"Expected: ${x + y}, got: ${result}"
+
+* Javascript/Typescript
+
+  .. code-block:: javascript
+
+    `Expected: ${x + y}, got: ${result}`
+
+This proposal proposes adding S-strings (like Scala's syntax) to Haskell.
+
+Motivation
+----------
+
+Most non-trivial projects build strings at some point: printing out logs, rendering exceptions, generating code, pretty-printing. There are currently multiple ways to do this:
+::
+
+  -- concatenation + show
+  error $ "Expected: " <> show (x + y) <> ", got: " <> show result
+
+  -- printf
+  error $ printf "Expected: %d, got: %d" (x + y) result
+
+  -- safer printf, e.g. the `formatting` package
+  error $ format ("Expected: " % int % ", got: " % int) (x + y) result
+
+  -- quasiquoters, e.g. `string-interpolate` using `haskell-src-exts`
+  error [i|Expected: #{x + y}, got: #{result}|]
+
+But each of these options leave much to be desired:
+
+* Manual interpolation (e.g. ``<>``, ``show``, ``unwords``, etc.) is annoying, especially for strings with a lot of interpolation. It's hard to see the overall structure of the string, especially when building up a ``Text``:
+  ::
+
+    let
+      name1 = _ :: Text
+      age1 = _ :: Int
+      name2 = _ :: Text
+      age2 = _ :: Int
+
+      textExample1 = name1 <> " (age: " <> T.pack (show age1) <> ") encountered " <> name2 <> " (age: " <> T.pack (show age2) <> ")"
+
+      textExample2 = T.pack $ T.unpack name1 <> " (age: " <> show age1 <> ") encountered " <> T.unpack name2 <> " (age: " <> show age2 <> ")"
+
+      textExample3 = T.unwords
+        [ name1
+        , "(age: " <> T.pack (show age1) <> ")"
+        , "encountered"
+        , name2
+        , "(age: " <> T.pack (show age2) <> ")"
+        ]
+
+* ``printf`` is partial and unsafe, which especially safety-conscious people might always stay away from anyway. Using a safer ``printf`` like ``formatting`` induces a third-party dependency, which is admittedly lightweight, but isn't as seamless of an integration as native string interpolation would be
+
+* Quasiquotes induces a dependency on Template Haskell, which a lot of people avoid out of principle. Most QuasiQuoters also add a dependency on ``haskell-src-exts`` to parse arbitrary Haskell expressions, which could technically be avoided by using something like ``ghc-meta`` (`repo <https://github.com/noughtmare/ghc-meta>`_, `GHC issue <https://gitlab.haskell.org/ghc/ghc/-/issues/20862>`_), but this isn't in wide use yet.
+
+If Haskell had native string interpolation, it would have the benefit and safety of the current third-party quasiquotes without the need for Template Haskell, and be able to take advantage of features like `multiline strings <https://github.com/ghc-proposals/ghc-proposals/pull/569>`_.
+::
+
+  error s"Expected: ${x + y}, got: ${result}"
+
+  let textExample = s"${name1} (age: ${age1}) encountered ${name2} (age: ${age2})"
+
+Proposed Change Specification
+-----------------------------
+
+This proposal introduces the ``-XStringInterpolation`` extension, with support for ``-XOverloadedStrings`` and ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/698>`_).
+
+High-level Overview
+~~~~~~~~~~~~~~~~~~~
+
+``-XStringInterpolation`` enables the following syntax:
+
+::
+
+  s"a ${x + 1} b"
+
+  -- Desugars to:
+  Data.String.Interpolate.Experimental.interpolateString $ \convert raw append empty ->
+             raw "a "
+    `append` convert (x + 1)
+    `append` raw " b"
+    `append` empty
+
+The string literals are affected by ``-XOverloadedStrings`` as usual, if enabled. ``Data.String.Interpolate.Experimental`` will be initially provided by ``ghc-experimental``, containing the following:
+
+::
+
+  interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
+
+  class Interpolate a where
+    {-# MINIMAL interpolate | interpolateS #-}
+
+    interpolate :: a -> String
+    interpolate x = interpolateS x ""
+
+    interpolateS :: a -> ShowS
+    interpolateS x s = interpolate x <> s
+
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation as well:
+
+::
+
+  Text.s"hello world"
+
+  -- Desugars to:
+  Text.interpolateString $ \_ raw _ _ -> raw "hello world"
+
+  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
+
+  -- Desugars to:
+  SQL.interpolateString $ \convert raw append empty ->
+             raw "select * from users where name = "
+    `append` convert (Text.toUpper name)
+    `append` raw " and age = "
+    `append` convert age
+    `append` empty
+
+It is highly recommended that any type with an ``IsString`` instance provide the below definition for use with ``-XQualifiedStrings``. This allows using locally-scoped string interpolation for non-String types without enabling it globally with ``-XOverloadedStrings``.
+
+::
+
+  interpolateString :: String -> MyString
+  interpolateString = Data.String.Interpolate.Experimental.interpolateString
+
+Lexical Structure
+~~~~~~~~~~~~~~~~~
+
+Update `Section 10.2 <https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17700010.2>`_ of the Haskell 2010 report as follows.
+
+Add ``istring*`` patterns to ``lexeme`` (not ``literal``, because they're not literals):
+
+.. code-block:: abnf
+
+  lexeme  → qvarid | qconid | qvarsym | qconsym
+          | literal | special | reservedop | reservedid
+          | istringBegin
+          | istringRaw
+          | istringExprOpen
+          | istringExprClose
+          | istringEnd
+          | istringMultilineBegin
+          | istringMultilineRawStartLine
+          | istringMultilineRawMidLine
+          | istringMultilineEnd
+          | istringQualifiedBegin
+          | istringQualifiedMultilineBegin
+
+  istringBegin → 's"' | modid . 's"'
+  istringRaw → {graphic⟨'\' | '"' | '${'⟩ | space | escape | gap}
+  istringExprOpen → '${'
+  istringExprClose → '}'
+  istringEnd → '"'
+
+  istringMultilineBegin → 's"""' | modid . 's"""'
+  istringMultilineRawStartLine → {whitechar} istringMultilineRawMidLine
+  istringMultilineRawMidLine → {graphic⟨'\' | '"""' | '${'⟩ | space | escape | gap}
+  istringMultilineEnd → '"""'
+
+Also add ``$`` to ``charesc``:
+
+.. code-block:: abnf
+
+  charesc → a | b | f | n | r | t | v | \ | " | ' | & | $
+
+With ``$`` added to ``charesc``, interpolation can be avoided by escaping the dollar sign; e.g. ``s"\${foo}" == "${foo}"``.
+
+Context-Free Syntax
+~~~~~~~~~~~~~~~~~~~
+
+Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-18000010.5>`_ of the Haskell 2010 report as follows.
+
+.. code-block:: abnf
+
+  aexp → qvar
+       | ...
+       | istring
+       | istringMultiline
+
+  istring →
+    istringBegin
+      {istringRaw | istringExprOpen exp istringExprClose}
+      istringEnd
+
+  istringMultiline →
+    istringMultilineBegin
+      {istringMultilineRawStartLine | istringExprOpen exp istringExprClose istringMultilineRawMidLine}
+      istringMultilineEnd
+
+Machinery
+~~~~~~~~~
+
+The following code will live in ``ghc-experimental`` under ``Data.String.Interpolate.Experimental``. After the API has stablized, these would eventually live in ``Data.String`` alongside ``IsString``.
+
+::
+
+  interpolateString ::
+    (IsString s, Monoid s) =>
+    ( (forall a. Interpolate a => a -> s)
+      -> (s -> s)
+      -> (s -> s -> s)
+      -> s
+      -> s
+    )
+    -> s
+  interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
+  {-# INLINE interpolateString #-}
+
+  class Interpolate a where
+    {-# MINIMAL interpolate | interpolateS #-}
+
+    interpolate :: a -> String
+    interpolate x = interpolateS x ""
+
+    interpolateS :: a -> ShowS
+    interpolateS x s = interpolate x <> s
+
+``interpolateS`` is necessary in order to interpolate recursive data structures in linear time, but ``interpolate`` is more straightforward for simple data types.
+
+Instances will be provided as well, for example:
+
+::
+
+  instance Interpolate String where
+    interpolateS = showString
+  instance Interpolate Char where
+    interpolateS = showChar
+
+  instance Interpolate Int where
+    interpolateS = shows
+  instance Interpolate Double where
+    interpolateS = shows
+  instance Interpolate Bool where
+    interpolateS = shows
+
+  instance Interpolate a => Interpolate (Maybe a) where
+    interpolateS Nothing = showString "Nothing"
+    interpolateS (Just a) = showString "Just (" . interpolateS a . showChar ')'
+
+Expansion
+~~~~~~~~~
+
+With the machinery defined above, the following interpolated string desugars to the below expression:
+
+::
+
+  -- original string
+  s"foo ${f a b} bar ${g x} baz ${name}"
+
+  -- desugared
+  Data.String.Interpolate.Experimental.interpolateString $ \convert raw append empty ->
+             raw "foo "
+    `append` convert (f a b)
+    `append` raw " bar "
+    `append` convert (g x)
+    `append` raw " baz "
+    `append` convert name
+    `append` empty
+
+The string literals there will be handled by ``-XOverloadedStrings`` as usual, if enabled, although it's recommended to use ``-XQualifiedStrings`` instead, for more granular overloading.
+
+Template Haskell
+~~~~~~~~~~~~~~~~
+
+Template Haskell will add the following definitions:
+
+::
+
+  data Exp
+    = ...
+    | InterStringE (Maybe ModuleName) [InterStringPart]
+
+  data InterStringPart
+    = InterStringRaw String
+    | InterStringExp Exp
+
+We won't use ``Either`` as it doesn't seem like ``Either`` is used in any other TH types.
+
+Examples
+--------
+
+Parsing
+~~~~~~~
+
+.. list-table:: **Valid expressions**
+    :align: left
+
+    * - ``s"a ${x} b"``
+      - Simple expressions
+    * - ``s"a ${x + 1} b"``
+      - Complex expressions
+    * - ``s"a ${'{'} ${'}'} b"``
+      - Expressions containing braces (char)
+    * - ``s"a ${User{a = 1}} b"``
+      - Expressions containing braces (record)
+    * - ``s"a ${s"c ${x} d"} b"``
+      - Nested interpolation
+    * - ``s"a ${1 :: Int}"``
+      - Inline type annotation
+    * - ``s"a ${x {- a -}} b"``
+      - Inline comment
+    * - ``s"Name: ${user.name}"``
+      - OverloadedRecordDot
+
+.. list-table:: **Invalid expressions**
+    :align: left
+
+    * - ``s"a ${} b"``
+      - Expression is missing
+    * - ``s"a ${=} b"``
+      - Not a valid expression
+    * - ``s"a ${let x =} b"``
+      - Incomplete expression
+    * - ``s"a ${{b} c"``
+      - The second ``{`` is not a valid character to start an expression
+    * - ``s"a ${b -- asdf} c"``
+      - The rest of the string is commented out
+
+Multiline strings
+~~~~~~~~~~~~~~~~~
+
+::
+
+  let x = "hello"
+
+  -- original string
+  let str0 =
+        s"""
+        ${x} world
+        world ${x}
+        ${x} world
+        """
+
+  -- resolve multiline string
+  let str1 = s"${x} world\nworld ${x}\n${x} world"
+
+  -- resolve interpolation
+  let str2 = "hello world\nworld hello\nhello world"
+
+Effect and Interactions
+-----------------------
+
+An existing program containing ``s"..."`` will break when ``-XStringInterpolation`` is enabled. While there's precedent for this (Template Haskell splices make ``$(...)`` different from ``$ (...)``), this is the first instance where whitespace matters for an alphanumeric identifier. But this is not a big deal:
+
+#. It's unlikely for someone to be naming a function as ``s`` in the first place
+#. Easily mitigatable: just add a space, which improves readability anyway
+#. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
+
+When ``-XOverloadedStrings`` is enabled, string interpolation can be used for any type with an ``IsString`` instance. Otherwise, it will only ever build Strings.
+
+When ``-XQualifiedStrings`` is enabled, ``M.s"..."`` syntax is enabled, as described above. ``M`` should define ``interpolateString`` with concrete ``String`` inputs, so that the string literals concretize when ``-XOverloadedStrings`` is enabled as well. For example, defining ``interpolateString`` for an ``IsString`` type should be implemented as:
+
+::
+
+    import Data.String.Interpolate.Experimental qualified as S
+
+    interpolateString ::
+        ( (forall a. Interpolate a => a -> MyText)
+            -> (String -> MyText)
+            -> (MyText -> MyText -> MyText)
+            -> MyText
+            -> MyText
+        )
+        -> MyText
+    interpolateString = S.interpolateString
+
+Interpolation is also supported with ``-XMultilineStrings``, as described in "Proposed Change Specification".
+
+Costs and Drawbacks
+-------------------
+
+Development and maintenance is of moderate effort. Learnability for novice users will go up, since novice users probably expect string interpolation to be available, and might be frustrated at the lack of support currently.
+
+One minor drawback is the whitespace sensitivity of ``s"``, as discussed in "Effect and Interactions".
+
+Alternatives
+------------
+
+* Status quo (discussed in the "Motivation" section)
+
+* Allow ``$foo`` in addition to ``${foo}``
+
+  * This would complicate the syntax, and would also require interpolated string to escape bare ``$``.
+
+* Different quote delimiter
+
+  * ``s"..."`` was taken from Scala's interpolation syntax
+  * Could use ``f"..."`` like Python, with ``f`` for format, but ``f`` is a common variable name for functions and if the user forgets to enable ``-XStringInterpolation``, ``f"..."`` would parse as ``f "..."`` which is likely to be valid.
+  * Could use ``i"..."``, with ``i`` for interpolate.
+  * Could reuse QuasiQuote syntax, e.g. ``[s|`` or ``[fmt|``, except it would be special and NOT use Template Haskell.
+  * Could do ``''...''``, since ``''`` is invalid Haskell syntax today. However, code highlighters that aren't updated for ``-XStringInterpolation`` yet would not gracefully handle this.
+
+* No delimiter, always interpolate
+
+  * Would require any use of ``${...}`` to be escaped.
+  * No other language does this; even Bash has single quoted strings to avoid escaping
+
+* Different interpolation delimiter, e.g. ``#{foo}``
+
+  * Most languages use ``$``, and I see no reason to deviate
+
+* Don't implicitly convert values when interpolating
+
+  * ``s"a ${x}"`` would instead translate to ``fromBuilder (toBuilder "a " <> toBuilder x)``
+  * Pro: no more ``Interpolate`` class
+  * Pro: more explicit, e.g. the way you have to explicitly convert before calling ``+``
+  * Pro: less likely to encounter type inference issues
+  * Con: adds more noise to interpolate
+  * This is what ``neat-interpolation`` does
+  * See *Section 10.1 Community Survey*
+
+* Reuse ``PrintfArg``
+
+  * Would only allow converting to strings, see "Only allow interpolating string-like values"
+
+* Define ``Interpolate`` as a multi param type class, instead of only going to ``String``.
+
+  * More complex
+  * Introduces n^2 instances problem
+  * ``-XQualifiedStrings`` is available for any more advanced use cases
+
+* Desugar to a function
+
+  * like ``printf``: ``s"a %s b %s" foo bar => (\x0 x1 -> "a " <> interpolate x0 <> " b " <> interpolate x1) foo bar``
+  * or like ``formatting``: ``s"a {text} b {int}" foo bar => (\x0 x1 -> "a " <> text x0 <> " b " <> int x1) foo bar``
+  * This defeats the purpose of string interpolation making it easy to see the exact location a variable gets injected. If you're interpolating a lot of values into a large string (e.g. with multiline strings), it's extremely difficult to match up which expression to which interpolation position.
+
+* Allow custom delimiters, which could be defined with Template Haskell or some other approach
+
+  * See *Section 10.1 Community Survey*
+
+* Allow passing a String representation of the interpolated expression to ``interpolate``, e.g. to support something like ``Dbg."foo | ${x + 1}"`` returning ``"foo | x + 1 = 11"``
+
+  * I don't think this has any uses outside of debugging; if it's just that one use-case, quasiquotation should be sufficient
+  * https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/issues/8
+
+* Do something like `Python's new t-string feature <https://peps.python.org/pep-0750/>`_
+
+  * This doesn't translate easily to Haskell, since the point of t-string is to return a list of strings and a list of "anything" that was interpolated
+  * The ``QualifiedStrings`` part of the proposal should be able to handle any functionality here
+
+Unresolved Questions
+--------------------
+
+Implementation Plan
+-------------------
+
+I have a prototype started `here <https://gitlab.haskell.org/ghc/ghc/-/compare/master...wip%2Finterpolated-strings>`_
+
+Endorsements
+------------
+
+Appendix
+--------
+
+Community Survey
+~~~~~~~~~~~~~~~~
+
+I sent out multiple community surveys, the last one being open 2025-04-21 to 2025-04-30. Raw data and analysis can be found here: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/results
+
+Performance consideration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Strings are notorious for O(n^2) concatenations, but this only happens if you left-associate the concatenations. The desugaring here is always right-associated, so it should remain linear. The only case where it might be O(n^2) is when nesting interpolated strings inside interpolated strings (although benchmarking still shows this to be linear in practice).
+
+Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/bench
+
+Builder
+~~~~~~~
+
+A performance-minded person might want to take advantage of ``interpolateS`` and defer realizing the string until the very end.
+
+::
+
+  module Data.String.Builder.Interpolate where
+
+  import Data.String.Interpolate.Experimental qualified as S
+
+  newtype Builder = Builder (Endo String)
+    deriving newtype (Monoid, Semigroup)
+
+  build :: Builder -> String
+  build (Builder (Endo f)) = f ""
+
+  interpolateString f = f convert raw mappend mempty
+    where
+      convert = Builder . Endo . interpolateS
+      raw = Builder . Endo . showString
+
+With this definition, one can nest interpolated strings with linear performance:
+
+::
+
+  {-# LANGUAGE QualifiedStrings #-}
+  {-# LANGUAGE StringInterpolation #-}
+
+  import Data.String.Builder.Interpolate qualified as B
+
+  main = do
+    let name = "Alice"
+    let age = 10
+
+    let s1 = B.s"Name: ${name}!"
+    let s2 = B.s"Age: ${age}!"
+
+    print $ B.build B.s"${s1} + ${s2}"
+
+Text
+~~~~
+
+``text`` would not need any specific work, since it already supports ``IsString``. But it would be highly recommended for ``text`` to define a module for use with ``QualifiedStrings``:
+
+::
+
+  module Data.Text.Interpolate where
+
+  import Data.String.Interpolate.Experimental qualified as S
+
+  interpolateString ::
+    ( (forall a. Interpolate a => a -> Text)
+        -> (String -> Text)
+        -> (Text -> Text -> Text)
+        -> Text
+        -> Text
+    )
+    -> Text
+  interpolateString = S.interpolateString
+
+With this support, users can write the following:
+
+::
+
+  {-# LANGUAGE OverloadedStrings #-}
+  {-# LANGUAGE QualifiedStrings #-}
+  {-# LANGUAGE StringInterpolation #-}
+
+  import Data.Text.Interpolate qualified as T
+
+  main = do
+    let name = "Alice"
+    let age = 10
+
+    -- with overloaded strings
+    print $ T.toUpper s"Name: ${name}, Age: ${age}"
+
+    -- with qualified strings
+    print $ T.toUpper T.s"Name: ${name}, Age: ${age}"
+
+Custom interpolator: SqlQuery
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Imagine a library implements a ``SqlQuery`` type like:
+
+::
+
+  data SqlQuery = SqlQuery
+    { sqlText :: Text
+    , sqlValues :: [SqlValue]
+    }
+    deriving (Show, Eq)
+
+  instance IsString SqlQuery where
+    fromString s = SqlQuery{sqlText = T.pack s, sqlValues = []}
+  instance Semigroup SqlQuery where
+    q1 <> q2 =
+      SqlQuery
+        { sqlText = sqlText q1 <> sqlText q2
+        , sqlValues = sqlValues q1 <> sqlValues q2
+        }
+  instance Monoid SqlQuery where
+    mempty =
+      SqlQuery
+        { sqlText = ""
+        , sqlValues = []
+        }
+
+  data SqlValue
+    = SqlText Text
+    | SqlInt Int
+    deriving (Show)
+
+  class ToSqlValue a where
+    toSqlValue :: a -> SqlValue
+  instance ToSqlValue String where
+    toSqlValue = SqlText . T.pack
+  instance ToSqlValue Text where
+    toSqlValue = SqlText
+  instance ToSqlValue Int where
+    toSqlValue = SqlInt
+
+The library would also define a module for use with ``QualifiedStrings``:
+
+::
+
+  module Data.SQL.Interpolate where
+
+  import Data.String qualified as S
+  import Data.String.Interpolate.Experimental qualified as S
+
+  interpolateString ::
+    ( (forall a. Interpolate a => a -> SqlQuery)
+      -> (String -> SqlQuery)
+      -> (SqlQuery -> SqlQuery -> SqlQuery)
+      -> SqlQuery
+      -> SqlQuery
+    )
+    -> SqlQuery
+  interpolateString f = f convert raw mappend mempty
+    where
+      convert = interpolate
+      raw = S.fromString
+
+  class Interpolate a where
+    interpolate :: a -> SqlQuery
+  instance Interpolate SqlQuery where
+    interpolate = id
+  instance {-# OVERLAPPABLE #-} ToSqlValue a => Interpolate a where
+    interpolate a = SqlQuery{sqlText = "?", sqlValues = [toSqlValue a]}
+
+And gain access to safe string interpolation without SQL injection:
+
+::
+
+  let age = 10 :: Int
+  let name = "Robert'); DROP TABLE Students;--" :: String
+
+  SQL.s"SELECT * FROM tab WHERE age = ${age} AND name ILIKE ${name}"
+    == SqlQuery
+        { sqlText = "SELECT * FROM tab WHERE age = ? AND name ILIKE ?"
+        , sqlValues = [SqlInt 10,SqlText "Robert'); DROP TABLE Students;--"]
+        }
+
+  let
+    -- e.g. from user input
+    isAdult = True
+    nameFilter = SqlText "A%"
+
+    -- build where clause
+    whereClauses =
+      concat
+        [ ["age > 18" | isAdult]
+        , [SQL.s"name ILIKE ${nameFilter}"]
+        ]
+    conjoin cs = mconcat $ intersperse " AND " (cs :: [SqlQuery])
+
+  SQL.s"SELECT * FROM tab WHERE ${conjoin whereClauses}"
+    == SqlQuery
+        { sqlText = "SELECT * FROM tab WHERE age > 18 AND name ILIKE ?"
+        , sqlValues = [SqlText "A%"]
+        }
+
+The library could also define an implementation to support failure states:
+
+::
+
+  module Data.SQL.Compile.Interpolate where
+
+  import Data.SQL.Interpolate qualified as SQL
+
+  interpolateString ::
+    ( (forall a. ToSqlValue a => a -> SqlQuery)
+      -> (String -> SqlQuery)
+      -> (SqlQuery -> SqlQuery -> SqlQuery)
+      -> SqlQuery
+      -> SqlQuery
+    )
+    -> Either ParseError CompiledSqlQuery
+  interpolateString = compileQuery . SQL.interpolateString
+
+::
+
+  import Data.SQL.Interpolate qualified as SQL
+
+  main = do
+    let name = "Alice"
+    query <-
+      either (fail . show) pure $
+        SQL.s"SELECT * FROM users WHERE name = ${name}"
+
+    print query
+
+Custom interpolator: HTML
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Imagine a library implements a new ``Html`` type like:
+
+::
+
+  newtype Html = Html Text
+    deriving newtype (Show, IsString, Semigroup, Monoid)
+
+  escapeHtml :: Text -> Text
+  escapeHtml = Text.replace "<" "&lt;" . Text.replace ">" "&gt;"
+
+  newtype RawHtml = RawHtml {unRawHtml :: Text}
+
+  raw :: Text -> RawHtml
+  raw = RawHtml
+
+That library could define the module:
+
+::
+
+  module Data.HTML.Interpolate where
+
+  import Data.String.Interpolate.Experimental qualified as S
+
+  interpolateString ::
+    ( (forall a. Interpolate a => a -> Html)
+      -> (String -> Html)
+      -> (Html -> Html -> Html)
+      -> Html
+      -> Html
+    )
+    -> Html
+  interpolateString f = f interpolate raw mappend mempty
+
+  class Interpolate a where
+    interpolate :: a -> Html
+  instance Interpolate String where
+    interpolate = interpolate . T.pack
+  instance Interpolate Text where
+    interpolate = Html . escapeHtml
+  instance Interpolate RawHtml where
+    interpolate = Html . unRawHtml
+  instance {-# OVERLAPPABLE #-} S.Interpolate a => Interpolate a where
+    interpolate = interpolate . S.interpolate
+
+And gain access to safe string interpolation with HTML escaping by default:
+
+::
+
+  let title = "Why is 1 > 0?" :: Text
+  let body = "<p>Hello world</p>" :: Text
+
+  Html.s"<h1>${title}</h1>${raw body}"
+    == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
+
+Custom interpolatable type: BigDecimal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Imagine a library implements a new ``BigDecimal`` type:
+
+::
+
+  data BigDecimal = BigDecimal Integer Int
+
+  renderBigDecimal :: BigDecimal -> String
+  renderBigDecimal (BigDecimal digits scale) =
+    let (int, frac) = splitAt scale (show digits)
+     in int <> "." <> frac
+
+That library could define:
+
+::
+
+  instance Interpolate BigDecimal where
+    interpolate = renderBigDecimal
+
+And be able to use it in interpolated strings:
+
+::
+
+  let n = BigDecimal 123456 3
+  s"123456 / 10^3 = ${n}" == "123456 / 10^3 = 123.456"
+
+If ``text`` is implemented as described in *Section 10.2 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text`` for free.
+
+Format specifiers
+~~~~~~~~~~~~~~~~~
+
+Python is famous for being able to specify format specifiers when interpolating values:
+
+.. code-block:: python
+
+  x = 1.2
+  f"{x:.3f}" == "1.200"
+
+This would be provided by libraries, and the design and implementation of those libraries is not specified here. But from a user perspective, here's one possible way such a library could be used:
+
+::
+
+  {-
+  class Formattable a where
+    fmt :: String -> a -> String
+  -}
+
+  let today = fromGregorian 2024 08 12 :: Day
+   in s"Today's date is ${fmt "%a, %d %b %Y" today}."
+
+  let earned = -13.2 :: Float
+      total = 127.978 :: Float
+   in s"""
+        Points earned: ${fmt "+8.2" earned}
+        Current total: ${fmt "+8.2" total}
+      """
+
+Where these would return the strings:
+
+::
+
+  Today's date is Mon, 12 Aug 2024.
+
+  Points earned:   -13.20
+  Current total:  +127.98

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -273,15 +273,15 @@ With the machinery defined above, the following interpolated string desugars to 
   -- original string
   s"foo ${f a b} bar ${g x} baz ${name}"
 
-  -- desugared, where D.S.E = Data.String.Experimental.
-  D.S.E.interpolateFinalize $
-    D.S.E.interpolateRaw "foo "   `D.S.E.interpolateAppend`
-    D.S.E.interpolateValue (f a b)`D.S.E.interpolateAppend`
-    D.S.E.interpolateRaw " bar "  `D.S.E.interpolateAppend`
-    D.S.E.interpolateValue (g x)  `D.S.E.interpolateAppend`
-    D.S.E.interpolateRaw " baz "  `D.S.E.interpolateAppend`
-    D.S.E.interpolateValue name   `D.S.E.interpolateAppend`
-    D.S.E.interpolateEmpty
+  -- desugared
+  interpolateFinalize $
+    interpolateRaw "foo "   `interpolateAppend`
+    interpolateValue (f a b)`interpolateAppend`
+    interpolateRaw " bar "  `interpolateAppend`
+    interpolateValue (g x)  `interpolateAppend`
+    interpolateRaw " baz "  `interpolateAppend`
+    interpolateValue name   `interpolateAppend`
+    interpolateEmpty
     :: String
 
 Namely:
@@ -322,6 +322,85 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
       - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See *Section 10.3 Provided interpolator: Explicit*)
     * - ``Data.String.Interpolate.ShowS.Experimental``
       - Defines an interpolator useful for implementing ``showsPrec`` (See *Section 10.4 Provided interpolator: ShowS*)
+
+OverloadedStrings
+~~~~~~~~~~~~~~~~~
+
+When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding a ``StringInterpolator`` instance.
+
+QualifiedStrings
+~~~~~~~~~~~~~~~~
+
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, where ``[modid.]s"..."`` desugars to the same expressions, except resolving the ``interpolate*`` functions as ``[modid.]interpolate*``. Some examples:
+
+::
+
+  Text.s"hello world"
+
+  -- Desugars to:
+  Text.interpolateFinalize $
+    Text.interpolateRaw "hello world"
+
+::
+
+  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
+
+  -- Desugars to:
+  SQL.interpolateFinalize $
+    SQL.interpolateRaw   "select * from users where name = " `SQL.interpolateAppend`
+    SQL.interpolateValue (Text.toUpper name)                 `SQL.interpolateAppend`
+    SQL.interpolateRaw   " and age = "                       `SQL.interpolateAppend`
+    SQL.interpolateValue age                                 `SQL.interpolateAppend`
+    SQL.interpolateEmpty
+
+When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
+
+Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
+
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator should simply be a monomorphized version of the default interpolator:
+
+::
+
+    module Data.MyString (
+      module X,
+      interpolateFinalize,
+    ) where
+
+    import Data.String.Experimental as X hiding (interpolateFinalize)
+
+    -- MyString would already implement StringInterpolator for OverloadedStrings
+    interpolateFinalize :: MyStringBuilder -> MyString
+    interpolateFinalize = buildInterpolator
+
+The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
+
+The following laws should hold, if the expression compiles:
+
+* ``M."str" == M.s"str"``
+* ``Data.String.fromString "str" == M.s"str"``
+
+MultilineStrings
+~~~~~~~~~~~~~~~~
+
+When ``-XMultilineStrings`` is enabled, string interpolation may be used with multiline strings. Multiline string interpolations resolve the multiline string first, then do the string interpolation. This means that qualified string interpolations work with multiline strings for free.
+
+::
+
+  let x = "hello"
+
+  -- original string
+  let str0 =
+        s"""
+        ${x} world
+        world ${x}
+        ${x} world
+        """
+
+  -- resolve multiline string
+  let str1 = s"${x} world\nworld ${x}\n${x} world"
+
+  -- resolve interpolation
+  let str2 = "hello world\nworld hello\nhello world"
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
@@ -400,84 +479,7 @@ An existing program containing ``s"..."`` will break when ``-XStringInterpolatio
 #. Easily mitigatable: just add a space, which improves readability anyway
 #. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
 
-OverloadedStrings
-~~~~~~~~~~~~~~~~~
-
-When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding a ``StringInterpolator`` instance.
-
-QualifiedStrings
-~~~~~~~~~~~~~~~~
-
-When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
-
-::
-
-  Text.s"hello world"
-
-  -- Desugars to:
-  Text.interpolateFinalize $
-    Text.interpolateRaw "hello world"
-
-::
-
-  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
-
-  -- Desugars to:
-  SQL.interpolateFinalize $
-    SQL.interpolateRaw   "select * from users where name = " `SQL.interpolateAppend`
-    SQL.interpolateValue (Text.toUpper name)                 `SQL.interpolateAppend`
-    SQL.interpolateRaw   " and age = "                       `SQL.interpolateAppend`
-    SQL.interpolateValue age                                 `SQL.interpolateAppend`
-    SQL.interpolateEmpty
-
-When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
-
-Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
-
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator should simply be a monomorphized version of the default interpolator:
-
-::
-
-    module Data.MyString (
-      module X,
-      interpolateFinalize,
-    ) where
-
-    import Data.String.Experimental as X hiding (interpolateFinalize)
-
-    -- MyString would already implement StringInterpolator for OverloadedStrings
-    interpolateFinalize :: MyStringBuilder -> MyString
-    interpolateFinalize = buildInterpolator
-
-The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
-
-The following laws should hold, if the expression compiles:
-
-* ``M."str" == M.s"str"``
-* ``Data.String.fromString "str" == M.s"str"``
-
-MultilineStrings
-~~~~~~~~~~~~~~~~
-
-When ``-XMultilineStrings`` is enabled, string interpolation may be used with multiline strings. Multiline string interpolations resolve the multiline string first, then do the string interpolation. This means that qualified string interpolations work with multiline strings for free.
-
-::
-
-  let x = "hello"
-
-  -- original string
-  let str0 =
-        s"""
-        ${x} world
-        world ${x}
-        ${x} world
-        """
-
-  -- resolve multiline string
-  let str1 = s"${x} world\nworld ${x}\n${x} world"
-
-  -- resolve interpolation
-  let str2 = "hello world\nworld hello\nhello world"
+Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See *Section 2 Proposed Change Specification* above.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -213,55 +213,76 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateEmpty :: Monoid s => s
   interpolateEmpty = mempty
 
-  interpolateFinalize :: StringInterpolator s => InterpolatorBuilder s -> s
+  interpolateFinalize :: Interpolator s => InterpolatorBuilderFor s -> s
   interpolateFinalize = buildInterpolator
 
-  {----- String interpolator -----}
+  {----- Classes -----}
 
   class
-    ( IsString (InterpolatorBuilder s)
-    , Monoid (InterpolatorBuilder s)
-    ) => StringInterpolator s where
-    type InterpolatorBuilder s
-    buildInterpolator :: InterpolatorBuilder s -> s
+    ( InterpolatorBuilder (InterpolatorBuilderFor s)
+    ) => Interpolator s where
+    type InterpolatorBuilderFor s
+    buildInterpolator :: InterpolatorBuilderFor s -> s
+
+  class (IsString b, Monoid b, Interpolator b) => InterpolatorBuilder b where
+    interpolateString :: String -> b
+    interpolateString = fromString
+
+    interpolateIntegral :: (Integral a, Show a) => a -> b
+    interpolateIntegral = fromString . show
+
+    interpolateRealFloat :: (RealFloat a, Show a) => a -> b
+    interpolateRealFloat = fromString . show
+
+  class Interpolate a where
+    {-# MINIMAL interpolate | interpolatePrec #-}
+
+    interpolate :: (InterpolatorBuilder b) => a -> b
+    interpolate = interpolatePrec 0
+
+    interpolatePrec :: (InterpolatorBuilder b) => Int -> a -> b
+    interpolatePrec _ = interpolate
+
+  {----- StringBuilder -----}
 
   newtype StringBuilder = StringBuilder (Endo String)
     deriving newtype (Semigroup, Monoid)
   instance IsString StringBuilder where
     fromString s = StringBuilder (Endo (s <>))
 
-  instance StringInterpolator String where
-    type InterpolatorBuilder String = StringBuilder
+  instance Interpolator String where
+    type InterpolatorBuilderFor String = StringBuilder
     buildInterpolator (StringBuilder (Endo f)) = f ""
+
+  instance Interpolator StringBuilder where
+    type InterpolatorBuilderFor StringBuilder = StringBuilder
+    buildInterpolator = id
+
+  instance InterpolatorBuilder StringBuilder
 
   {----- Interpolation of values -----}
 
-  class Interpolate a where
-    {-# MINIMAL interpolate | interpolatePrec #-}
-
-    interpolate :: (IsString s, Monoid s) => a -> s
-    interpolate = interpolatePrec 0
-
-    interpolatePrec :: (IsString s, Monoid s) => Int -> a -> s
-    interpolatePrec _ = interpolate
-
   instance Interpolate String where
-    interpolate = fromString
+    interpolate = interpolateString
   instance Interpolate Char where
-    interpolate c = fromString [c]
+    interpolate c = interpolateString [c]
 
   instance Interpolate Int where
-    interpolate = fromString . show
+    interpolate = interpolateIntegral
+  instance Interpolate Word8 where
+    interpolate = interpolateIntegral
   instance Interpolate Double where
-    interpolate = fromString . show
+    interpolate = interpolateRealFloat
+  instance Interpolate Float where
+    interpolate = interpolateRealFloat
   instance Interpolate Bool where
-    interpolate = fromString . show
+    interpolate = interpolateString . show
 
   instance Interpolate a => Interpolate (Maybe a) where
-    interpolate Nothing = fromString "Nothing"
+    interpolate Nothing = interpolateString "Nothing"
     interpolate (Just a) = interpolate a
 
-Primitive types should typically implement ``interpolate`` using ``fromString``. Going through ``String`` is unavoidable without making ``Interpolate`` a multi param type class and introducing type ambiguity. But composite types will be able to avoid going through ``String``; see *Section 3.2 Composite types* for an example.
+Types may implement ``Interpolate`` either using the functions in ``InterpolatorBuilder``, ``Monoid``, or using ``s"..."`` itself; see *Section 3.2 Composite types* for an example.
 
 Expansion
 ~~~~~~~~~
@@ -317,7 +338,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
     * - ``Data.String.Interpolate.Class.Experimental``
       - Defines the ``Interpolate`` class and instances as written in *Section 2.4 Machinery*
     * - ``Data.String.Interpolate.Default.Experimental``
-      - Defines the ``StringInterpolator`` class and the ``interpolate*`` functions for the default ``s"..."`` syntax, as written in *Section 2.4 Machinery*
+      - Defines the classes and functions for the default ``s"..."`` syntax, as written in *Section 2.4 Machinery*
     * - ``Data.String.Interpolate.Explicit.Experimental``
       - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See *Section 10.3 Provided interpolator: Explicit*)
     * - ``Data.String.Interpolate.ShowS.Experimental``
@@ -326,7 +347,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding a ``StringInterpolator`` instance.
+When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding ``Interpolator`` + ``InterpolatorBuilder`` instances.
 
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
@@ -368,7 +389,7 @@ It's highly recommended that every string type with an ``IsString`` instance pro
 
     import Data.String.Experimental as X hiding (interpolateFinalize)
 
-    -- MyString would already implement StringInterpolator for OverloadedStrings
+    -- MyString would already implement Interpolator for OverloadedStrings
     interpolateFinalize :: MyStringBuilder -> MyString
     interpolateFinalize = buildInterpolator
 
@@ -666,32 +687,26 @@ Users could then write:
 Text
 ~~~~
 
-After implementing ``StringInterpolator``, ``text`` should already have a decently performant interpolation using the default interpolation. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that are simply the monomorphized versions of the default interpolator for ``Text``, ``LazyText``, and ``Builder``.
+After implementing ``Interpolator``, ``text`` should already have a decently performant interpolation using the default interpolation. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that are simply the monomorphized versions of the default interpolator for ``Text``, ``LazyText``, and ``Builder``.
 
-However, the default interpolator forces primitive types to interpolate via ``String``, which might be inefficient. So ``text`` might be interested in providing additional interpolators using a new ``Text.Interpolate`` class providing ``interpolate :: a -> Builder``:
+``text`` would implement ``InterpolatorBuilder Text.Builder`` using builder functions, so it should be fairly performant:
 
 ::
 
-    {----- Data.Text.Interpolate.Builder -----}
+    instance Interpolator Text where
+      type InterpolatorBuilderFor Text = LazyText.Builder
+      buildInterpolator = LazyText.toStrict . LazyText.toLazyText
 
-    class Interpolate a where
-      interpolate :: a -> Builder
+    instance Interpolator LazyText.Builder where
+      type InterpolatorBuilderFor LazyText.Builder = LazyText.Builder
+      buildInterpolator = id
 
-    interpolateRaw = fromString
-    interpolateValue = interpolate
-    interpolateAppend = mappend
-    interpolateEmpty = mempty
-    interpolateFinalize = interpolate
+    instance InterpolatorBuilder LazyText.Builder where
+      interpolateIntegral = LazyText.decimal
+      interpolateRealFloat = LazyText.realFloat
 
-    infixr 6 interpolateAppend
-
-    {----- Data.Text.Interpolate.Lazy; re-exports everything else from Builder -----}
-
-    interpolateFinalize = Builder.toLazyText
-
-    {----- Data.Text.Interpolate; re-exports everything else from Builder -----}
-
-    interpolateFinalize = LazyText.toStrict . Builder.toLazyText
+    instance Interpolate Text where
+      interpolate = interpolateString . Text.unpack
 
 With this support, users can write the following:
 
@@ -900,10 +915,10 @@ Imagine a library implements a new ``BigDecimal`` type:
 
   data BigDecimal = BigDecimal Integer Int
 
-  renderBigDecimal :: (IsString s, Monoid s) => BigDecimal -> s
+  renderBigDecimal :: (InterpolatorBuilder s) => BigDecimal -> s
   renderBigDecimal (BigDecimal digits scale) =
     let (int, frac) = splitAt scale (show digits)
-     in fromString $ int <> "." <> frac
+     in interpolateString $ int <> "." <> frac
 
 That library could define:
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -258,10 +258,8 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
     interpolate = fromString . show
 
   instance Interpolate a => Interpolate (Maybe a) where
-    interpolatePrec _ Nothing = fromString "Nothing"
-    interpolatePrec d (Just a) = fromString "Just " <> paren (interpolatePrec 11 a)
-      where
-        paren s = if d > 10 then fromString "(" <> s <> fromString ")" else s
+    interpolate Nothing = fromString "Nothing"
+    interpolate (Just a) = interpolate a
 
 Primitive types should typically implement ``interpolate`` using ``fromString``. Going through ``String`` is unavoidable without making ``Interpolate`` a multi param type class and introducing type ambiguity. But composite types will be able to avoid going through ``String``; see *Section 3.2 Composite types* for an example.
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -580,8 +580,9 @@ Delimiter-related Alternatives
 
 * No quote delimiter, always interpolate
 
-  * Would require any use of ``${...}`` to be escaped.
-  * No other language does this; even Bash has single quoted strings to avoid escaping
+  * e.g. if we switch the delimiter to `\{...}`, which is currently invalid in a string
+  * Used by `jq <https://jqlang.org/manual/#string-interpolation>`_
+  * Downside is that you have to parse the string before figuring out how it should be desugared
 
 * Different interpolation delimiter, e.g. ``#{foo}``
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -59,6 +59,12 @@ Most non-trivial projects build strings at some point: printing out logs, render
   -- quasiquoters, e.g. `string-interpolate` using `haskell-src-exts`
   error [i|Expected: #{x + y}, got: #{result}|]
 
+  -- find-and-replace
+  error $
+    Text.replace "${x + y}" (show $ x + y) $
+    Text.replace "${result}" (show result) $
+    "Expected: ${x + y}, got: ${result}
+
 But each of these options leave much to be desired:
 
 * Manual interpolation (e.g. ``<>``, ``show``, ``unwords``, etc.) is annoying, especially for strings with a lot of interpolation. It's hard to see the overall structure of the string, especially when building up a ``Text``:
@@ -85,6 +91,8 @@ But each of these options leave much to be desired:
 * ``printf`` is partial and unsafe, which especially safety-conscious people might always stay away from anyway. Using a safer ``printf`` like ``formatting`` induces a third-party dependency, which is admittedly lightweight, but isn't as seamless of an integration as native string interpolation would be
 
 * Quasiquotes induces a dependency on Template Haskell, which a lot of people avoid out of principle. Most QuasiQuoters also add a dependency on ``haskell-src-exts`` to parse arbitrary Haskell expressions, which could technically be avoided by using something like ``ghc-meta`` (`repo <https://github.com/noughtmare/ghc-meta>`_, `GHC issue <https://gitlab.haskell.org/ghc/ghc/-/issues/20862>`_), but this isn't in wide use yet.
+
+* Find-and-replace is much more verbose and a bit less performant. It can also replace too much (e.g. ``Text.replace "${a}" a . Text.replace "${b}" "${a}" $ "${a}${b}"``), and it's possible to get out of sync (e.g. ``Text.replace "${a}" a "${a}${b}"``)
 
 If Haskell had native string interpolation, it would have the benefit and safety of the current third-party quasiquotes without the need for Template Haskell, and be able to take advantage of features like `multiline strings <https://github.com/ghc-proposals/ghc-proposals/pull/569>`_.
 ::
@@ -301,7 +309,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using QualifiedStrings instead.
+When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using ``-XQualifiedStrings`` instead.
 
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
@@ -314,7 +322,8 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, wh
 
   -- Desugars to:
   Text.interpolateFinalize $
-    Text.interpolateRaw "hello world"
+    Text.interpolateRaw "hello world" `Text.interpolateAppend`
+    Text.interpolateEmpty
 
 ::
 
@@ -364,11 +373,14 @@ Or it could reuse the built-in ``Interpolate`` class using its own ``Builder`` t
     interpolateFinalize :: MyStringBuilder -> MyString
     interpolateFinalize = buildMyString
 
-The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
+The only requirement for this recommendation is that ``MyString`` provide a module implementing string interpolation using the built-in ``Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
 
 The following laws should hold, if the expression compiles:
 
 * ``M."str" == M.s"str"``
+
+    * That is, a ``-XQualifiedStrings`` string literal and a ``-XStringInterpolation`` string expression with no interpolated values should be equivalent
+
 * ``Data.String.fromString "str" == M.s"str"``
 
 MultilineStrings
@@ -460,6 +472,13 @@ Composite types
         fromString ":" <>
         interpolate col
 
+The ``Basic`` interpolator would be useful here, to reuse string interpolation syntax (`Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_):
+
+::
+
+    instance Interpolate SrcLoc where
+      interpolate SrcLoc{..} = Basic.s"${file}:${line}:${col}"
+
 Effect and Interactions
 -----------------------
 
@@ -528,6 +547,12 @@ Alternatives
 
   * Would be slightly slower for finally outputting ``String`` compared to ``ShowS``
   * Writing a byte array is pretty low-level, perhaps more low-level than we'd like here
+
+* Instead of string-specific logic, allow a general syntax for variadic functions
+
+  * String interpolation could then just be a variadic function that takes multiple arguments of type ``Interpolate a => a``
+  * Would be a nice language construct on its own, but its unfamiliarity would be a major loss for this feature
+  * Also doesn't compose well with other features e.g. with multiline strings
 
 Expansion-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -111,7 +111,7 @@ At its core, this proposal proposes the following functionality:
 
   * Same technique as ``-XQualifiedStrings``
 
-* ``s"..."`` is exactly equivalent to ``Data.String.Interpolate.Experimental.s"..."``, where ``Data.String.Interpolate.Experimental`` is a new module in ``ghc-experimental``.
+* ``s"..."`` is exactly equivalent to ``Data.String.Experimental.s"..."``, where ``Data.String.Experimental`` is a new module in ``ghc-experimental``.
 
 Concretely, ``-XStringInterpolation`` enables the following syntax:
 
@@ -126,7 +126,7 @@ Concretely, ``-XStringInterpolation`` enables the following syntax:
     interpolateRaw " b"      `interpolateAppend`
     interpolateEmpty
 
-These definitions will be provided by ``Data.String.Interpolate.Experimental``, which will be initially implemented in ``ghc-experimental``. See *Section 2.4 Machinery* for details.
+These definitions will be provided by ``Data.String.Experimental``, which will be initially implemented in ``ghc-experimental``. See *Section 2.4 Machinery* for details.
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~
@@ -195,7 +195,7 @@ Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch
 Machinery
 ~~~~~~~~~
 
-The following code will live in ``ghc-experimental`` under ``Data.String.Interpolate.Experimental``. After the API has stablized, these might eventually live in ``Data.String`` alongside ``IsString``.
+The following code will live in ``ghc-experimental`` under ``Data.String.Experimental``. After the API has stablized, these might eventually live in ``Data.String`` alongside ``IsString``.
 
 ::
 
@@ -253,15 +253,15 @@ With the machinery defined above, the following interpolated string desugars to 
   -- original string
   s"foo ${f a b} bar ${g x} baz ${name}"
 
-  -- desugared, where D.S.I.E = Data.String.Interpolate.Experimental.
-  D.S.I.E.interpolateFinalize $
-    D.S.I.E.interpolateRaw "foo "    `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateValue (f a b) `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateRaw " bar "   `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateValue (g x)   `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateRaw " baz "   `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateValue name    `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateEmpty
+  -- desugared, where D.S.E = Data.String.Experimental.
+  D.S.E.interpolateFinalize $
+    D.S.E.interpolateRaw "foo "   `D.S.E.interpolateAppend`
+    D.S.E.interpolateValue (f a b)`D.S.E.interpolateAppend`
+    D.S.E.interpolateRaw " bar "  `D.S.E.interpolateAppend`
+    D.S.E.interpolateValue (g x)  `D.S.E.interpolateAppend`
+    D.S.E.interpolateRaw " baz "  `D.S.E.interpolateAppend`
+    D.S.E.interpolateValue name   `D.S.E.interpolateAppend`
+    D.S.E.interpolateEmpty
 
 Namely:
 
@@ -351,12 +351,12 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
     SQL.interpolateValue age                               `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. At the very least, such an implementation could simply re-export the functions from ``Data.String.Interpolate.Experimental``, except monomorphize ``interpolateFinalize`` as
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. At the very least, such an implementation could simply re-export the functions from ``Data.String.Experimental``, except monomorphize ``interpolateFinalize`` as
 
 ::
 
     interpolateFinalize :: ShowS -> MyString
-    interpolateFinalize = fromString . D.S.I.E.interpolateFinalize
+    interpolateFinalize = fromString . D.S.E.interpolateFinalize
 
 But more likely, ``MyString`` would probably want to use a more performant builder of some sort, such as:
 
@@ -368,8 +368,8 @@ But more likely, ``MyString`` would probably want to use a more performant build
     interpolateRaw :: String -> MyStringBuilder
     interpolateRaw = fromString
 
-    interpolateValue :: D.S.I.E.Interpolate a => a -> MyStringBuilder
-    interpolateValue = fromString . D.S.I.E.interpolate
+    interpolateValue :: D.S.E.Interpolate a => a -> MyStringBuilder
+    interpolateValue = fromString . D.S.E.interpolate
 
     interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder 
     interpolateAppend = mappend
@@ -377,7 +377,7 @@ But more likely, ``MyString`` would probably want to use a more performant build
     interpolateEmpty :: MyStringBuilder
     interpolateEmpty = mempty
 
-The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Interpolate.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations than interpolating via ``String``.
+The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations than interpolating via ``String``.
 
 The following laws should hold, if the expression compiles:
 
@@ -562,7 +562,7 @@ Here's an example implementing the ``Builder`` + ``Text`` interpolators:
 
   module Data.Text.Interpolate.Builder where
 
-  import Data.String.Interpolate.Experimental (interpolate)
+  import Data.String.Experimental (interpolate)
 
   interpolateFinalize = id
   interpolateValue = fromString . interpolate
@@ -649,7 +649,7 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   module Data.SQL.Interpolate where
 
   import Data.String qualified as S
-  import Data.String.Interpolate.Experimental qualified as S
+  import Data.String.Experimental qualified as S
 
   interpolateFinalize = id
   interpolateValue = interpolate
@@ -747,7 +747,7 @@ That library could define the module:
   module Data.HTML.Interpolate where
 
   import Data.HTML as HTML
-  import Data.String.Interpolate.Experimental qualified as S
+  import Data.String.Experimental qualified as S
 
   interpolateFinalize = id
   interpolateValue = interpolate

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -121,9 +121,9 @@ Concretely, ``-XStringInterpolation`` enables the following syntax:
 
   -- Desugars to:
   interpolateFinalize $
-    interpolateRawString "a " `interpolateAppend` 
-    interpolateConvertValue (x + 1)  `interpolateAppend` 
-    interpolateRawString " b" `interpolateAppend` 
+    interpolateRaw "a "      `interpolateAppend`
+    interpolateValue (x + 1) `interpolateAppend`
+    interpolateRaw " b"      `interpolateAppend`
     interpolateEmpty
 
 These definitions will be provided by ``Data.String.Interpolate.Experimental``, which will be initially implemented in ``ghc-experimental``. See *Section 2.4 Machinery* for details.
@@ -199,11 +199,11 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Interpo
 
 ::
 
-  interpolateRawString :: String -> ShowS
-  interpolateRawString = showString
+  interpolateRaw :: String -> ShowS
+  interpolateRaw = showString
 
-  interpolateConvertValue :: Interpolate a => a -> ShowS
-  interpolateConvertValue = interpolateS
+  interpolateValue :: Interpolate a => a -> ShowS
+  interpolateValue = interpolateS
 
   interpolateAppend :: ShowS -> ShowS -> ShowS
   interpolateAppend = (.)
@@ -255,21 +255,21 @@ With the machinery defined above, the following interpolated string desugars to 
 
   -- desugared, where D.S.I.E = Data.String.Interpolate.Experimental.
   D.S.I.E.interpolateFinalize $
-    D.S.I.E.interpolateRawString "foo "     `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateConvertValue (f a b) `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateRawString " bar "    `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateConvertValue (g x)   `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateRawString " baz "    `D.S.I.E.interpolateAppend`
-    D.S.I.E.interpolateConvertValue name    `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateRaw "foo "    `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateValue (f a b) `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateRaw " bar "   `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateValue (g x)   `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateRaw " baz "   `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateValue name    `D.S.I.E.interpolateAppend`
     D.S.I.E.interpolateEmpty
 
 Namely:
 
-* An ``istringRaw <str>`` component expands to ``interpolateRawString "<str>"``
+* An ``istringRaw <str>`` component expands to ``interpolateRaw "<str>"``
 
-    * The string literal passed to ``interpolateRawString`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
+    * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
-* An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateConvertValue (<exp>)``
+* An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateValue (<exp>)``
 * The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
 Template Haskell
@@ -337,7 +337,7 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
 
   -- Desugars to:
   Text.interpolateFinalize $
-    Text.interpolateRawString "hello world"
+    Text.interpolateRaw "hello world"
 
 ::
 
@@ -345,10 +345,10 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
 
   -- Desugars to:
   SQL.interpolateFinalize $
-    SQL.interpolateRawString "select * from users where name = " `SQL.interpolateAppend`
-    SQL.interpolateConvertValue (Text.toUpper name)              `SQL.interpolateAppend`
-    SQL.interpolateRawString " and age = "                       `SQL.interpolateAppend`
-    SQL.interpolateConvertValue age                              `SQL.interpolateAppend`
+    SQL.interpolateRaw "select * from users where name = " `SQL.interpolateAppend`
+    SQL.interpolateValue (Text.toUpper name)               `SQL.interpolateAppend`
+    SQL.interpolateRaw " and age = "                       `SQL.interpolateAppend`
+    SQL.interpolateValue age                               `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
 It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. At the very least, such an implementation could simply re-export the functions from ``Data.String.Interpolate.Experimental``, except monomorphize ``interpolateFinalize`` as
@@ -365,11 +365,11 @@ But more likely, ``MyString`` would probably want to use a more performant build
     interpolateFinalize :: MyStringBuilder -> MyString
     interpolateFinalize = buildMyString
 
-    interpolateRawString :: String -> MyStringBuilder
-    interpolateRawString = fromString
+    interpolateRaw :: String -> MyStringBuilder
+    interpolateRaw = fromString
 
-    interpolateConvertValue :: D.S.I.E.Interpolate a => a -> MyStringBuilder
-    interpolateConvertValue = fromString . D.S.I.E.interpolate
+    interpolateValue :: D.S.I.E.Interpolate a => a -> MyStringBuilder
+    interpolateValue = fromString . D.S.I.E.interpolate
 
     interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder 
     interpolateAppend = mappend
@@ -475,7 +475,7 @@ Expansion-related Alternatives
   * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementions *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
   * Even if we hardcoded ``fromString``, one could still devise a custom string interpolator that's inconsistent with ``M.fromString``; e.g. ``interpolateFinalize _ = "bad"``
 
-* Hardcode a wired-in ``Interpolate`` class with ``interpolateConvertValue`` (and potentially ``interpolateRawString``)
+* Hardcode a wired-in ``Interpolate`` class with ``interpolateValue`` (and potentially ``interpolateRaw``)
 
   * Redundant with the rebindable functionality with ``-XQualifiedStrings``
 
@@ -553,7 +553,7 @@ Text
 
 * How to interpolate values
 
-  * Reuse built-in ``Interpolate``: ``interpolateConvertValue = fromString . interpolate``
+  * Reuse built-in ``Interpolate``: ``interpolateValue = fromString . interpolate``
   * Provide a new ``Interpolate`` class with ``interpolate :: a -> Builder``
 
 Here's an example implementing the ``Builder`` + ``Text`` interpolators:
@@ -565,8 +565,8 @@ Here's an example implementing the ``Builder`` + ``Text`` interpolators:
   import Data.String.Interpolate.Experimental (interpolate)
 
   interpolateFinalize = id
-  interpolateConvertValue = fromString . interpolate
-  interpolateRawString = fromString
+  interpolateValue = fromString . interpolate
+  interpolateRaw = fromString
   interpolateAppend = mappend
   interpolateEmpty = mempty
 
@@ -577,8 +577,8 @@ Here's an example implementing the ``Builder`` + ``Text`` interpolators:
   import Data.Text.Interpolate.Builder qualified as B
 
   interpolateFinalize = toStrict . toLazyText
-  interpolateConvertValue = B.interpolateConvertValue
-  interpolateRawString = B.interpolateRawString
+  interpolateValue = B.interpolateValue
+  interpolateRaw = B.interpolateRaw
   interpolateAppend = B.interpolateAppend
   interpolateEmpty = B.interpolateEmpty
 
@@ -652,8 +652,8 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   import Data.String.Interpolate.Experimental qualified as S
 
   interpolateFinalize = id
-  interpolateConvertValue = interpolate
-  interpolateRawString = fromString
+  interpolateValue = interpolate
+  interpolateRaw = fromString
   interpolateAppend = mappend
   interpolateEmpty = mempty
 
@@ -750,8 +750,8 @@ That library could define the module:
   import Data.String.Interpolate.Experimental qualified as S
 
   interpolateFinalize = id
-  interpolateConvertValue = interpolate
-  interpolateRawString = HTML.raw
+  interpolateValue = interpolate
+  interpolateRaw = HTML.raw
   interpolateAppend = mappend
   interpolateEmpty = mempty
 
@@ -786,8 +786,8 @@ String interpolation could also make it easier to implement `shows`, in a module
   module Data.ShowS.Interpolate (P (..), interpolateString) where
 
   interpolateFinalize = id
-  interpolateConvertValue = shows
-  interpolateRawString = showString
+  interpolateValue = shows
+  interpolateRaw = showString
   interpolateAppend = (.)
   interpolateEmpty = id
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -103,7 +103,7 @@ High-level Overview
 
 At its core, this proposal proposes the following functionality:
 
-* The syntax ``s"age: ${age}"`` expands to a built-in implementation using a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
+* The syntax ``s"age: ${age}"`` expands to a built-in implementation using a new ``Interpolate`` type class to interpolate values such as ``age``
 
 * The syntax ``M.s"age: ${age}"`` expands to a user-defined implementation where the implementor of the module ``M`` has total control over the implementation
 
@@ -124,7 +124,7 @@ Concretely, ``-XStringInterpolation`` enables the following syntax:
     interpolateRaw " b"      `interpolateAppend`
     interpolateEmpty
 
-These definitions will be provided by ``Data.String.Experimental``, which will be initially implemented in ``ghc-experimental``. See *Section 2.4 Machinery* for details.
+These definitions will be provided by ``Data.String.Experimental``, which will be initially implemented in ``ghc-experimental``. See `Section 2.4 Machinery <#24machinery>`_ for details.
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~
@@ -166,7 +166,7 @@ Also add ``$`` to ``charesc``:
 
 With ``$`` added to ``charesc``, interpolation can be avoided by escaping the dollar sign; e.g. ``s"\${foo}" == "${foo}"``.
 
-This grammar enables interpolating expressions with nested braces. Concretely, ``istringExprOpen`` and ``istringExprClose`` are only lexed within the ``istring`` context, using Alex start codes. See *Section 3.1* for examples.
+This grammar enables interpolating expressions with nested braces. Concretely, ``istringExprOpen`` and ``istringExprClose`` are only lexed within the ``istring`` and ``istringMultiline`` grammar productions, using Alex start codes. See `Section 3.1 Parsing <#31parsing>`_ for examples.
 
 Context-Free Syntax
 ~~~~~~~~~~~~~~~~~~~
@@ -208,13 +208,11 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateAppend :: StringBuilder -> StringBuilder -> StringBuilder
   interpolateAppend = mappend
 
-  infixr 6 `interpolateAppend` -- matches (<>)
-
   interpolateEmpty :: StringBuilder
   interpolateEmpty = mempty
 
-  interpolateFinalize :: IsString s => StringBuilder -> s
-  interpolateFinalize = fromString . buildString
+  interpolateFinalize :: StringBuilder -> String
+  interpolateFinalize = buildString
 
   {----- StringBuilder -----}
 
@@ -243,7 +241,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   instance Interpolate Bool where
     interpolate = fromString . show
 
-Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``; see *Section 3.2 Composite types* for an example.
+Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``; see `Section 3.2 Composite types <#32composite-types>`_ for an example. The default interpolator will only ever use this as ``s ~ StringBuilder``, but this allows other qualified interpolators to reuse the built-in ``Interpolate`` class and avoid roundtripping through ``String`` in certain instances.
 
 Expansion
 ~~~~~~~~~
@@ -256,7 +254,7 @@ With the machinery defined above, the following interpolated string desugars to 
   s"foo ${f a b} bar ${g x} baz ${name}"
 
   -- desugared
-  interpolateFinalize @String $
+  interpolateFinalize $
     interpolateRaw "foo "   `interpolateAppend`
     interpolateValue (f a b)`interpolateAppend`
     interpolateRaw " bar "  `interpolateAppend`
@@ -267,7 +265,7 @@ With the machinery defined above, the following interpolated string desugars to 
 
 Namely:
 
-* An ``istringRaw <str>`` component expands to ``interpolateRaw "<str>"``
+* An ``istringRaw`` component expands to ``interpolateRaw "<istringRaw>"``
 
   * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
@@ -275,11 +273,9 @@ Namely:
 
 * The list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
-  * ``interpolateAppend`` is explicitly inserted as an infix operation, so that qualified string interpolations can customize the fixity (see *Section 4.2 QualifiedStrings*)
+  * ``interpolateAppend`` is always right-associative
 
-* ``interpolateFinalize`` is passed an explicit ``@String`` type application, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
-
-  * Related: *Section 4.1 OverloadedStrings* and *Section 4.2 QualifiedStrings*
+  * Related: `Section 2.7 OverloadedStrings <#27overloadedstrings>`_ and `Section 2.8 QualifiedStrings <#28qualifiedstrings>`_
 
 ``ghc-experimental`` modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -292,22 +288,20 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
     * - **Module**
       - **Details**
     * - ``Data.String.Experimental``
-      - Re-exports ``Data.String.Interpolate.Class.Experimental``
-    * - ``Data.String.Interpolate.Experimental``
       - Re-exports ``Data.String.Interpolate.Class.Experimental`` and ``Data.String.Interpolate.Default.Experimental``
     * - ``Data.String.Interpolate.Class.Experimental``
-      - Defines the ``Interpolate`` class and instances as written in *Section 2.4 Machinery*
+      - Defines the ``Interpolate`` class and instances as written in `Section 2.4 Machinery <#24machinery>`_
     * - ``Data.String.Interpolate.Default.Experimental``
-      - Defines the classes and functions for the default ``s"..."`` syntax, as written in *Section 2.4 Machinery*
-    * - ``Data.String.Interpolate.Explicit.Experimental``
-      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See *Section 10.3 Provided interpolator: Explicit*)
+      - Defines the classes and functions for the default ``s"..."`` syntax, as written in `Section 2.4 Machinery <#24machinery>`_
+    * - ``Data.String.Interpolate.Basic.Experimental``
+      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See `Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_)
     * - ``Data.String.Interpolate.ShowS.Experimental``
-      - Defines an interpolator useful for implementing ``showsPrec`` (See *Section 10.4 Provided interpolator: ShowS*)
+      - Defines an interpolator useful for implementing ``showsPrec`` (See `Section 10.4 Provided interpolator: ShowS <#104provided-interpolator-shows>`_)
 
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, ``@String`` is *not* included. Any ``IsString`` type may be built with string interpolation, which still builds via ``ShowS``/``String`` with a final ``fromString`` at the very end.
+When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using QualifiedStrings instead.
 
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
@@ -333,10 +327,6 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, wh
     SQL.interpolateRaw   " and age = "                       `SQL.interpolateAppend`
     SQL.interpolateValue age                                 `SQL.interpolateAppend`
     SQL.interpolateEmpty
-
-When ``-XQualifiedStrings`` is enabled, ``@String`` is *not* included.
-
-Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
 
 It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator could simply be a monomorphized version of the default interpolator:
 
@@ -367,7 +357,6 @@ Or it could reuse the built-in ``Interpolate`` class using its own ``Builder`` t
 
     interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder
     interpolateAppend = mappend
-    infixr 6 `interpolateAppend`
 
     interpolateEmpty :: MyStringBuilder
     interpolateEmpty = mempty
@@ -480,7 +469,7 @@ An existing program containing ``s"..."`` will break when ``-XStringInterpolatio
 #. Easily mitigatable: just add a space, which improves readability anyway
 #. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
 
-Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See *Section 2 Proposed Change Specification* above.
+Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See `Section 2 Proposed Change Specification <#2proposed-change-specification>`_ above.
 
 Costs and Drawbacks
 -------------------
@@ -502,7 +491,7 @@ Alternatives
   * Pro: less likely to encounter type inference issues
   * Con: adds more noise to interpolate non-string values
   * This is what ``neat-interpolation`` does
-  * See *Section 10.1 Community Survey*
+  * See `Section 10.1 Community Survey <#101community-survey>`_
 
 * Reuse ``PrintfArg``
 
@@ -597,7 +586,7 @@ Delimiter-related Alternatives
 
 * Allow custom delimiters, which could be defined with Template Haskell or some other approach
 
-  * See *Section 10.1 Community Survey*
+  * See `Section 10.1 Community Survey <#101community-survey>`_
 
 Unresolved Questions
 --------------------
@@ -625,14 +614,14 @@ Strings are notorious for O(n^2) concatenations, but the current proposal builds
 
 Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/bench
 
-Provided interpolator: Explicit
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Provided interpolator: Basic
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.Explicit.Experimental``, which provides an interpolator that does not implicitly convert values and stays in ``s`` the whole time.
+As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.Basic.Experimental``, which provides an interpolator that does not implicitly convert values and stays in ``s`` the whole time.
 
 ::
 
-  module Data.String.Interpolate.Explicit.Experimental where
+  module Data.String.Interpolate.Basic.Experimental where
 
   interpolateRaw :: IsString s => String -> s
   interpolateRaw = fromString
@@ -642,7 +631,6 @@ As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpol
 
   interpolateAppend :: Monoid s => s -> s -> s
   interpolateAppend = mappend
-  infixr 6 `interpolateAppend`
 
   interpolateEmpty :: Monoid s => s
   interpolateEmpty = mempty
@@ -654,11 +642,11 @@ This is particularly useful for ``Builder``, where users could explicitly conver
 
 ::
 
-  import Data.String.Interpolate.Explicit.Experimental qualified as I
+  import Data.String.Interpolate.Basic.Experimental qualified as B
   import Data.Text.Lazy.Builder qualified as B
 
   render :: Person -> B.Builder
-  render Person{..} = I.s"Person(name = ${B.fromLazyText name}, age = ${B.decimal age})"
+  render Person{..} = B.s"Person(name = ${B.fromLazyText name}, age = ${B.decimal age})"
 
 Provided interpolator: ShowS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -674,8 +662,6 @@ As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpol
   interpolateAppend = (.)
   interpolateEmpty = id
   interpolateFinalize = id
-
-  infixr 9 `interpolateAppend`
 
   data P a = P !Int !a
   instance Show a => Show (P a) where
@@ -693,7 +679,7 @@ Users could then write:
 Text
 ~~~~
 
-When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``ShowS`` then converts to ``Text`` with a final ``fromString``. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
+When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``StringBuilder`` then converts to ``Text`` with a final ``fromString``. As mentioned in `Section 2.8 QualifiedStrings <#28qualifiedstrings>`_, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
 
 ::
 
@@ -778,8 +764,6 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   interpolateEmpty = mempty
   interpolateFinalize = id
 
-  infixr 6 `interpolateAppend`
-
   class Interpolate a where
     interpolate :: a -> SqlQuery
   instance Interpolate SqlQuery where
@@ -858,11 +842,6 @@ Imagine a library implements a new ``Html`` type like:
   escapeHtml :: Text -> Text
   escapeHtml = Text.replace "<" "&lt;" . Text.replace ">" "&gt;"
 
-  newtype RawHtml = RawHtml {unRawHtml :: Text}
-
-  raw :: Text -> RawHtml
-  raw = RawHtml
-
 That library could define the module:
 
 ::
@@ -872,22 +851,20 @@ That library could define the module:
   import Data.HTML as HTML
   import Data.String.Experimental qualified as S
 
-  interpolateRaw = HTML.raw
+  interpolateRaw = fromString
   interpolateValue = interpolate
   interpolateAppend = mappend
   interpolateEmpty = mempty
   interpolateFinalize = id
 
-  infixr 6 `interpolateAppend`
-
   class Interpolate a where
     interpolate :: a -> Html
+  instance Interpolate Html where
+    interpolate = id
   instance Interpolate String where
     interpolate = interpolate . T.pack
   instance Interpolate Text where
     interpolate = Html . escapeHtml
-  instance Interpolate RawHtml where
-    interpolate = Html . unRawHtml
   instance {-# OVERLAPPABLE #-} S.Interpolate a => Interpolate a where
     interpolate = interpolate @Text . S.interpolate
 
@@ -898,7 +875,7 @@ And gain access to safe string interpolation with HTML escaping by default:
   let title = "Why is 1 > 0?" :: Text
   let body = "<p>Hello world</p>" :: Text
 
-  Html.s"<h1>${title}</h1>${raw body}"
+  Html.s"<h1>${title}</h1>${Html.raw body}"
     == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
 
 Custom interpolatable type: BigDecimal

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -61,9 +61,9 @@ Most non-trivial projects build strings at some point: printing out logs, render
 
   -- find-and-replace
   error $
-    Text.replace "${x + y}" (show $ x + y) $
-    Text.replace "${result}" (show result) $
-    "Expected: ${x + y}, got: ${result}
+    Text.replace "${x + y}" (Text.show $ x + y) $
+    Text.replace "${result}" (Text.show result) $
+    "Expected: ${x + y}, got: ${result}"
 
 But each of these options leave much to be desired:
 
@@ -477,7 +477,11 @@ The ``Basic`` interpolator would be useful here, to reuse string interpolation s
 ::
 
     instance Interpolate SrcLoc where
-      interpolate SrcLoc{..} = Basic.s"${file}:${line}:${col}"
+      interpolate SrcLoc{..} = Basic.s"${file'}:${line'}:${col'}"
+        where
+          file' = interpolate file
+          line' = interpolate line
+          col' = interpolate col
 
 Effect and Interactions
 -----------------------
@@ -873,7 +877,7 @@ That library could define the module:
 
   module Data.HTML.Interpolate where
 
-  import Data.HTML as HTML
+  import Data.HTML
   import Data.String.Experimental qualified as S
 
   interpolateRaw = fromString
@@ -900,7 +904,7 @@ And gain access to safe string interpolation with HTML escaping by default:
   let title = "Why is 1 > 0?" :: Text
   let body = "<p>Hello world</p>" :: Text
 
-  Html.s"<h1>${title}</h1>${Html.raw body}"
+  HTML.s"<h1>${title}</h1>${HTML.raw body}"
     == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
 
 Custom interpolatable type: BigDecimal

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -298,6 +298,29 @@ Namely:
 
   * Related: *Section 4.1 OverloadedStrings* and *Section 4.2 QualifiedStrings*
 
+``ghc-experimental`` modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This proposal would be adding the following modules to ``ghc-experimental``, which would potentially be promoted to a proper library like ``base`` once the feature is stablized.
+
+.. list-table::
+    :align: left
+
+    * - **Module**
+      - **Details**
+    * - ``Data.String.Experimental``
+      - Re-exports ``Data.String.Interpolate.Class.Experimental``
+    * - ``Data.String.Interpolate.Experimental``
+      - Re-exports ``Data.String.Interpolate.Class.Experimental`` and ``Data.String.Interpolate.Default.Experimental``
+    * - ``Data.String.Interpolate.Class.Experimental``
+      - Defines the ``Interpolate`` class and instances as written in *Section 2.4 Machinery*
+    * - ``Data.String.Interpolate.Default.Experimental``
+      - Defines the ``StringInterpolator`` class and the ``interpolate*`` functions for the default ``s"..."`` syntax, as written in *Section 2.4 Machinery*
+    * - ``Data.String.Interpolate.Explicit.Experimental``
+      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See *Section 10.3 Provided interpolator: Explicit*)
+    * - ``Data.String.Interpolate.ShowS.Experimental``
+      - Defines an interpolator useful for implementing ``showsPrec`` (See *Section 10.4 Provided interpolator: ShowS*)
+
 Template Haskell
 ~~~~~~~~~~~~~~~~
 
@@ -578,6 +601,60 @@ Strings are notorious for O(n^2) concatenations, but the current proposal builds
 
 Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/bench
 
+Provided interpolator: Explicit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.Explicit.Experimental``, which provides an interpolator that does not implicitly convert values.
+
+::
+
+  module Data.String.Interpolate.Explicit.Experimental (
+    module X,
+    interpolateValue,
+  ) where
+
+  import Data.String.Interpolate.Default.Experimental as X hiding (interpolateValue)
+
+  interpolateValue = id
+
+This is particularly useful for ``Builder``, where users could explicitly convert values and avoid the penalty of going through ``String`` with the default ``Interpolate`` class.
+
+::
+
+  import Data.String.Interpolate.Explicit.Experimental qualified as I
+  import Data.Text.Lazy.Builder qualified as B
+
+  render :: Person -> B.Builder
+  render Person{..} = I.s"Person(name = ${B.fromLazyText name}, age = ${B.decimal age})"
+
+Provided interpolator: ShowS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.ShowS.Experimental``, which provides an interpolator that makes it easier to implement ``showsPrec``:
+
+::
+
+  module Data.String.Interpolate.ShowS.Experimental where
+
+  interpolateRaw = showString
+  interpolateValue = shows
+  interpolateAppend = (.)
+  interpolateEmpty = id
+  interpolateFinalize = id
+
+  data P a = P !Int !a
+  instance Show a => Show (P a) where
+    showsPrec _ (P p a) = showsPrec p a
+
+Users could then write:
+
+::
+
+  instance Show a => Show (MyTree a) where
+    showsPrec d (MyTree l v r) =
+      showParen (d > 10) $
+        ShowS.s"MyTree ${ShowS.P 11 l} ${v} ${ShowS.P 11 r}"
+
 Text
 ~~~~
 
@@ -799,34 +876,6 @@ And gain access to safe string interpolation with HTML escaping by default:
 
   Html.s"<h1>${title}</h1>${raw body}"
     == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
-
-Custom interpolator: ShowS
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-String interpolation could also make it easier to implement `shows`, in a module potentially provided by `base`:
-
-::
-
-  module Data.ShowS.Interpolate (P (..), interpolateString) where
-
-  interpolateRaw = showString
-  interpolateValue = shows
-  interpolateAppend = (.)
-  interpolateEmpty = id
-  interpolateFinalize = id
-
-  data P a = P !Int !a
-  instance Show a => Show (P a) where
-    showsPrec _ (P p a) = showsPrec p a
-
-Users could then do
-
-::
-
-  instance Show a => Show (MyTree a) where
-    showsPrec d (MyTree l v r) =
-      showParen (d > 10) $
-        ShowS.s"MyTree ${ShowS.P 11 l} ${v} ${ShowS.P 11 r}"
 
 Custom interpolatable type: BigDecimal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -208,6 +208,8 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateAppend :: Monoid s => s -> s -> s
   interpolateAppend = mappend
 
+  infixr 6 interpolateAppend -- matches (<>)
+
   interpolateEmpty :: Monoid s => s
   interpolateEmpty = mempty
 
@@ -292,7 +294,9 @@ Namely:
 
 * An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateValue (<exp>)``
 
-* The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
+* The list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
+
+  * ``interpolateAppend`` is explicitly inserted as an infix operation, so that qualified string interpolations can customize the fixity (see *Section 4.2 QualifiedStrings*)
 
 * The entire expression is explicitly typed as ``String``, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
 
@@ -429,6 +433,8 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
     SQL.interpolateEmpty
 
 When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
+
+Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
 
 It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator should simply be a monomorphized version of the default interpolator:
 
@@ -642,6 +648,8 @@ As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpol
   interpolateEmpty = id
   interpolateFinalize = id
 
+  infixr 9 interpolateAppend
+
   data P a = P !Int !a
   instance Show a => Show (P a) where
     showsPrec _ (P p a) = showsPrec p a
@@ -674,6 +682,8 @@ However, the default interpolator forces primitive types to interpolate via ``St
     interpolateAppend = mappend
     interpolateEmpty = mempty
     interpolateFinalize = interpolate
+
+    infixr 6 interpolateAppend
 
     {----- Data.Text.Interpolate.Lazy; re-exports everything else from Builder -----}
 
@@ -757,6 +767,8 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   interpolateAppend = mappend
   interpolateEmpty = mempty
   interpolateFinalize = id
+
+  infixr 6 interpolateAppend
 
   class Interpolate a where
     interpolate :: a -> SqlQuery
@@ -855,6 +867,8 @@ That library could define the module:
   interpolateAppend = mappend
   interpolateEmpty = mempty
   interpolateFinalize = id
+
+  infixr 6 interpolateAppend
 
   class Interpolate a where
     interpolate :: a -> Html

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -199,40 +199,22 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
 
   {----- Implementation of s"..." -----}
 
-  interpolateRaw :: IsString s => String -> s
+  interpolateRaw :: String -> StringBuilder
   interpolateRaw = fromString
 
-  interpolateValue :: (Interpolate a, InterpolateBuilder b) => a -> b
+  interpolateValue :: Interpolate a => a -> StringBuilder
   interpolateValue = interpolate
 
-  interpolateAppend :: Monoid s => s -> s -> s
+  interpolateAppend :: StringBuilder -> StringBuilder -> StringBuilder
   interpolateAppend = mappend
 
   infixr 6 `interpolateAppend` -- matches (<>)
 
-  interpolateEmpty :: Monoid s => s
+  interpolateEmpty :: StringBuilder
   interpolateEmpty = mempty
 
-  interpolateFinalize :: Interpolator s => InterpolatorBuilderFor s -> s
-  interpolateFinalize = buildInterpolator
-
-  {----- Classes -----}
-
-  class
-    ( InterpolatorBuilder (InterpolatorBuilderFor s)
-    ) => Interpolator s where
-    type InterpolatorBuilderFor s
-    buildInterpolator :: InterpolatorBuilderFor s -> s
-
-  class (IsString b, Monoid b, Interpolator b) => InterpolatorBuilder b where
-    interpolateIntegral :: (Integral a, Show a) => a -> b
-    interpolateIntegral = fromString . show
-
-    interpolateRealFloat :: (RealFloat a, Show a) => a -> b
-    interpolateRealFloat = fromString . show
-
-  class Interpolate a where
-    interpolate :: InterpolatorBuilder b => a -> b
+  interpolateFinalize :: IsString s => StringBuilder -> s
+  interpolateFinalize = fromString . buildString
 
   {----- StringBuilder -----}
 
@@ -241,17 +223,13 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   instance IsString StringBuilder where
     fromString s = StringBuilder (Endo (s <>))
 
-  instance Interpolator String where
-    type InterpolatorBuilderFor String = StringBuilder
-    buildInterpolator (StringBuilder (Endo f)) = f ""
-
-  instance Interpolator StringBuilder where
-    type InterpolatorBuilderFor StringBuilder = StringBuilder
-    buildInterpolator = id
-
-  instance InterpolatorBuilder StringBuilder
+  buildString :: StringBuilder -> String
+  buildString (StringBuilder (Endo f)) = f ""
 
   {----- Interpolation of values -----}
+
+  class Interpolate a where
+    interpolate :: (IsString s, Monoid s) => a -> s
 
   instance Interpolate String where
     interpolate = fromString
@@ -259,17 +237,13 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
     interpolate c = fromString [c]
 
   instance Interpolate Int where
-    interpolate = interpolateIntegral
-  instance Interpolate Word8 where
-    interpolate = interpolateIntegral
+    interpolate = fromString . show
   instance Interpolate Double where
-    interpolate = interpolateRealFloat
-  instance Interpolate Float where
-    interpolate = interpolateRealFloat
+    interpolate = fromString . show
   instance Interpolate Bool where
     interpolate = fromString . show
 
-Types may implement ``Interpolate`` either using the functions in ``InterpolatorBuilder``, ``Monoid``, or using ``s"..."`` itself; see *Section 3.2 Composite types* for an example.
+Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``; see *Section 3.2 Composite types* for an example.
 
 Expansion
 ~~~~~~~~~
@@ -303,7 +277,7 @@ Namely:
 
   * ``interpolateAppend`` is explicitly inserted as an infix operation, so that qualified string interpolations can customize the fixity (see *Section 4.2 QualifiedStrings*)
 
-* The entire expression is explicitly typed as ``String``, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
+* ``interpolateFinalize`` is passed an explicit ``@String`` type application, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
 
   * Related: *Section 4.1 OverloadedStrings* and *Section 4.2 QualifiedStrings*
 
@@ -333,7 +307,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, ``@String`` is *not* included. The only requirement needed for string interpolation for working on a string type is adding ``Interpolator`` + ``InterpolatorBuilder`` instances.
+When ``-XOverloadedStrings`` is enabled, ``@String`` is *not* included. Any ``IsString`` type may be built with string interpolation, which still builds via ``ShowS``/``String`` with a final ``fromString`` at the very end.
 
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
@@ -364,7 +338,7 @@ When ``-XQualifiedStrings`` is enabled, ``@String`` is *not* included.
 
 Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
 
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator should simply be a monomorphized version of the default interpolator:
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator could simply be a monomorphized version of the default interpolator:
 
 ::
 
@@ -374,12 +348,34 @@ It's highly recommended that every string type with an ``IsString`` instance pro
     ) where
 
     import Data.String.Experimental as X hiding (interpolateFinalize)
+    import Data.String.Experimental qualified as S
 
-    -- MyString would already implement Interpolator for OverloadedStrings
+    interpolateFinalize :: StringBuilder -> MyString
+    interpolateFinalize = S.interpolateFinalize
+
+Or it could reuse the built-in ``Interpolate`` class using its own ``Builder`` type:
+
+::
+
+    module Data.MyString where
+
+    interpolateRaw :: String -> MyStringBuilder
+    interpolateRaw = fromString
+
+    interpolateValue :: Interpolate a => a -> MyStringBuilder
+    interpolateValue = interpolate
+
+    interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder
+    interpolateAppend = mappend
+    infixr 6 `interpolateAppend`
+
+    interpolateEmpty :: MyStringBuilder
+    interpolateEmpty = mempty
+
     interpolateFinalize :: MyStringBuilder -> MyString
-    interpolateFinalize = buildInterpolator
+    interpolateFinalize = buildMyString
 
-The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
+The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
 
 The following laws should hold, if the expression compiles:
 
@@ -468,14 +464,12 @@ Composite types
       }
 
     instance Interpolate SrcLoc where
-      interpolate SrcLoc{..} = s"${file}:${line}:${col}"
-
-      -- desugars to
-      --   interpolate file <>
-      --   fromString ":" <>
-      --   interpolate line <>
-      --   fromString ":" <>
-      --   interpolate col
+      interpolate SrcLoc{..} =
+        interpolate file <>
+        fromString ":" <>
+        interpolate line <>
+        fromString ":" <>
+        interpolate col
 
 Effect and Interactions
 -----------------------
@@ -536,6 +530,16 @@ Alternatives
   * This doesn't translate easily to Haskell, since the point of t-string is to return a list of strings and a list of "anything" that was interpolated
   * The ``QualifiedStrings`` part of the proposal should be able to handle any functionality here
 
+* Instead of interpolating primitives via ``String``, define a finally tagless API to allow interpolating certain other blessed types, like ``Integral`` or ``RealFloat``
+
+  * Would allow performant interpolation of primitives for ``Text.Builder`` using the same ``Interpolate`` class
+  * Wouldn't solve the issue of ``Text.Builder`` interpolating to itself via ``String``
+
+* Instead of interpolating primitives via ``String``, define a bytearray writer enabling primitives to explicitly write bytes, which could be a useful lowest-common-denominator for both ``String`` and ``Text.Builder``
+
+  * Would be slightly slower for finally outputting ``String`` compared to ``ShowS``
+  * Writing a byte array is pretty low-level, perhaps more low-level than we'd like here
+
 Expansion-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -552,6 +556,12 @@ Expansion-related Alternatives
 * Hardcode a wired-in ``Interpolate`` class with ``interpolateValue`` (and potentially ``interpolateRaw``)
 
   * Redundant with the rebindable functionality with ``-XQualifiedStrings``
+
+* Add an ``InterpolateBuilder`` type family to specify a builder type for the interpolator ``s`` and define ``interpolateFinalize`` with that type family
+
+  * Allows the default ``s"..."`` to build more performantly for non-``String``
+  * Type inference should be unambiguous, since ``s`` should be known, and ``Builder s`` is unique for a given ``s``
+  * Adds complexity; probably better to just use a qualified interpolator for this
 
 Delimiter-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -617,18 +627,27 @@ Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototyp
 Provided interpolator: Explicit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.Explicit.Experimental``, which provides an interpolator that does not implicitly convert values.
+As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpolate.Explicit.Experimental``, which provides an interpolator that does not implicitly convert values and stays in ``s`` the whole time.
 
 ::
 
-  module Data.String.Interpolate.Explicit.Experimental (
-    module X,
-    interpolateValue,
-  ) where
+  module Data.String.Interpolate.Explicit.Experimental where
 
-  import Data.String.Interpolate.Default.Experimental as X hiding (interpolateValue)
+  interpolateRaw :: IsString s => String -> s
+  interpolateRaw = fromString
 
+  interpolateValue :: s -> s
   interpolateValue = id
+
+  interpolateAppend :: Monoid s => s -> s -> s
+  interpolateAppend = mappend
+  infixr 6 `interpolateAppend`
+
+  interpolateEmpty :: Monoid s => s
+  interpolateEmpty = mempty
+
+  interpolateFinalize :: s -> s
+  interpolateFinalize = id
 
 This is particularly useful for ``Builder``, where users could explicitly convert values and avoid the penalty of going through ``String`` with the default ``Interpolate`` class.
 
@@ -673,26 +692,15 @@ Users could then write:
 Text
 ~~~~
 
-After implementing ``Interpolator``, ``text`` should already have a decently performant interpolation using the default interpolation. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that are simply the monomorphized versions of the default interpolator for ``Text``, ``LazyText``, and ``Builder``.
-
-``text`` would implement ``InterpolatorBuilder Text.Builder`` using builder functions, so it should be fairly performant:
+When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``ShowS`` then converts to ``Text`` with a final ``fromString``. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
 
 ::
 
-    instance Interpolator Text where
-      type InterpolatorBuilderFor Text = LazyText.Builder
-      buildInterpolator = LazyText.toStrict . LazyText.toLazyText
-
-    instance Interpolator LazyText.Builder where
-      type InterpolatorBuilderFor LazyText.Builder = LazyText.Builder
-      buildInterpolator = id
-
-    instance InterpolatorBuilder LazyText.Builder where
-      interpolateIntegral = LazyText.decimal
-      interpolateRealFloat = LazyText.realFloat
-
-    instance Interpolate Text where
-      interpolate = fromString . Text.unpack
+  interpolateRaw = fromString
+  interpolateValue = interpolate
+  interpolateAppend = mappend
+  interpolateEmpty = mempty
+  interpolateFinalize = LazyText.toStrict . Builder.toLazyText
 
 With this support, users can write the following:
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -96,20 +96,20 @@ If Haskell had native string interpolation, it would have the benefit and safety
 Proposed Change Specification
 -----------------------------
 
-This proposal introduces the ``-XStringInterpolation`` extension, which includes syntax similar to ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/723>`_).
+This proposal introduces the ``-XStringInterpolation`` extension, which enables ``s"Name: ${name}"`` syntax. It synergizes well with ``-XOverloadedStrings``, ``-XMultilineStrings``, and ``-XQualifiedStrings``.
 
 High-level Overview
 ~~~~~~~~~~~~~~~~~~~
 
 At its core, this proposal proposes the following functionality:
 
-* The syntax ``s"age: ${age}"`` expands to a built-in implementation hardcoded to ``String`` and a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
+* The syntax ``s"age: ${age}"`` expands to a built-in implementation using a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
 
-    * ``-XOverloadedStrings`` does not affect this expression at all
+  * When ``-XOverloadedStrings`` is enabled, ``fromString`` is added at the very end.
 
 * The syntax ``M.s"age: ${age}"`` expands to a user-defined implementation where the implementor of the module ``M`` has total control over the implementation
 
-    * Same technique as ``-XQualifiedStrings``
+  * Same technique as ``-XQualifiedStrings``
 
 * ``s"..."`` is exactly equivalent to ``Data.String.Interpolate.Experimental.s"..."``, where ``Data.String.Interpolate.Experimental`` is a new module in ``ghc-experimental``.
 
@@ -272,38 +272,6 @@ Namely:
 * An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateConvertValue (<exp>)``
 * The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
-Qualified string interpolation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Similar to ``-XQualifiedStrings``, you may qualify string interpolation:
-
-::
-
-  Text.s"hello world"
-
-  -- Desugars to:
-  Text.interpolateFinalize $
-    Text.interpolateRawString "hello world"
-
-::
-
-  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
-
-  -- Desugars to:
-  SQL.interpolateFinalize $
-    SQL.interpolateRawString "select * from users where name = " `SQL.interpolateAppend`
-    SQL.interpolateConvertValue (Text.toUpper name)              `SQL.interpolateAppend`
-    SQL.interpolateRawString " and age = "                       `SQL.interpolateAppend`
-    SQL.interpolateConvertValue age                              `SQL.interpolateAppend`
-    SQL.interpolateEmpty
-
-This syntax does not require ``-XQualifiedStrings``, only ``-XStringInterpolation``. It doesn't enable ``-XQualifiedStrings`` for normal string literals, only interpolation strings. While asymmetrical, since ``s"..."`` only works with ``String``, it's highly likely that most uses will use qualified syntax, so we enable it with only ``-XStringInterpolation``.
-
-The following laws should hold, if the expression compiles:
-
-* ``M."str" == M.s"str"``
-* ``Data.String.fromString "str" == M.s"str"``
-
 Template Haskell
 ~~~~~~~~~~~~~~~~
 
@@ -349,6 +317,78 @@ Parsing
     * - ``s"a ${b -- asdf} c"``
       - The rest of the string is commented out
 
+Effect and Interactions
+-----------------------
+
+An existing program containing ``s"..."`` will break when ``-XStringInterpolation`` is enabled. While there's precedent for this (Template Haskell splices make ``$(...)`` different from ``$ (...)``), this is the first instance where whitespace matters for an alphanumeric identifier. But this is not a big deal:
+
+#. It's unlikely for someone to be naming a function as ``s`` in the first place
+#. Easily mitigatable: just add a space, which improves readability anyway
+#. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
+
+QualifiedStrings
+~~~~~~~~~~~~~~~~
+
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
+
+::
+
+  Text.s"hello world"
+
+  -- Desugars to:
+  Text.interpolateFinalize $
+    Text.interpolateRawString "hello world"
+
+::
+
+  SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
+
+  -- Desugars to:
+  SQL.interpolateFinalize $
+    SQL.interpolateRawString "select * from users where name = " `SQL.interpolateAppend`
+    SQL.interpolateConvertValue (Text.toUpper name)              `SQL.interpolateAppend`
+    SQL.interpolateRawString " and age = "                       `SQL.interpolateAppend`
+    SQL.interpolateConvertValue age                              `SQL.interpolateAppend`
+    SQL.interpolateEmpty
+
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. At the very least, such an implementation could simply re-export the functions from ``Data.String.Interpolate.Experimental``, except monomorphize ``interpolateFinalize`` as
+
+::
+
+    interpolateFinalize :: ShowS -> MyString
+    interpolateFinalize = fromString . D.S.I.E.interpolateFinalize
+
+But more likely, ``MyString`` would probably want to use a more performant builder of some sort, such as:
+
+::
+
+    interpolateFinalize :: MyStringBuilder -> MyString
+    interpolateFinalize = buildMyString
+
+    interpolateRawString :: String -> MyStringBuilder
+    interpolateRawString = fromString
+
+    interpolateConvertValue :: D.S.I.E.Interpolate a => a -> MyStringBuilder
+    interpolateConvertValue = fromString . D.S.I.E.interpolate
+
+    interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder 
+    interpolateAppend = mappend
+
+    interpolateEmpty :: MyStringBuilder
+    interpolateEmpty = mempty
+
+The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Interpolate.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations than interpolating via ``String``.
+
+The following laws should hold, if the expression compiles:
+
+* ``M."str" == M.s"str"``
+* ``Data.String.fromString "str" == M.s"str"``
+
+OverloadedStrings
+~~~~~~~~~~~~~~~~~
+
+When ``-XOverloadedStrings`` is enabled, ``fromString`` is added at the end, only for ``s"..."`` (not ``M.s"..."``). ``fromString`` is rebindable with ``-XRebindableSyntax``, as usual.
+
 Multiline strings
 ~~~~~~~~~~~~~~~~~
 
@@ -371,19 +411,6 @@ When ``-XMultilineStrings`` is enabled, string interpolation may be used with mu
 
   -- resolve interpolation
   let str2 = "hello world\nworld hello\nhello world"
-
-Effect and Interactions
------------------------
-
-An existing program containing ``s"..."`` will break when ``-XStringInterpolation`` is enabled. While there's precedent for this (Template Haskell splices make ``$(...)`` different from ``$ (...)``), this is the first instance where whitespace matters for an alphanumeric identifier. But this is not a big deal:
-
-#. It's unlikely for someone to be naming a function as ``s`` in the first place
-#. Easily mitigatable: just add a space, which improves readability anyway
-#. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
-
-When ``-XStringInterpolation`` is enabled, ``M.s"..."`` syntax is enabled, as described above. This is enabled whether ``-XQualifiedStrings`` is enabled or not, but the two extensions should not conflict.
-
-Interpolation is also supported with ``-XMultilineStrings``, as described above.
 
 Costs and Drawbacks
 -------------------
@@ -615,7 +642,7 @@ Imagine a library implements a ``SqlQuery`` type like:
   instance ToSqlValue Int where
     toSqlValue = SqlInt
 
-The library would also define a module for use with qualified string interpolations:
+The library would also define a module for use with ``-XStringInterpolation`` + ``-XQualifiedStrings``:
 
 ::
 
@@ -805,7 +832,7 @@ And be able to use it in interpolated strings:
   let n = BigDecimal 123456 3
   s"123456 / 10^3 = ${n}" == "123456 / 10^3 = 123.456"
 
-If ``text`` is implemented as described in *Section 10.3 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text.s"..."`` for free.
+If ``text`` provided an interpolator using the built-in ``Interpolate`` class with ``Text.pack``, ``BigDecimal`` could interpolate into ``Text.s"..."`` for free.
 
 Format specifiers
 ~~~~~~~~~~~~~~~~~
@@ -862,20 +889,20 @@ Alternate 1: Built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsStr
 
     {----- Data.String.Interpolate -----}
 
-    finalize :: Monoid s => [s] -> s
-    finalize = mconcat
-
-    raw :: IsString s => String -> s
-    raw = fromString
+    raw :: String -> ShowS
+    raw = showString
 
     convert :: Interpolate a => a -> s
-    convert x = fromString $ interpolateS x ""
+    convert = interpolateS
 
-    append :: s -> [s] -> [s]
-    append = (:)
+    append :: ShowS -> ShowS -> ShowS
+    append = (.)
 
-    empty :: [s]
-    empty = []
+    empty :: ShowS
+    empty = id
+
+    finalize :: ShowS -> String
+    finalize = ($ "")
 
     -- One instance for all user-defined types; e.g. the `url` library
     -- would just need to implement `Interpolate URL`
@@ -894,13 +921,11 @@ Alternate 1: Built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsStr
     newtype SimpleText = SimpleText Text
       deriving newtype (Semigroup, Monoid)
 
-    convert :: Text -> SimpleText
-    convert = SimpleText
-
-    finalize = mconcat
-    raw = SimpleText . Text.pack
-    append = (:)
-    empty = []
+    convert = Text.Builder.fromText
+    raw = Text.Builder.fromText
+    append = mappend
+    empty = mempty
+    finalize = SimpleText . Text.toStrict . Text.Builder.toLazyText
 
 Alternate 2: Built-in ``s"..."`` with polymorphic builder:
 
@@ -921,7 +946,7 @@ Alternate 2: Built-in ``s"..."`` with polymorphic builder:
       raw      :: String -> Builder s
       append   :: Builder s -> Builder s -> Builder s
       empty    :: Builder s
-      finalise :: Builder s -> s
+      finalize :: Builder s -> s
 
     class Interpolate a builder where
       convert :: a -> builder
@@ -931,10 +956,10 @@ Alternate 2: Built-in ``s"..."`` with polymorphic builder:
       raw = fromString
       append = (.)
       empty = id
-      finalise = ($ "")
+      finalize = ($ "")
 
     instance Interpolate String ShowS where
-      convert = fromString
+      convert = showString
     instance Interpolate Int ShowS where
       convert = shows
     -- ...
@@ -946,7 +971,7 @@ Alternate 2: Built-in ``s"..."`` with polymorphic builder:
       raw = Text.Builder.fromText
       append = mappend
       empty = mempty
-      finalise = Text.toStrict . Text.Builder.toLazyText
+      finalize = Text.toStrict . Text.Builder.toLazyText
 
     instance Interpolate String Text.Builder where
       convert = Text.Builder.fromString

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -195,15 +195,17 @@ Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch
 Machinery
 ~~~~~~~~~
 
-The following code will live in ``ghc-experimental`` under ``Data.String.Experimental``. After the API has stablized, these might eventually live in ``Data.String`` alongside ``IsString``.
+The following code will live in ``ghc-experimental`` under ``Data.String.Experimental``. After the API has stablized, these might eventually live in ``base`` under ``Data.String``, alongside ``IsString``.
 
 ::
+
+  {----- Implementation of s"..." -----}
 
   interpolateRaw :: String -> ShowS
   interpolateRaw = showString
 
   interpolateValue :: Interpolate a => a -> ShowS
-  interpolateValue = interpolateS
+  interpolateValue = showString . interpolate
 
   interpolateAppend :: ShowS -> ShowS -> ShowS
   interpolateAppend = (.)
@@ -214,34 +216,34 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateFinalize :: ShowS -> String
   interpolateFinalize f = f ""
 
+  {----- Interpolation of values -----}
+
   class Interpolate a where
-    {-# MINIMAL interpolate | interpolateS #-}
+    {-# MINIMAL interpolate | interpolatePrec #-}
 
-    interpolate :: a -> String
-    interpolate x = interpolateS x ""
+    interpolate :: (IsString s, Monoid s) => a -> s
+    interpolate = interpolatePrec 0
 
-    interpolateS :: Int -> a -> ShowS
-    interpolateS _ x s = interpolate x <> s
-
-Instances will be provided as well, for example:
-
-::
+    interpolatePrec :: (IsString s, Monoid s) => Int -> a -> s
+    interpolatePrec _ = interpolate
 
   instance Interpolate String where
-    interpolateS _ = showString
+    interpolate = fromString
   instance Interpolate Char where
-    interpolateS _ = showChar
+    interpolate c = fromString [c]
 
   instance Interpolate Int where
-    interpolateS = showsPrec
+    interpolate = fromString . show
   instance Interpolate Double where
-    interpolateS = showsPrec
+    interpolate = fromString . show
   instance Interpolate Bool where
-    interpolateS = showsPrec
+    interpolate = fromString . show
 
   instance Interpolate a => Interpolate (Maybe a) where
-    interpolateS _ Nothing = showString "Nothing"
-    interpolateS d (Just a) = showString "Just " . showParen (d > 10) (interpolateS 11 a)
+    interpolatePrec _ Nothing = fromString "Nothing"
+    interpolatePrec d (Just a) = fromString "Just " <> paren (interpolatePrec 11 a)
+      where
+        paren s = if d > 10 then fromString "(" <> s <> fromString ")"
 
 Expansion
 ~~~~~~~~~
@@ -270,6 +272,7 @@ Namely:
     * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
 * An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateValue (<exp>)``
+
 * The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
 Template Haskell
@@ -345,20 +348,13 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
 
   -- Desugars to:
   SQL.interpolateFinalize $
-    SQL.interpolateRaw "select * from users where name = " `SQL.interpolateAppend`
-    SQL.interpolateValue (Text.toUpper name)               `SQL.interpolateAppend`
-    SQL.interpolateRaw " and age = "                       `SQL.interpolateAppend`
-    SQL.interpolateValue age                               `SQL.interpolateAppend`
+    SQL.interpolateRaw   "select * from users where name = " `SQL.interpolateAppend`
+    SQL.interpolateValue (Text.toUpper name)                 `SQL.interpolateAppend`
+    SQL.interpolateRaw   " and age = "                       `SQL.interpolateAppend`
+    SQL.interpolateValue age                                 `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. At the very least, such an implementation could simply re-export the functions from ``Data.String.Experimental``, except monomorphize ``interpolateFinalize`` as
-
-::
-
-    interpolateFinalize :: ShowS -> MyString
-    interpolateFinalize = fromString . D.S.E.interpolateFinalize
-
-But more likely, ``MyString`` would probably want to use a more performant builder of some sort, such as:
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator would probably be implemented as:
 
 ::
 
@@ -369,7 +365,7 @@ But more likely, ``MyString`` would probably want to use a more performant build
     interpolateRaw = fromString
 
     interpolateValue :: D.S.E.Interpolate a => a -> MyStringBuilder
-    interpolateValue = fromString . D.S.E.interpolate
+    interpolateValue = D.S.E.interpolate
 
     interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder 
     interpolateAppend = mappend
@@ -377,7 +373,7 @@ But more likely, ``MyString`` would probably want to use a more performant build
     interpolateEmpty :: MyStringBuilder
     interpolateEmpty = mempty
 
-The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations than interpolating via ``String``.
+The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
 
 The following laws should hold, if the expression compiles:
 
@@ -438,10 +434,10 @@ Alternatives
 
   * The bulk of its API deals with format specifiers, which is not applicable to this proposal. ``Interpolate`` is much simpler
 
-* Define ``Interpolate`` as a multi param type class, instead of only going to ``String``.
+* Define ``Interpolate`` as a multi param type class
 
   * More complex
-  * Introduces n^2 instances problem
+  * Introduces M*N instances problem
   * ``-XQualifiedStrings`` is available for any more advanced use cases
 
 * Desugar to a function
@@ -564,11 +560,11 @@ Here's an example implementing the ``Builder`` + ``Text`` interpolators:
 
   import Data.String.Experimental (interpolate)
 
-  interpolateFinalize = id
-  interpolateValue = fromString . interpolate
   interpolateRaw = fromString
+  interpolateValue = interpolate
   interpolateAppend = mappend
   interpolateEmpty = mempty
+  interpolateFinalize = id
 
 ::
 
@@ -651,11 +647,11 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   import Data.String qualified as S
   import Data.String.Experimental qualified as S
 
-  interpolateFinalize = id
-  interpolateValue = interpolate
   interpolateRaw = fromString
+  interpolateValue = interpolate
   interpolateAppend = mappend
   interpolateEmpty = mempty
+  interpolateFinalize = id
 
   class Interpolate a where
     interpolate :: a -> SqlQuery
@@ -764,7 +760,7 @@ That library could define the module:
   instance Interpolate RawHtml where
     interpolate = Html . unRawHtml
   instance {-# OVERLAPPABLE #-} S.Interpolate a => Interpolate a where
-    interpolate = interpolate . S.interpolate
+    interpolate = interpolate @Text . S.interpolate
 
 And gain access to safe string interpolation with HTML escaping by default:
 
@@ -785,11 +781,11 @@ String interpolation could also make it easier to implement `shows`, in a module
 
   module Data.ShowS.Interpolate (P (..), interpolateString) where
 
-  interpolateFinalize = id
-  interpolateValue = shows
   interpolateRaw = showString
+  interpolateValue = shows
   interpolateAppend = (.)
   interpolateEmpty = id
+  interpolateFinalize = id
 
   data P a = P !Int !a
   instance Show a => Show (P a) where
@@ -813,10 +809,10 @@ Imagine a library implements a new ``BigDecimal`` type:
 
   data BigDecimal = BigDecimal Integer Int
 
-  renderBigDecimal :: BigDecimal -> String
+  renderBigDecimal :: (IsString s, Monoid s) => BigDecimal -> s
   renderBigDecimal (BigDecimal digits scale) =
     let (int, frac) = splitAt scale (show digits)
-     in int <> "." <> frac
+     in fromString $ int <> "." <> frac
 
 That library could define:
 
@@ -832,12 +828,12 @@ And be able to use it in interpolated strings:
   let n = BigDecimal 123456 3
   s"123456 / 10^3 = ${n}" == "123456 / 10^3 = 123.456"
 
-If ``text`` provided an interpolator using the built-in ``Interpolate`` class with ``Text.pack``, ``BigDecimal`` could interpolate into ``Text.s"..."`` for free.
+If ``text`` provided an interpolator using the built-in ``Interpolate`` class, ``BigDecimal`` could interpolate into ``Text.s"..."`` for free.
 
 Format specifiers
 ~~~~~~~~~~~~~~~~~
 
-Python is famous for being able to specify format specifiers when interpolating values:
+One notable feature Python supports in string interpolation is specifying format specifiers:
 
 .. code-block:: python
 
@@ -871,140 +867,3 @@ Where these would return the strings:
 
   Points earned:   -13.20
   Current total:  +127.98
-
-Alternative - Polymorphic interpolable expansion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Alternate 1: Built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsString``:
-
-::
-
-    -- Desugared expression for M.s"age: ${age}"
-    --
-    -- s"..." is equivalent to Data.String.Interpolate.s"..."
-    M.finalize $
-                 M.raw "age: "
-      `M.append` M.convert age
-      `M.append` M.empty
-
-    {----- Data.String.Interpolate -----}
-
-    raw :: String -> ShowS
-    raw = showString
-
-    convert :: Interpolate a => a -> s
-    convert = interpolateS
-
-    append :: ShowS -> ShowS -> ShowS
-    append = (.)
-
-    empty :: ShowS
-    empty = id
-
-    finalize :: ShowS -> String
-    finalize = ($ "")
-
-    -- One instance for all user-defined types; e.g. the `url` library
-    -- would just need to implement `Interpolate URL`
-    class Interpolate a where
-      interpolateS :: a -> ShowS
-
-    {----- Text library: s"..." :: Text -----}
-
-    -- Doesn't have to do anything; built-in works for free.
-    -- Could optionally implement a more performant interpolation with
-    -- qualified interpolation.
-
-    {----- User-defined SimpleText: SimpleText.s"..." -----}
-
-    -- | Text, except only support interpolating Text values
-    newtype SimpleText = SimpleText Text
-      deriving newtype (Semigroup, Monoid)
-
-    convert = Text.Builder.fromText
-    raw = Text.Builder.fromText
-    append = mappend
-    empty = mempty
-    finalize = SimpleText . Text.toStrict . Text.Builder.toLazyText
-
-Alternate 2: Built-in ``s"..."`` with polymorphic builder:
-
-::
-
-    -- Desugared expression for M.s"age: ${age}"
-    --
-    -- s"..." is equivalent to Data.String.Interpolate.s"..."
-    M.finalize $
-                 M.raw "age: "
-      `M.append` M.convert age
-      `M.append` M.empty
-
-    {----- Data.String.Interpolate -----}
-
-    class Interpolable s where
-      type Builder s = b | b -> s
-      raw      :: String -> Builder s
-      append   :: Builder s -> Builder s -> Builder s
-      empty    :: Builder s
-      finalize :: Builder s -> s
-
-    class Interpolate a builder where
-      convert :: a -> builder
-
-    instance Interpolable String where
-      type Builder String = ShowS
-      raw = fromString
-      append = (.)
-      empty = id
-      finalize = ($ "")
-
-    instance Interpolate String ShowS where
-      convert = showString
-    instance Interpolate Int ShowS where
-      convert = shows
-    -- ...
-
-    {----- Text library: s"..." :: Text -----}
-
-    instance Interpolable Text where
-      type Builder Text = Text.Builder
-      raw = Text.Builder.fromText
-      append = mappend
-      empty = mempty
-      finalize = Text.toStrict . Text.Builder.toLazyText
-
-    instance Interpolate String Text.Builder where
-      convert = Text.Builder.fromString
-    instance Interpolate Int Text.Builder where
-      convert = Text.Builder.decimal
-    -- ...
-
-    {----- User-defined SimpleText: SimpleText.s"..." -----}
-
-    -- | Text, except ONLY support interpolating Text values.
-    --
-    -- Avoid `Interpolate` class, since we can't forbid someone
-    -- from adding a new `Interpolate Foo SimpleText` instance.
-    newtype SimpleText = SimpleText Text
-      deriving newtype (Semigroup, Monoid)
-
-    convert = Text.Builder.fromText
-    raw = Text.Builder.fromText
-    append = mappend
-    empty = mempty
-    finalize = SimpleText . Text.toStrict . Text.Builder.toLazyText
-
-Downsides of Alternate 2 compared to Alternate 1:
-
-* All types that can be interpolated (e.g. a ``URL`` type) must have an instance for each string-like type it can be interpolated within:
-
-    * ``Interpolate URL String``
-    * ``Interpolate URL Text``
-    * ``Interpolate URL ByteString``
-    * ...
-
-  Alternate 1 only needs to implement one ``Interpolate URL``. May be less performant, since we're always going via ``String`` instead of a potentially more efficient conversion (e.g. going straight to ``Text``), but it's a good default.
-
-* All string-like types _must_ implement their own instance, e.g. ``Interpolable Text``, and _must_ implement ``Interpolate`` instances for all built-in types.
-
-  Alternate 1 will automatically work for any ``IsString`` type. Types _may_ implement their own custom interpolation with qualified string interpolation, but that's not a requirement (although recommended, to monomorphize the default interpolation).

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -105,8 +105,6 @@ At its core, this proposal proposes the following functionality:
 
 * The syntax ``s"age: ${age}"`` expands to a built-in implementation using a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
 
-  * When ``-XOverloadedStrings`` is enabled, ``fromString`` is added at the very end.
-
 * The syntax ``M.s"age: ${age}"`` expands to a user-defined implementation where the implementor of the module ``M`` has total control over the implementation
 
   * Same technique as ``-XQualifiedStrings``
@@ -201,20 +199,20 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
 
   {----- Implementation of s"..." -----}
 
-  interpolateRaw :: String -> ShowS
-  interpolateRaw = showString
+  interpolateRaw :: IsString s => String -> s
+  interpolateRaw = fromString
 
-  interpolateValue :: Interpolate a => a -> ShowS
-  interpolateValue = showString . interpolate
+  interpolateValue :: (Interpolate a, IsString s, Monoid s) => a -> s
+  interpolateValue = interpolate
 
-  interpolateAppend :: ShowS -> ShowS -> ShowS
-  interpolateAppend = (.)
+  interpolateAppend :: Monoid s => s -> s -> s
+  interpolateAppend = mappend
 
-  interpolateEmpty :: ShowS
-  interpolateEmpty = id
+  interpolateEmpty :: Monoid s => s
+  interpolateEmpty = mempty
 
-  interpolateFinalize :: ShowS -> String
-  interpolateFinalize f = f ""
+  interpolateFinalize :: s -> s
+  interpolateFinalize = id
 
   {----- Interpolation of values -----}
 
@@ -245,6 +243,8 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
       where
         paren s = if d > 10 then fromString "(" <> s <> fromString ")"
 
+Primitive types should typically implement ``interpolate`` using ``fromString``. Going through ``String`` is unavoidable without making ``Interpolate`` a multi param type class and introducing type ambiguity. But composite types will be able to avoid going through ``String``; see *Section 3.2 Composite types* for an example.
+
 Expansion
 ~~~~~~~~~
 
@@ -264,16 +264,21 @@ With the machinery defined above, the following interpolated string desugars to 
     D.S.E.interpolateRaw " baz "  `D.S.E.interpolateAppend`
     D.S.E.interpolateValue name   `D.S.E.interpolateAppend`
     D.S.E.interpolateEmpty
+    :: String
 
 Namely:
 
 * An ``istringRaw <str>`` component expands to ``interpolateRaw "<str>"``
 
-    * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
+  * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
 * An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateValue (<exp>)``
 
 * The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
+
+* The entire expression is explicitly typed as ``String``, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
+
+  * Related: *Section 4.1 QualifiedStrings* and *Section 4.2 OverloadedStrings*
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
@@ -320,6 +325,29 @@ Parsing
     * - ``s"a ${b -- asdf} c"``
       - The rest of the string is commented out
 
+Composite types
+~~~~~~~~~~~~~~~
+
+``Interpolate`` specifies a generic ``IsString s, Monoid s``, which allows composite types to stay within ``s``. If it were monomorphized to ``String``, instances that would only use ``fromString`` and ``<>`` would make unnecessary roundtrips through ``String``.
+
+::
+
+    data SrcLoc = SrcLoc
+      { file :: FilePath
+      , line :: Int
+      , col :: Int
+      }
+
+    instance Interpolate SrcLoc where
+      interpolate SrcLoc{..} = s"${file}:${line}:${col}"
+
+      -- desugars to
+      --   interpolate file <>
+      --   fromString ":" <>
+      --   interpolate line <>
+      --   fromString ":" <>
+      --   interpolate col
+
 Effect and Interactions
 -----------------------
 
@@ -354,24 +382,21 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
     SQL.interpolateValue age                                 `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
+When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
+
 It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator would probably be implemented as:
 
 ::
 
+    module Data.MyString (
+      module X,
+      interpolateFinalize,
+    ) where
+
+    import Data.String.Experimental as X hiding (interpolateFinalize)
+
     interpolateFinalize :: MyStringBuilder -> MyString
     interpolateFinalize = buildMyString
-
-    interpolateRaw :: String -> MyStringBuilder
-    interpolateRaw = fromString
-
-    interpolateValue :: D.S.E.Interpolate a => a -> MyStringBuilder
-    interpolateValue = D.S.E.interpolate
-
-    interpolateAppend :: MyStringBuilder -> MyStringBuilder -> MyStringBuilder 
-    interpolateAppend = mappend
-
-    interpolateEmpty :: MyStringBuilder
-    interpolateEmpty = mempty
 
 The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
 
@@ -383,10 +408,10 @@ The following laws should hold, if the expression compiles:
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, ``fromString`` is added at the end, only for ``s"..."`` (not ``M.s"..."``). ``fromString`` is rebindable with ``-XRebindableSyntax``, as usual.
+When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. Since the functions in ``Data.String.Experimental`` are polymorphic over ``(IsString s, Monoid s)``, it should automatically pick up the overloaded type.
 
-Multiline strings
-~~~~~~~~~~~~~~~~~
+MultilineStrings
+~~~~~~~~~~~~~~~~
 
 When ``-XMultilineStrings`` is enabled, string interpolation may be used with multiline strings. Multiline string interpolations resolve the multiline string first, then do the string interpolation. This means that qualified string interpolations work with multiline strings for free.
 
@@ -458,8 +483,6 @@ Alternatives
 
 Expansion-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* Also see *Section 10.9 Alternative - Polymorphic interpolable expansion*
 
 * Hardcode to Monoid's ``mappend`` and ``mempty``
 
@@ -539,44 +562,22 @@ Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototyp
 Text
 ~~~~
 
-``text`` has a few options for string interpolation, potentially even providing multiple modules for each variant of string interpolator. All the interpolators would probably be implemented with ``Builder``, for performance, but one could implement variants for:
-
-* The final type to return
-
-  * ``interpolateFinalize :: Builder -> Builder; interpolateFinalize = id``
-  * ``interpolateFinalize :: Builder -> LazyText; interpolateFinalize = toLazyText``
-  * ``interpolateFinalize :: Builder -> Text; interpolateFinalize = toStrict . toLazyText``
-
-* How to interpolate values
-
-  * Reuse built-in ``Interpolate``: ``interpolateValue = fromString . interpolate``
-  * Provide a new ``Interpolate`` class with ``interpolate :: a -> Builder``
-
-Here's an example implementing the ``Builder`` + ``Text`` interpolators:
+As mentioned in *Section 4.1 QualifiedStrings*, ``text`` should provide interpolator(s) using the built-in ``Interpolate`` class, but it may optionally also provide interpolator(s) with its own ``Interpolate`` class, if it wants an option to interpolate straight to ``Builder`` (e.g. ``interpolate @Int = Builder.decimal``). For all of these interpolators, whichever ``Interpolate`` class they want to use, they should probably always build with ``Builder``:
 
 ::
 
-  module Data.Text.Interpolate.Builder where
+    -- Data.Text.Interpolate.Builder
+    interpolateRaw = fromString
+    interpolateValue = interpolate -- Either built-in Interpolate or new Builder.Interpolate
+    interpolateAppend = mappend
+    interpolateEmpty = mempty
+    interpolateFinalize = id
 
-  import Data.String.Experimental (interpolate)
+    -- Data.Text.Interpolate.Lazy; re-exports everything else from Builder
+    interpolateFinalize = Builder.toLazyText
 
-  interpolateRaw = fromString
-  interpolateValue = interpolate
-  interpolateAppend = mappend
-  interpolateEmpty = mempty
-  interpolateFinalize = id
-
-::
-
-  module Data.Text.Interpolate where
-
-  import Data.Text.Interpolate.Builder qualified as B
-
-  interpolateFinalize = toStrict . toLazyText
-  interpolateValue = B.interpolateValue
-  interpolateRaw = B.interpolateRaw
-  interpolateAppend = B.interpolateAppend
-  interpolateEmpty = B.interpolateEmpty
+    -- Data.Text.Interpolate; re-exports everything else from Builder
+    interpolateFinalize = LazyText.toStrict . Builder.toLazyText
 
 With this support, users can write the following:
 
@@ -745,11 +746,11 @@ That library could define the module:
   import Data.HTML as HTML
   import Data.String.Experimental qualified as S
 
-  interpolateFinalize = id
-  interpolateValue = interpolate
   interpolateRaw = HTML.raw
+  interpolateValue = interpolate
   interpolateAppend = mappend
   interpolateEmpty = mempty
+  interpolateFinalize = id
 
   class Interpolate a where
     interpolate :: a -> Html

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -96,14 +96,16 @@ If Haskell had native string interpolation, it would have the benefit and safety
 Proposed Change Specification
 -----------------------------
 
-This proposal introduces the ``-XStringInterpolation`` extension, with support for ``-XOverloadedStrings`` and ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/723>`_).
+This proposal introduces the ``-XStringInterpolation`` extension, which includes syntax similar to ``-XQualifiedStrings`` (`proposal <https://github.com/ghc-proposals/ghc-proposals/pull/723>`_).
 
 High-level Overview
 ~~~~~~~~~~~~~~~~~~~
 
-At its core, this proposal proposes the following system:
+At its core, this proposal proposes the following functionality:
 
-* The syntax ``s"age: ${age}"`` expands to a built-in implementation hardcoded to ``IsString`` and a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
+* The syntax ``s"age: ${age}"`` expands to a built-in implementation hardcoded to ``String`` and a new ``Interpolate`` type class with an ``interpolate :: a -> String`` function.
+
+    * ``-XOverloadedStrings`` does not affect this expression at all
 
 * The syntax ``M.s"age: ${age}"`` expands to a user-defined implementation where the implementor of the module ``M`` has total control over the implementation
 
@@ -118,30 +120,13 @@ Concretely, ``-XStringInterpolation`` enables the following syntax:
   s"a ${x + 1} b"
 
   -- Desugars to:
-  Data.String.Interpolate.Experimental.interpolateString
-    ( \convert raw append empty ->
-                 raw "a "
-        `append` convert (x + 1)
-        `append` raw " b"
-        `append` empty
-    )
-    :: String
+  interpolateFinalize $
+    interpolateRawString "a " `interpolateAppend` 
+    interpolateConvertValue (x + 1)  `interpolateAppend` 
+    interpolateRawString " b" `interpolateAppend` 
+    interpolateEmpty
 
-``Data.String.Interpolate.Experimental`` will be initially provided by ``ghc-experimental``, containing the following:
-
-::
-
-  -- See *Section 2.4* for the type of this definition
-  interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
-
-  class Interpolate a where
-    {-# MINIMAL interpolate | interpolateS #-}
-
-    interpolate :: a -> String
-    interpolate x = interpolateS x ""
-
-    interpolateS :: a -> ShowS
-    interpolateS x s = interpolate x <> s
+These definitions will be provided by ``Data.String.Interpolate.Experimental``, which will be initially implemented in ``ghc-experimental``. See *Section 2.4 Machinery* for details.
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~
@@ -210,23 +195,24 @@ Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch
 Machinery
 ~~~~~~~~~
 
-The following code will live in ``ghc-experimental`` under ``Data.String.Interpolate.Experimental``. After the API has stablized, these would eventually live in ``Data.String`` alongside ``IsString``.
+The following code will live in ``ghc-experimental`` under ``Data.String.Interpolate.Experimental``. After the API has stablized, these might eventually live in ``Data.String`` alongside ``IsString``.
 
 ::
 
-  type SimpleStringInterpolator s =
-    ( forall ss.
-      (forall a. Interpolate a => a -> s)
-      -> (s -> s)
-      -> (s -> ss -> ss)
-      -> ss
-      -> ss
-    )
-    -> s
+  interpolateRawString :: String -> ShowS
+  interpolateRawString = showString
 
-  interpolateString :: (IsString s, Monoid s) => SimpleStringInterpolator s
-  interpolateString f = mconcat $ f (fromString . interpolate) id (:) []
-  {-# INLINE interpolateString #-}
+  interpolateConvertValue :: Interpolate a => a -> ShowS
+  interpolateConvertValue = interpolateS
+
+  interpolateAppend :: ShowS -> ShowS -> ShowS
+  interpolateAppend = (.)
+
+  interpolateEmpty :: ShowS
+  interpolateEmpty = id
+
+  interpolateFinalize :: ShowS -> String
+  interpolateFinalize f = f ""
 
   class Interpolate a where
     {-# MINIMAL interpolate | interpolateS #-}
@@ -234,30 +220,28 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Interpo
     interpolate :: a -> String
     interpolate x = interpolateS x ""
 
-    interpolateS :: a -> ShowS
-    interpolateS x s = interpolate x <> s
-
-``interpolateS`` is necessary in order to interpolate recursive data structures in linear time, but ``interpolate`` is more straightforward for simple data types.
+    interpolateS :: Int -> a -> ShowS
+    interpolateS _ x s = interpolate x <> s
 
 Instances will be provided as well, for example:
 
 ::
 
   instance Interpolate String where
-    interpolateS = showString
+    interpolateS _ = showString
   instance Interpolate Char where
-    interpolateS = showChar
+    interpolateS _ = showChar
 
   instance Interpolate Int where
-    interpolateS = shows
+    interpolateS = showsPrec
   instance Interpolate Double where
-    interpolateS = shows
+    interpolateS = showsPrec
   instance Interpolate Bool where
-    interpolateS = shows
+    interpolateS = showsPrec
 
   instance Interpolate a => Interpolate (Maybe a) where
-    interpolateS Nothing = showString "Nothing"
-    interpolateS (Just a) = showString "Just (" . interpolateS a . showChar ')'
+    interpolateS _ Nothing = showString "Nothing"
+    interpolateS d (Just a) = showString "Just " . showParen (d > 10) (interpolateS 11 a)
 
 Expansion
 ~~~~~~~~~
@@ -269,59 +253,53 @@ With the machinery defined above, the following interpolated string desugars to 
   -- original string
   s"foo ${f a b} bar ${g x} baz ${name}"
 
-  -- desugared
-  Data.String.Interpolate.Experimental.interpolateString
-    ( \convert raw append empty ->
-                 raw "foo "
-        `append` convert (f a b)
-        `append` raw " bar "
-        `append` convert (g x)
-        `append` raw " baz "
-        `append` convert name
-        `append` empty
-    )
-    :: String
+  -- desugared, where D.S.I.E = Data.String.Interpolate.Experimental.
+  D.S.I.E.interpolateFinalize $
+    D.S.I.E.interpolateRawString "foo "     `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateConvertValue (f a b) `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateRawString " bar "    `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateConvertValue (g x)   `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateRawString " baz "    `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateConvertValue name    `D.S.I.E.interpolateAppend`
+    D.S.I.E.interpolateEmpty
 
 Namely:
 
-* An ``istringRaw <str>`` component expands to ``raw "<str>"``
-* An ``istringExprOpen exp istringExprClose`` component expands to ``convert (<exp>)``
-* The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``append`` as "list cons" and ``empty`` as "list nil".
+* An ``istringRaw <str>`` component expands to ``interpolateRawString "<str>"``
 
-If ``-XOverloadedStrings`` is enabled, the string literals passed to ``raw`` are overloaded and the ``:: String`` annotation is removed. The ``:: String`` annotation is included when ``-XOverloadedStrings`` is disabled; it's redundant in most cases, since ``raw "..."`` would resolve the return type to ``String``, but it's necessary if there are no ``raw`` calls (e.g. ``s"${a}${b}"``).
+    * The string literal passed to ``interpolateRawString`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
-QualifiedStrings
-~~~~~~~~~~~~~~~~
+* An ``istringExprOpen exp istringExprClose`` component expands to ``interpolateConvertValue (<exp>)``
+* The right-associated list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
-When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation as well:
+Qualified string interpolation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to ``-XQualifiedStrings``, you may qualify string interpolation:
 
 ::
 
   Text.s"hello world"
 
   -- Desugars to:
-  Text.interpolateString $ \_ raw _ _ -> raw "hello world"
+  Text.interpolateFinalize $
+    Text.interpolateRawString "hello world"
+
+::
 
   SQL.s"select * from users where name = ${Text.toUpper name} and age = ${age}"
 
   -- Desugars to:
-  SQL.interpolateString $ \convert raw append empty ->
-             raw "select * from users where name = "
-    `append` convert (Text.toUpper name)
-    `append` raw " and age = "
-    `append` convert age
-    `append` empty
+  SQL.interpolateFinalize $
+    SQL.interpolateRawString "select * from users where name = " `SQL.interpolateAppend`
+    SQL.interpolateConvertValue (Text.toUpper name)              `SQL.interpolateAppend`
+    SQL.interpolateRawString " and age = "                       `SQL.interpolateAppend`
+    SQL.interpolateConvertValue age                              `SQL.interpolateAppend`
+    SQL.interpolateEmpty
 
-The desugaring will NOT include a ``:: String`` annotation, whether ``-XOverloadedStrings`` is enabled or not.
+This syntax does not require ``-XQualifiedStrings``, only ``-XStringInterpolation``. It doesn't enable ``-XQualifiedStrings`` for normal string literals, only interpolation strings. While asymmetrical, since ``s"..."`` only works with ``String``, it's highly likely that most uses will use qualified syntax, so we enable it with only ``-XStringInterpolation``.
 
-It is highly recommended that any type with an ``IsString`` instance provide the below definition for use with ``-XQualifiedStrings``. This allows using locally-scoped string interpolation for non-String types without enabling it globally with ``-XOverloadedStrings``.
-
-::
-
-  interpolateString :: SimpleStringInterpolator MyString
-  interpolateString = Data.String.Interpolate.Experimental.interpolateString
-
-The following laws should hold, if the expression typechecks:
+The following laws should hold, if the expression compiles:
 
 * ``M."str" == M.s"str"``
 * ``Data.String.fromString "str" == M.s"str"``
@@ -374,6 +352,8 @@ Parsing
 Multiline strings
 ~~~~~~~~~~~~~~~~~
 
+When ``-XMultilineStrings`` is enabled, string interpolation may be used with multiline strings. Multiline string interpolations resolve the multiline string first, then do the string interpolation. This means that qualified string interpolations work with multiline strings for free.
+
 ::
 
   let x = "hello"
@@ -401,18 +381,9 @@ An existing program containing ``s"..."`` will break when ``-XStringInterpolatio
 #. Easily mitigatable: just add a space, which improves readability anyway
 #. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
 
-When ``-XOverloadedStrings`` is enabled, string interpolation can be used for any type with an ``IsString`` instance. Otherwise, it will only ever build Strings.
+When ``-XStringInterpolation`` is enabled, ``M.s"..."`` syntax is enabled, as described above. This is enabled whether ``-XQualifiedStrings`` is enabled or not, but the two extensions should not conflict.
 
-When ``-XQualifiedStrings`` is enabled, ``M.s"..."`` syntax is enabled, as described above. ``M`` should define ``interpolateString`` with concrete ``String`` inputs, so that the string literals concretize when ``-XOverloadedStrings`` is enabled as well. For example, defining ``interpolateString`` for an ``IsString`` type should be implemented as:
-
-::
-
-    import Data.String.Interpolate.Experimental qualified as S
-
-    interpolateString :: S.SimpleStringInterpolator MyText
-    interpolateString = S.interpolateString
-
-Interpolation is also supported with ``-XMultilineStrings``, as described in "Proposed Change Specification".
+Interpolation is also supported with ``-XMultilineStrings``, as described above.
 
 Costs and Drawbacks
 -------------------
@@ -470,23 +441,16 @@ Expansion-related Alternatives
 * Hardcode to Monoid's ``mappend`` and ``mempty``
 
   * Would remove potential use-cases needing type-changing ``append``, e.g. ``a -> [a] -> [a]`` or ``f a -> f as -> f (a ': as)``
-  * Most custom ``interpolateString`` might simply use Monoid, but at least the default ``interpolateString`` does not, in order to use a potentially more efficient ``mconcat`` (e.g. for ``Text``)
+  * It's likely that most custom ``interpolateString`` will use ``Monoid``, but we should avoid restricting the interface here
 
-* Use ``M.fromString`` instead of ``raw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
+* Use ``M.fromString`` instead of ``interpolateStringRaw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
 
   * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementions *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
-  * Even if we hardcoded ``fromString``, one could still devise a custom ``M.interpolateString`` that's inconsistent with ``M.fromString``; e.g. a law-breaking ``Monoid`` instance such that ``x `mappend` mempty /= x``
+  * Even if we hardcoded ``fromString``, one could still devise a custom string interpolator that's inconsistent with ``M.fromString``; e.g. ``interpolateFinalize _ = "bad"``
 
-* Hardcode a wired-in ``Interpolate`` class with ``convert`` (and potentially ``raw``)
+* Hardcode a wired-in ``Interpolate`` class with ``interpolateConvertValue`` (and potentially ``interpolateRawString``)
 
-  * Eliminates the whole benefit of a rebindable ``interpolateString``; having a blessed ``Interpolate`` class with a ``convert :: something`` function means everyone has to use that ``something`` type. The whole benefit of a rebindable ``interpolateString`` is, just like ``QualifiedDo``, as long as it typechecks, you can make its type whatever you want.
-
-* Replace the callback ``M.interpolateString $ \raw convert append empty -> raw "age: " `append` convert age `append` empty`` with the expression directly, e.g. ``M.fromString "age: " `M.mappend` M.convert age `M.mappend` M.mempty``.
-
-  * This would remove the major benefit of having one function to link to when clicking into an interpolated string, in an IDE / using a language server
-  * This would also remove the ability to add a "finalizer", where perhaps it's more efficient to append in one type, but the final type should be "compiled"/"built" in some fashion
-    * You could add ``M.finalizeInterpolatedString`` at the end, but then that's becoming more complicated than the current approach
-  * See also the other alternatives to hardcode the operations
+  * Redundant with the rebindable functionality with ``-XQualifiedStrings``
 
 Delimiter-related Alternatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -538,70 +502,51 @@ I sent out multiple community surveys, the last one being open 2025-04-21 to 202
 Performance consideration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Strings are notorious for O(n^2) concatenations, but this only happens if you left-associate the concatenations. The desugaring here is always right-associated, so it should remain linear. The only case where it might be O(n^2) is when nesting interpolated strings inside interpolated strings (although benchmarking still shows this to be linear in practice).
+Strings are notorious for O(n^2) concatenations, but the current proposal builds with ``ShowS``, so it should remain linear. The only case where it might be O(n^2) is when nesting interpolated strings inside interpolated strings (although benchmarking still shows this to be linear in practice).
 
 Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/bench
-
-Builder
-~~~~~~~
-
-A performance-minded person might want to take advantage of ``interpolateS`` and defer realizing the string until the very end.
-
-::
-
-  module Data.String.Builder.Interpolate where
-
-  import Data.String.Interpolate.Experimental qualified as S
-
-  newtype Builder = Builder (Endo String)
-    deriving newtype (Monoid, Semigroup)
-
-  build :: Builder -> String
-  build (Builder (Endo f)) = f ""
-
-  interpolateString f = f convert raw mappend mempty
-    where
-      convert = Builder . Endo . interpolateS
-      raw = Builder . Endo . showString
-
-With this definition, one can nest interpolated strings with linear performance:
-
-::
-
-  {-# LANGUAGE QualifiedStrings #-}
-  {-# LANGUAGE StringInterpolation #-}
-
-  import Data.String.Builder.Interpolate qualified as B
-
-  main = do
-    let name = "Alice"
-    let age = 10
-
-    let s1 = B.s"Name: ${name}!"
-    let s2 = B.s"Age: ${age}!"
-
-    print $ B.build B.s"${s1} + ${s2}"
 
 Text
 ~~~~
 
-``text`` would not need any specific work, since it already supports ``IsString``. But it would be highly recommended for ``text`` to define a module for use with ``QualifiedStrings``:
+``text`` has a few options for string interpolation, potentially even providing multiple modules for each variant of string interpolator. All the interpolators would probably be implemented with ``Builder``, for performance, but one could implement variants for:
+
+* The final type to return
+
+  * ``interpolateFinalize :: Builder -> Builder; interpolateFinalize = id``
+  * ``interpolateFinalize :: Builder -> LazyText; interpolateFinalize = toLazyText``
+  * ``interpolateFinalize :: Builder -> Text; interpolateFinalize = toStrict . toLazyText``
+
+* How to interpolate values
+
+  * Reuse built-in ``Interpolate``: ``interpolateConvertValue = fromString . interpolate``
+  * Provide a new ``Interpolate`` class with ``interpolate :: a -> Builder``
+
+Here's an example implementing the ``Builder`` + ``Text`` interpolators:
+
+::
+
+  module Data.Text.Interpolate.Builder where
+
+  import Data.String.Interpolate.Experimental (interpolate)
+
+  interpolateFinalize = id
+  interpolateConvertValue = fromString . interpolate
+  interpolateRawString = fromString
+  interpolateAppend = mappend
+  interpolateEmpty = mempty
 
 ::
 
   module Data.Text.Interpolate where
 
-  import Data.String.Interpolate.Experimental qualified as S
+  import Data.Text.Interpolate.Builder qualified as B
 
-  interpolateString ::
-    ( (forall a. Interpolate a => a -> Text)
-        -> (String -> Text)
-        -> (Text -> Text -> Text)
-        -> Text
-        -> Text
-    )
-    -> Text
-  interpolateString = S.interpolateString
+  interpolateFinalize = toStrict . toLazyText
+  interpolateConvertValue = B.interpolateConvertValue
+  interpolateRawString = B.interpolateRawString
+  interpolateAppend = B.interpolateAppend
+  interpolateEmpty = B.interpolateEmpty
 
 With this support, users can write the following:
 
@@ -611,14 +556,12 @@ With this support, users can write the following:
   {-# LANGUAGE QualifiedStrings #-}
   {-# LANGUAGE StringInterpolation #-}
 
+  import Data.Text qualified as T
   import Data.Text.Interpolate qualified as T
 
   main = do
     let name = "Alice"
     let age = 10
-
-    -- with overloaded strings
-    print $ T.toUpper s"Name: ${name}, Age: ${age}"
 
     -- with qualified strings
     print $ T.toUpper T.s"Name: ${name}, Age: ${age}"
@@ -665,7 +608,7 @@ Imagine a library implements a ``SqlQuery`` type like:
   instance ToSqlValue Int where
     toSqlValue = SqlInt
 
-The library would also define a module for use with ``QualifiedStrings``:
+The library would also define a module for use with qualified string interpolations:
 
 ::
 
@@ -674,18 +617,11 @@ The library would also define a module for use with ``QualifiedStrings``:
   import Data.String qualified as S
   import Data.String.Interpolate.Experimental qualified as S
 
-  interpolateString ::
-    ( (forall a. Interpolate a => a -> SqlQuery)
-      -> (String -> SqlQuery)
-      -> (SqlQuery -> SqlQuery -> SqlQuery)
-      -> SqlQuery
-      -> SqlQuery
-    )
-    -> SqlQuery
-  interpolateString f = f convert raw mappend mempty
-    where
-      convert = interpolate
-      raw = S.fromString
+  interpolateFinalize = id
+  interpolateConvertValue = interpolate
+  interpolateRawString = fromString
+  interpolateAppend = mappend
+  interpolateEmpty = mempty
 
   class Interpolate a where
     interpolate :: a -> SqlQuery
@@ -730,23 +666,19 @@ The library could also define an implementation to support failure states:
 
 ::
 
-  module Data.SQL.Compile.Interpolate where
+  module Data.SQL.Compile.Interpolate (
+    module X,
+    interpolateFinalize,
+  ) where
 
-  import Data.SQL.Interpolate qualified as SQL
+  import Data.SQL.Interpolate as X hiding (interpolateFinalize)
 
-  interpolateString ::
-    ( (forall a. ToSqlValue a => a -> SqlQuery)
-      -> (String -> SqlQuery)
-      -> (SqlQuery -> SqlQuery -> SqlQuery)
-      -> SqlQuery
-      -> SqlQuery
-    )
-    -> Either ParseError CompiledSqlQuery
-  interpolateString = compileQuery . SQL.interpolateString
+  interpolateFinalize :: SqlQuery -> Either ParseError CompiledSqlQuery
+  interpolateFinalize = compileQuery
 
 ::
 
-  import Data.SQL.Interpolate qualified as SQL
+  import Data.SQL.Compile.Interpolate qualified as SQL
 
   main = do
     let name = "Alice"
@@ -780,17 +712,14 @@ That library could define the module:
 
   module Data.HTML.Interpolate where
 
+  import Data.HTML as HTML
   import Data.String.Interpolate.Experimental qualified as S
 
-  interpolateString ::
-    ( (forall a. Interpolate a => a -> Html)
-      -> (String -> Html)
-      -> (Html -> Html -> Html)
-      -> Html
-      -> Html
-    )
-    -> Html
-  interpolateString f = f interpolate raw mappend mempty
+  interpolateFinalize = id
+  interpolateConvertValue = interpolate
+  interpolateRawString = HTML.raw
+  interpolateAppend = mappend
+  interpolateEmpty = mempty
 
   class Interpolate a where
     interpolate :: a -> Html
@@ -822,15 +751,11 @@ String interpolation could also make it easier to implement `shows`, in a module
 
   module Data.ShowS.Interpolate (P (..), interpolateString) where
 
-  interpolateString ::
-    (  (forall a. Show a => a -> ShowS)
-      -> (String -> ShowS)
-      -> (ShowS -> ShowS -> ShowS)
-      -> ShowS
-      -> ShowS
-    )
-    -> ShowS
-  interpolateString f = f shows showString (.) id
+  interpolateFinalize = id
+  interpolateConvertValue = shows
+  interpolateRawString = showString
+  interpolateAppend = (.)
+  interpolateEmpty = id
 
   data P a = P !Int !a
   instance Show a => Show (P a) where
@@ -873,7 +798,7 @@ And be able to use it in interpolated strings:
   let n = BigDecimal 123456 3
   s"123456 / 10^3 = ${n}" == "123456 / 10^3 = 123.456"
 
-If ``text`` is implemented as described in *Section 10.4 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text`` for free.
+If ``text`` is implemented as described in *Section 10.3 Custom interpolator: Text*, ``BigDecimal`` can interpolate into ``Text.s"..."`` for free.
 
 Format specifiers
 ~~~~~~~~~~~~~~~~~
@@ -885,7 +810,7 @@ Python is famous for being able to specify format specifiers when interpolating 
   x = 1.2
   f"{x:.3f}" == "1.200"
 
-This would be provided by libraries, and the design and implementation of those libraries is not specified here. But from a user perspective, here's one possible way such a library could be used:
+This could be provided by libraries with the proposed machinery, and the design and implementation of those libraries is left as an exercise for the reader. But from a user perspective, here's one possible way such a library could be used:
 
 ::
 
@@ -916,32 +841,39 @@ Where these would return the strings:
 Alternative - Polymorphic interpolable expansion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Current proposal - built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsString``:
+Alternate 1: Built-in ``s"..."`` is hardcoded and is only polymorphic on ``IsString``:
 
 ::
 
     -- Desugared expression for M.s"age: ${age}"
     --
     -- s"..." is equivalent to Data.String.Interpolate.s"..."
-    M.interpolateString $ \convert raw append empty ->
-               raw "age: "
-      `append` convert age
-      `append` empty
+    M.finalize $
+                 M.raw "age: "
+      `M.append` M.convert age
+      `M.append` M.empty
 
     {----- Data.String.Interpolate -----}
 
-    -- Conceptually, think of this as a more performant version of:
-    --   fromString $ raw "age: " <> convert age
-    interpolateString f = mconcat $ f convert raw (:) []
-      where
-        convert = fromString . interpolate
-        raw = id
+    finalize :: Monoid s => [s] -> s
+    finalize = mconcat
+
+    raw :: IsString s => String -> s
+    raw = fromString
+
+    convert :: Interpolate a => a -> s
+    convert x = fromString $ interpolateS x ""
+
+    append :: s -> [s] -> [s]
+    append = (:)
+
+    empty :: [s]
+    empty = []
 
     -- One instance for all user-defined types; e.g. the `url` library
-    -- would just need to implement
-    --   Interpolate URL
+    -- would just need to implement `Interpolate URL`
     class Interpolate a where
-      interpolate :: a -> String
+      interpolateS :: a -> ShowS
 
     {----- Text library: s"..." :: Text -----}
 
@@ -953,29 +885,32 @@ Current proposal - built-in ``s"..."`` is hardcoded and is only polymorphic on `
 
     -- | Text, except only support interpolating Text values
     newtype SimpleText = SimpleText Text
+      deriving newtype (Semigroup, Monoid)
 
-    interpolateString f = f convert raw mappend mempty
-      where
-        convert = SimpleText
-        raw = SimpleText . Text.pack
+    convert :: Text -> SimpleText
+    convert = SimpleText
 
-Built-in ``s"..."`` with polymorphic builder:
+    finalize = mconcat
+    raw = SimpleText . Text.pack
+    append = (:)
+    empty = []
+
+Alternate 2: Built-in ``s"..."`` with polymorphic builder:
 
 ::
 
     -- Desugared expression for M.s"age: ${age}"
     --
     -- s"..." is equivalent to Data.String.Interpolate.s"..."
-    M.finalize
-      (            M.raw "age: "
-        `M.append` M.convert age
-        `M.append` M.empty
-      )
+    M.finalize $
+                 M.raw "age: "
+      `M.append` M.convert age
+      `M.append` M.empty
 
     {----- Data.String.Interpolate -----}
 
     class Interpolable s where
-      type Builder s
+      type Builder s = b | b -> s
       raw      :: String -> Builder s
       append   :: Builder s -> Builder s -> Builder s
       empty    :: Builder s
@@ -985,39 +920,41 @@ Built-in ``s"..."`` with polymorphic builder:
       convert :: a -> builder
 
     instance Interpolable String where
-      type Builder String = String
-      raw = id
-      append = (++)
-      empty = []
-      finalise = id
+      type Builder String = ShowS
+      raw = fromString
+      append = (.)
+      empty = id
+      finalise = ($ "")
 
-    instance Interpolate String String where
-      convert = id
-    instance Interpolate Int String where
-      convert = show
+    instance Interpolate String ShowS where
+      convert = fromString
+    instance Interpolate Int ShowS where
+      convert = shows
     -- ...
 
     {----- Text library: s"..." :: Text -----}
 
     instance Interpolable Text where
-      type Builder Text = TextBuilder
+      type Builder Text = Text.Builder
       raw = Text.Builder.fromText
       append = mappend
       empty = mempty
       finalise = Text.toStrict . Text.Builder.toLazyText
 
-    instance Interpolate String Text where
-      convert = Text.pack
-    instance Interpolate Int Text where
-      convert = Text.pack . show
+    instance Interpolate String Text.Builder where
+      convert = Text.Builder.fromString
+    instance Interpolate Int Text.Builder where
+      convert = Text.Builder.decimal
     -- ...
 
     {----- User-defined SimpleText: SimpleText.s"..." -----}
 
     -- | Text, except ONLY support interpolating Text values.
+    --
     -- Avoid `Interpolate` class, since we can't forbid someone
     -- from adding a new `Interpolate Foo SimpleText` instance.
     newtype SimpleText = SimpleText Text
+      deriving newtype (Semigroup, Monoid)
 
     convert = Text.Builder.fromText
     raw = Text.Builder.fromText
@@ -1025,7 +962,7 @@ Built-in ``s"..."`` with polymorphic builder:
     empty = mempty
     finalize = SimpleText . Text.toStrict . Text.Builder.toLazyText
 
-Downsides of alternative approach:
+Downsides of Alternate 2 compared to Alternate 1:
 
 * All types that can be interpolated (e.g. a ``URL`` type) must have an instance for each string-like type it can be interpolated within:
 
@@ -1034,8 +971,8 @@ Downsides of alternative approach:
     * ``Interpolate URL ByteString``
     * ...
 
-  The current proposal only needs to implement one ``Interpolate URL``. May be less performant, since we're always going via ``String`` instead of a potentially more efficient conversion (e.g. going straight to ``Text``), but it's a good default.
+  Alternate 1 only needs to implement one ``Interpolate URL``. May be less performant, since we're always going via ``String`` instead of a potentially more efficient conversion (e.g. going straight to ``Text``), but it's a good default.
 
 * All string-like types _must_ implement their own instance, e.g. ``Interpolable Text``, and _must_ implement ``Interpolate`` instances for all built-in types.
 
-  The current proposal will automatically work for any ``IsString`` type. Types _may_ implement their own custom interpolation with qualified string interpolation, but that's not a requirement (although recommended, to monomorphize the default interpolation).
+  Alternate 1 will automatically work for any ``IsString`` type. Types _may_ implement their own custom interpolation with qualified string interpolation, but that's not a requirement (although recommended, to monomorphize the default interpolation).

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -467,14 +467,21 @@ Delimiter-related Alternatives
   * Could reuse QuasiQuote syntax, e.g. ``[s|`` or ``[fmt|``, except it would be special and NOT use Template Haskell.
   * Could do ``''...''``, since ``''`` is invalid Haskell syntax today. However, code highlighters that aren't updated for ``-XStringInterpolation`` yet would not gracefully handle this.
 
-* No delimiter, always interpolate
+* No quote delimiter, always interpolate
 
   * Would require any use of ``${...}`` to be escaped.
   * No other language does this; even Bash has single quoted strings to avoid escaping
 
 * Different interpolation delimiter, e.g. ``#{foo}``
 
-  * Most languages use ``$``, and I see no reason to deviate
+  * ``${`` is familiar to most developers
+
+* No interpolation delimiter, e.g. ``{foo}``, like Python/Rust, escape with ``\{``
+
+  * One less character for the "common" case where interpolation typically doesn't happen in strings containing ``{``
+  * It would make interpolating into JSON, LaTeX, etc. more annoying
+  * It would make interpolating into code more annoying (e.g. shell, C-like languages, Haskell code with records)
+  * ``{`` is more likely to come up than ``${``
 
 * Allow custom delimiters, which could be defined with Template Haskell or some other approach
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -202,13 +202,13 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateRaw :: IsString s => String -> s
   interpolateRaw = fromString
 
-  interpolateValue :: (Interpolate a, IsString s, Monoid s) => a -> s
+  interpolateValue :: (Interpolate a, InterpolateBuilder b) => a -> b
   interpolateValue = interpolate
 
   interpolateAppend :: Monoid s => s -> s -> s
   interpolateAppend = mappend
 
-  infixr 6 interpolateAppend -- matches (<>)
+  infixr 6 `interpolateAppend` -- matches (<>)
 
   interpolateEmpty :: Monoid s => s
   interpolateEmpty = mempty
@@ -225,9 +225,6 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
     buildInterpolator :: InterpolatorBuilderFor s -> s
 
   class (IsString b, Monoid b, Interpolator b) => InterpolatorBuilder b where
-    interpolateString :: String -> b
-    interpolateString = fromString
-
     interpolateIntegral :: (Integral a, Show a) => a -> b
     interpolateIntegral = fromString . show
 
@@ -235,13 +232,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
     interpolateRealFloat = fromString . show
 
   class Interpolate a where
-    {-# MINIMAL interpolate | interpolatePrec #-}
-
-    interpolate :: (InterpolatorBuilder b) => a -> b
-    interpolate = interpolatePrec 0
-
-    interpolatePrec :: (InterpolatorBuilder b) => Int -> a -> b
-    interpolatePrec _ = interpolate
+    interpolate :: InterpolatorBuilder b => a -> b
 
   {----- StringBuilder -----}
 
@@ -263,9 +254,9 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   {----- Interpolation of values -----}
 
   instance Interpolate String where
-    interpolate = interpolateString
+    interpolate = fromString
   instance Interpolate Char where
-    interpolate c = interpolateString [c]
+    interpolate c = fromString [c]
 
   instance Interpolate Int where
     interpolate = interpolateIntegral
@@ -276,11 +267,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   instance Interpolate Float where
     interpolate = interpolateRealFloat
   instance Interpolate Bool where
-    interpolate = interpolateString . show
-
-  instance Interpolate a => Interpolate (Maybe a) where
-    interpolate Nothing = interpolateString "Nothing"
-    interpolate (Just a) = interpolate a
+    interpolate = fromString . show
 
 Types may implement ``Interpolate`` either using the functions in ``InterpolatorBuilder``, ``Monoid``, or using ``s"..."`` itself; see *Section 3.2 Composite types* for an example.
 
@@ -295,7 +282,7 @@ With the machinery defined above, the following interpolated string desugars to 
   s"foo ${f a b} bar ${g x} baz ${name}"
 
   -- desugared
-  interpolateFinalize $
+  interpolateFinalize @String $
     interpolateRaw "foo "   `interpolateAppend`
     interpolateValue (f a b)`interpolateAppend`
     interpolateRaw " bar "  `interpolateAppend`
@@ -303,7 +290,6 @@ With the machinery defined above, the following interpolated string desugars to 
     interpolateRaw " baz "  `interpolateAppend`
     interpolateValue name   `interpolateAppend`
     interpolateEmpty
-    :: String
 
 Namely:
 
@@ -347,7 +333,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
 OverloadedStrings
 ~~~~~~~~~~~~~~~~~
 
-When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding ``Interpolator`` + ``InterpolatorBuilder`` instances.
+When ``-XOverloadedStrings`` is enabled, ``@String`` is *not* included. The only requirement needed for string interpolation for working on a string type is adding ``Interpolator`` + ``InterpolatorBuilder`` instances.
 
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
@@ -374,7 +360,7 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, wh
     SQL.interpolateValue age                                 `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
-When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
+When ``-XQualifiedStrings`` is enabled, ``@String`` is *not* included.
 
 Qualified string interpolators should specify a fixity for ``interpolateAppend``, or else the default ``infixl 9`` fixity will be used.
 
@@ -556,9 +542,9 @@ Expansion-related Alternatives
 * Hardcode to Monoid's ``mappend`` and ``mempty``
 
   * Would remove potential use-cases needing type-changing ``append``, e.g. ``a -> [a] -> [a]`` or ``f a -> f as -> f (a ': as)``
-  * It's likely that most custom ``interpolateString`` will use ``Monoid``, but we should avoid restricting the interface here
+  * It's likely that most custom interpolators will implement ``interpolateAppend``/``interpolateEmpty`` with ``Monoid``, but we should avoid restricting the interface here
 
-* Use ``M.fromString`` instead of ``interpolateStringRaw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
+* Use ``M.fromString`` instead of ``interpolateRaw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
 
   * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementions *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
   * Even if we hardcoded ``fromString``, one could still devise a custom string interpolator that's inconsistent with ``M.fromString``; e.g. ``interpolateFinalize _ = "bad"``
@@ -669,7 +655,7 @@ As part of the feature, ``ghc-experimental`` will provide ``Data.String.Interpol
   interpolateEmpty = id
   interpolateFinalize = id
 
-  infixr 9 interpolateAppend
+  infixr 9 `interpolateAppend`
 
   data P a = P !Int !a
   instance Show a => Show (P a) where
@@ -706,7 +692,7 @@ After implementing ``Interpolator``, ``text`` should already have a decently per
       interpolateRealFloat = LazyText.realFloat
 
     instance Interpolate Text where
-      interpolate = interpolateString . Text.unpack
+      interpolate = fromString . Text.unpack
 
 With this support, users can write the following:
 
@@ -783,7 +769,7 @@ The library would also define a module for use with ``-XStringInterpolation`` + 
   interpolateEmpty = mempty
   interpolateFinalize = id
 
-  infixr 6 interpolateAppend
+  infixr 6 `interpolateAppend`
 
   class Interpolate a where
     interpolate :: a -> SqlQuery
@@ -883,7 +869,7 @@ That library could define the module:
   interpolateEmpty = mempty
   interpolateFinalize = id
 
-  infixr 6 interpolateAppend
+  infixr 6 `interpolateAppend`
 
   class Interpolate a where
     interpolate :: a -> Html
@@ -915,10 +901,10 @@ Imagine a library implements a new ``BigDecimal`` type:
 
   data BigDecimal = BigDecimal Integer Int
 
-  renderBigDecimal :: (InterpolatorBuilder s) => BigDecimal -> s
+  renderBigDecimal :: (IsString s) => BigDecimal -> s
   renderBigDecimal (BigDecimal digits scale) =
     let (int, frac) = splitAt scale (show digits)
-     in interpolateString $ int <> "." <> frac
+     in fromString $ int <> "." <> frac
 
 That library could define:
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -211,8 +211,26 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   interpolateEmpty :: Monoid s => s
   interpolateEmpty = mempty
 
-  interpolateFinalize :: s -> s
-  interpolateFinalize = id
+  interpolateFinalize :: StringInterpolator s => InterpolatorBuilder s -> s
+  interpolateFinalize = buildInterpolator
+
+  {----- String interpolator -----}
+
+  class
+    ( IsString (InterpolatorBuilder s)
+    , Monoid (InterpolatorBuilder s)
+    ) => StringInterpolator s where
+    type InterpolatorBuilder s
+    buildInterpolator :: InterpolatorBuilder s -> s
+
+  newtype StringBuilder = StringBuilder (Endo String)
+    deriving newtype (Semigroup, Monoid)
+  instance IsString StringBuilder where
+    fromString s = StringBuilder (Endo (s <>))
+
+  instance StringInterpolator String where
+    type InterpolatorBuilder String = StringBuilder
+    buildInterpolator (StringBuilder (Endo f)) = f ""
 
   {----- Interpolation of values -----}
 
@@ -241,7 +259,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
     interpolatePrec _ Nothing = fromString "Nothing"
     interpolatePrec d (Just a) = fromString "Just " <> paren (interpolatePrec 11 a)
       where
-        paren s = if d > 10 then fromString "(" <> s <> fromString ")"
+        paren s = if d > 10 then fromString "(" <> s <> fromString ")" else s
 
 Primitive types should typically implement ``interpolate`` using ``fromString``. Going through ``String`` is unavoidable without making ``Interpolate`` a multi param type class and introducing type ambiguity. But composite types will be able to avoid going through ``String``; see *Section 3.2 Composite types* for an example.
 
@@ -278,7 +296,7 @@ Namely:
 
 * The entire expression is explicitly typed as ``String``, to monomorphize the expression when ``-XOverloadedStrings`` is not enabled
 
-  * Related: *Section 4.1 QualifiedStrings* and *Section 4.2 OverloadedStrings*
+  * Related: *Section 4.1 OverloadedStrings* and *Section 4.2 QualifiedStrings*
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
@@ -357,6 +375,11 @@ An existing program containing ``s"..."`` will break when ``-XStringInterpolatio
 #. Easily mitigatable: just add a space, which improves readability anyway
 #. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
 
+OverloadedStrings
+~~~~~~~~~~~~~~~~~
+
+When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. The only requirement needed for string interpolation for working on a string type is adding a ``StringInterpolator`` instance.
+
 QualifiedStrings
 ~~~~~~~~~~~~~~~~
 
@@ -384,7 +407,7 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation:
 
 When ``-XQualifiedStrings`` is enabled, ``:: String`` is _not_ included.
 
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator would probably be implemented as:
+It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator should simply be a monomorphized version of the default interpolator:
 
 ::
 
@@ -395,8 +418,9 @@ It's highly recommended that every string type with an ``IsString`` instance pro
 
     import Data.String.Experimental as X hiding (interpolateFinalize)
 
+    -- MyString would already implement StringInterpolator for OverloadedStrings
     interpolateFinalize :: MyStringBuilder -> MyString
-    interpolateFinalize = buildMyString
+    interpolateFinalize = buildInterpolator
 
 The only recommendation here is that ``MyString`` provide a module implementing string interpolation using the built-in ``Data.String.Experimental.Interpolate`` type class. Of course, ``MyString`` is free to implement more string interpolators, potentially using its own ``MyString.Interpolate`` type class for more performant interpolations.
 
@@ -404,11 +428,6 @@ The following laws should hold, if the expression compiles:
 
 * ``M."str" == M.s"str"``
 * ``Data.String.fromString "str" == M.s"str"``
-
-OverloadedStrings
-~~~~~~~~~~~~~~~~~
-
-When ``-XOverloadedStrings`` is enabled, ``:: String`` is _not_ included. Since the functions in ``Data.String.Experimental`` are polymorphic over ``(IsString s, Monoid s)``, it should automatically pick up the overloaded type.
 
 MultilineStrings
 ~~~~~~~~~~~~~~~~
@@ -562,21 +581,29 @@ Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototyp
 Text
 ~~~~
 
-As mentioned in *Section 4.1 QualifiedStrings*, ``text`` should provide interpolator(s) using the built-in ``Interpolate`` class, but it may optionally also provide interpolator(s) with its own ``Interpolate`` class, if it wants an option to interpolate straight to ``Builder`` (e.g. ``interpolate @Int = Builder.decimal``). For all of these interpolators, whichever ``Interpolate`` class they want to use, they should probably always build with ``Builder``:
+After implementing ``StringInterpolator``, ``text`` should already have a decently performant interpolation using the default interpolation. As mentioned in *Section 4.2 QualifiedStrings*, ``text`` should provide interpolators that are simply the monomorphized versions of the default interpolator for ``Text``, ``LazyText``, and ``Builder``.
+
+However, the default interpolator forces primitive types to interpolate via ``String``, which might be inefficient. So ``text`` might be interested in providing additional interpolators using a new ``Text.Interpolate`` class providing ``interpolate :: a -> Builder``:
 
 ::
 
-    -- Data.Text.Interpolate.Builder
+    {----- Data.Text.Interpolate.Builder -----}
+
+    class Interpolate a where
+      interpolate :: a -> Builder
+
     interpolateRaw = fromString
-    interpolateValue = interpolate -- Either built-in Interpolate or new Builder.Interpolate
+    interpolateValue = interpolate
     interpolateAppend = mappend
     interpolateEmpty = mempty
-    interpolateFinalize = id
+    interpolateFinalize = interpolate
 
-    -- Data.Text.Interpolate.Lazy; re-exports everything else from Builder
+    {----- Data.Text.Interpolate.Lazy; re-exports everything else from Builder -----}
+
     interpolateFinalize = Builder.toLazyText
 
-    -- Data.Text.Interpolate; re-exports everything else from Builder
+    {----- Data.Text.Interpolate; re-exports everything else from Builder -----}
+
     interpolateFinalize = LazyText.toStrict . Builder.toLazyText
 
 With this support, users can write the following:

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -249,7 +249,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   instance Interpolate Bool where
     interpolate = fromString . show
 
-Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``; see `Section 3.2 Composite types <#32composite-types>`_ for an example. The default interpolator will only ever use this as ``s ~ StringBuilder``, but this allows other qualified interpolators to reuse the built-in ``Interpolate`` class and avoid roundtripping through ``String`` in certain instances.
+Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``. The default interpolator will only ever use this as ``s ~ StringBuilder``, but this allows other qualified interpolators to reuse the built-in ``Interpolate`` class and avoid roundtripping through ``String`` in certain instances. See `Section 3.2 Composite types <#32composite-types>`_ for an example and additional details.
 
 Expansion
 ~~~~~~~~~
@@ -271,9 +271,11 @@ With the machinery defined above, the following interpolated string desugars to 
     interpolateValue name   `interpolateAppend`
     interpolateEmpty
 
-Namely:
+To be more precise, the tokens parsed in `Section 2.2 Context-Free Syntax <#22context-free-syntax>`_ will be expanded as follows:
 
 * An ``istringRaw`` component expands to ``interpolateRaw "<istringRaw>"``
+
+  * ``<istringRaw>`` refers to the string literal stored in the ``istringRaw`` token
 
   * The string literal passed to ``interpolateRaw`` is a strict ``String`` literal, unaffected by ``-XOverloadedStrings``
 
@@ -281,40 +283,23 @@ Namely:
 
 * The list of ``istring`` components between ``istringBegin`` and ``istringEnd`` expands to the expansion of the components, with ``interpolateAppend`` as "list cons" and ``interpolateEmpty`` as "list nil".
 
-  * ``interpolateAppend`` is always right-associative
+  * The expansion is generated as right-associative; i.e. it will desugar to ``x `interpolateAppend` (y `interpolateAppend` (z `interpolateAppend` ...))`` (parentheses omitted in all the examples for clarity)
 
-  * Related: `Section 2.7 OverloadedStrings <#27overloadedstrings>`_ and `Section 2.8 QualifiedStrings <#28qualifiedstrings>`_
+  * Related: `Section 2.5.1 OverloadedStrings <#251overloadedstrings>`_ and `Section 2.5.2 QualifiedStrings <#252qualifiedstrings>`_
 
-``ghc-experimental`` modules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This proposal would be adding the following modules to ``ghc-experimental``, which would potentially be promoted to a proper library like ``base`` once the feature is stablized.
-
-.. list-table::
-    :align: left
-
-    * - **Module**
-      - **Details**
-    * - ``Data.String.Experimental``
-      - Re-exports ``Data.String.Interpolate.Class.Experimental`` and ``Data.String.Interpolate.Default.Experimental``
-    * - ``Data.String.Interpolate.Class.Experimental``
-      - Defines the ``Interpolate`` class and instances as written in `Section 2.4 Machinery <#24machinery>`_
-    * - ``Data.String.Interpolate.Default.Experimental``
-      - Defines the classes and functions for the default ``s"..."`` syntax, as written in `Section 2.4 Machinery <#24machinery>`_
-    * - ``Data.String.Interpolate.Basic.Experimental``
-      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See `Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_)
-    * - ``Data.String.Interpolate.ShowS.Experimental``
-      - Defines an interpolator useful for implementing ``showsPrec`` (See `Section 10.4 Provided interpolator: ShowS <#104provided-interpolator-shows>`_)
+The desugaring here respects ``RebindableSyntax``, so a project that wishes to use a different desugaring for the default ``s"..."`` syntax may rebind the interpolator bindings as desired.
 
 OverloadedStrings
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using ``-XQualifiedStrings`` instead.
 
 QualifiedStrings
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
-When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, where ``[modid.]s"..."`` desugars to the same expressions, except resolving the ``interpolate*`` functions as ``[modid.]interpolate*``. Some examples:
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, where ``[modid.]s"..."`` desugars to the same expressions, except resolving the ``interpolate*`` functions as ``[modid.]interpolate*``. If both ``-XOverloadedStrings`` and ``-XQualifiedStrings`` are enabled, ``-XOverloadedStrings`` is ignored for ``[modid.]s"..."`` constructs.
+
+Some examples:
 
 ::
 
@@ -337,7 +322,7 @@ When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, wh
     SQL.interpolateValue age                                 `SQL.interpolateAppend`
     SQL.interpolateEmpty
 
-It's highly recommended that every string type with an ``IsString`` instance provides at least one string interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. This interpolator could simply be a monomorphized version of the default interpolator:
+It's highly recommended that every type with an ``IsString`` instance provides at least one ``QualifiedStrings`` interpolator reusing the built-in ``Interpolate`` class. That way, there's always an option to use ``MyString.s"..."`` if the user does not wish to globally enable ``-XOverloadedStrings``. A naive implementation would simply be a monomorphized version of the default interpolator:
 
 ::
 
@@ -352,7 +337,7 @@ It's highly recommended that every string type with an ``IsString`` instance pro
     interpolateFinalize :: StringBuilder -> MyString
     interpolateFinalize = S.interpolateFinalize
 
-Or it could reuse the built-in ``Interpolate`` class using its own ``Builder`` type:
+A more sophisticated implementation could reuse the built-in ``Interpolate`` class using its own ``Builder`` type:
 
 ::
 
@@ -384,7 +369,7 @@ The following laws should hold, if the expression compiles:
 * ``Data.String.fromString "str" == M.s"str"``
 
 MultilineStrings
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 When ``-XMultilineStrings`` is enabled, string interpolation may be used with multiline strings. Multiline string interpolations resolve the multiline string first, then do the string interpolation. This means that qualified string interpolations work with multiline strings for free.
 
@@ -405,6 +390,27 @@ When ``-XMultilineStrings`` is enabled, string interpolation may be used with mu
 
   -- resolve interpolation
   let str2 = "hello world\nworld hello\nhello world"
+
+``ghc-experimental`` modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This proposal would be adding the following modules to ``ghc-experimental``, which would potentially be promoted to a proper library like ``base`` once the feature is stablized.
+
+.. list-table::
+    :align: left
+
+    * - **Module**
+      - **Details**
+    * - ``Data.String.Experimental``
+      - Re-exports ``Data.String.Interpolate.Class.Experimental`` and ``Data.String.Interpolate.Default.Experimental``
+    * - ``Data.String.Interpolate.Class.Experimental``
+      - Defines the ``Interpolate`` class and instances as written in `Section 2.4 Machinery <#24machinery>`_
+    * - ``Data.String.Interpolate.Default.Experimental``
+      - Defines the classes and functions for the default ``s"..."`` syntax, as written in `Section 2.4 Machinery <#24machinery>`_
+    * - ``Data.String.Interpolate.Basic.Experimental``
+      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See `Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_)
+    * - ``Data.String.Interpolate.ShowS.Experimental``
+      - Defines an interpolator useful for implementing ``showsPrec`` (See `Section 10.4 Provided interpolator: ShowS <#104provided-interpolator-shows>`_)
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
@@ -482,6 +488,33 @@ The ``Basic`` interpolator would be useful here, to reuse string interpolation s
           file' = interpolate file
           line' = interpolate line
           col' = interpolate col
+
+If this instance did not take advantage of the polymorphism and was implemented as ``fromString s"${file}:${line}:${col}"``, it could have a performance impact on custom interpolators, such as ``text``:
+
+::
+
+    -- Original
+    Text.s"Error at: ${loc}"
+
+    -- Desugared, staying in polymorphic `s` with `interpolate file <> ...`
+    interpolateRaw "Error at: " `interpolateAppend`
+        (interpolate file <> fromString ":" <> interpolate line <> fromString ":" <> interpolate col) `interpolateAppend`
+        interpolateEmpty
+    Text.Builder.toText $
+        fromString "Error at: " <>
+        (fromString file <> fromString ":" <> fromString (show line) <> fromString ":" <> fromString (show col)) <>
+        mempty
+
+    -- Desugared, monomorphic implementation with `fromString s"..."`
+    interpolateRaw "Error at: " `interpolateAppend`
+        fromString (interpolate file <> fromString ":" <> interpolate line <> fromString ":" <> interpolate col) `interpolateAppend`
+        interpolateEmpty
+    Text.Builder.toText $
+        fromString "Error at: " <>
+        fromString (file <> ":" <> show line <> ":" <> show col) <>
+        mempty
+
+Notice that the monomorphic implementation would concatenate the file/line/col as String and then lifting it up to TextBuilder, while the polymorphic implementation lifts file/line/col to TextBuilder immediately and concatenates as TextBuilder.
 
 Effect and Interactions
 -----------------------
@@ -708,7 +741,7 @@ Users could then write:
 Text
 ~~~~
 
-When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``StringBuilder`` then converts to ``Text`` with a final ``fromString``. As mentioned in `Section 2.8 QualifiedStrings <#28qualifiedstrings>`_, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
+When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``StringBuilder`` then converts to ``Text`` with a final ``fromString``. As mentioned in `Section 2.5.2 QualifiedStrings <#252qualifiedstrings>`_, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
 
 ::
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -962,6 +962,56 @@ And gain access to safe string interpolation with HTML escaping by default:
   HTML.s"<h1>${title}</h1>${HTML.raw body}"
     == Html "<h1>Why is 1 &gt; 0?</h1><p>Hello world</p>"
 
+Custom interpolator: Ascii
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The existing machinery is general enough to support ``-XRequiredTypeArguments``, to support interpolators with compile-time validations:
+
+::
+
+    interpolateRaw :: forall (s :: Symbol) -> (KnownSymbol s, AsciiOnly s) => String
+    interpolateRaw s = symbolVal (Proxy @s)
+
+    interpolateValue :: InterpolateAscii a => a -> String
+    interpolateValue = interpolateAscii
+
+    interpolateAppend = (<>)
+    interpolateEmpty = ""
+    interpolateFinalize = id
+
+    class InterpolateAscii a where
+      interpolateAscii :: a -> String
+    instance InterpolateAscii Int where
+      interpolateAscii = show
+
+    -- | A usable constraint that raises a nice TypeError on failure.
+    type AsciiOnly :: Symbol -> Constraint
+    type family AsciiOnly s where
+      AsciiOnly s = Unless (IsAscii s) (
+        TypeError ('Text "Symbol " ':<>: 'ShowType s ':<>: 'Text " is not ASCII-only")
+        )
+
+    type Unless :: Bool -> Constraint -> Constraint
+    type family Unless s b where
+      Unless 'True _ = ()
+      Unless 'False c = c
+
+    -- | Walk the Symbol one Char at a time via UnconsSymbol.
+    type IsAscii :: Symbol -> Bool
+    type family IsAscii s where
+      IsAscii s = IsAsciiGo (UnconsSymbol s)
+
+    type IsAsciiGo :: Maybe (Char, Symbol) -> Bool
+    type family IsAsciiGo m where
+      IsAsciiGo 'Nothing            = 'True
+      IsAsciiGo ('Just '(c, rest))  = (CharToNat c <=? 127) && IsAscii rest
+
+::
+
+    Ascii.s"this is valid: ${123 :: Int}"
+
+    -- Ascii.s"this is a type error: 🙂"
+
 Custom interpolatable type: BigDecimal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -2,14 +2,11 @@ Add native string interpolation syntax
 ======================================
 
 .. author:: Brandon Chinn
-.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
-.. ticket-url:: Leave blank. This will eventually be filled with the
-                ticket URL which will track the progress of the
-                implementation of the feature.
-.. implemented:: Leave blank. This will be filled in with the first GHC version which
-                 implements the described feature.
+.. date-accepted:: 2026-07-26
+.. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/work_items/27592
+.. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/570>`_.
+.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/570>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -101,6 +101,8 @@ If Haskell had native string interpolation, it would have the benefit and safety
 
   let textExample = s"${name1} (age: ${age1}) encountered ${name2} (age: ${age2})"
 
+.. _proposed-spec:
+
 Proposed Change Specification
 -----------------------------
 
@@ -132,7 +134,7 @@ Concretely, ``-XStringInterpolation`` enables the following syntax:
     interpolateRaw " b"      `interpolateAppend`
     interpolateEmpty
 
-These definitions will be provided by ``Data.String.Experimental``, which will be initially implemented in ``ghc-experimental``. See `Section 2.4 Machinery <#24machinery>`_ for details.
+These definitions will be provided by ``Data.String.Experimental``, which will be initially implemented in ``ghc-experimental``. See :ref:`machinery` for details.
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~
@@ -174,7 +176,9 @@ Also add ``$`` to ``charesc``:
 
 With ``$`` added to ``charesc``, interpolation can be avoided by escaping the dollar sign; e.g. ``s"\${foo}" == "${foo}"``.
 
-This grammar enables interpolating expressions with nested braces. Concretely, ``istringExprOpen`` and ``istringExprClose`` are only lexed within the ``istring`` and ``istringMultiline`` grammar productions, using Alex start codes. See `Section 3.1 Parsing <#31parsing>`_ for examples.
+This grammar enables interpolating expressions with nested braces. Concretely, ``istringExprOpen`` and ``istringExprClose`` are only lexed within the ``istring`` and ``istringMultiline`` grammar productions, using Alex start codes. See :ref:`parsing` for examples.
+
+.. _context-free-syntax:
 
 Context-Free Syntax
 ~~~~~~~~~~~~~~~~~~~
@@ -197,6 +201,8 @@ Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch
     istringMultilineBegin
       {istringMultilineRawStartLine | istringExprOpen exp istringExprClose istringMultilineRawMidLine}
       istringMultilineEnd
+
+.. _machinery:
 
 Machinery
 ~~~~~~~~~
@@ -249,7 +255,7 @@ The following code will live in ``ghc-experimental`` under ``Data.String.Experim
   instance Interpolate Bool where
     interpolate = fromString . show
 
-Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``. The default interpolator will only ever use this as ``s ~ StringBuilder``, but this allows other qualified interpolators to reuse the built-in ``Interpolate`` class and avoid roundtripping through ``String`` in certain instances. See `Section 3.2 Composite types <#32composite-types>`_ for an example and additional details.
+Types may implement ``Interpolate`` using ``IsString`` or ``Monoid``. The default interpolator will only ever use this as ``s ~ StringBuilder``, but this allows other qualified interpolators to reuse the built-in ``Interpolate`` class and avoid roundtripping through ``String`` in certain instances. See :ref:`composite-types` for an example and additional details.
 
 Expansion
 ~~~~~~~~~
@@ -271,7 +277,7 @@ With the machinery defined above, the following interpolated string desugars to 
     interpolateValue name   `interpolateAppend`
     interpolateEmpty
 
-To be more precise, the tokens parsed in `Section 2.2 Context-Free Syntax <#22context-free-syntax>`_ will be expanded as follows:
+To be more precise, the tokens parsed in :ref:`context-free-syntax` will be expanded as follows:
 
 * An ``istringRaw`` component expands to ``interpolateRaw "<istringRaw>"``
 
@@ -285,14 +291,18 @@ To be more precise, the tokens parsed in `Section 2.2 Context-Free Syntax <#22co
 
   * The expansion is generated as right-associative; i.e. it will desugar to ``x `interpolateAppend` (y `interpolateAppend` (z `interpolateAppend` ...))`` (parentheses omitted in all the examples for clarity)
 
-  * Related: `Section 2.5.1 OverloadedStrings <#251overloadedstrings>`_ and `Section 2.5.2 QualifiedStrings <#252qualifiedstrings>`_
+  * Related: :ref:`overloaded-strings` and :ref:`qualified-strings`
 
 The desugaring here respects ``RebindableSyntax``, so a project that wishes to use a different desugaring for the default ``s"..."`` syntax may rebind the interpolator bindings as desired.
+
+.. _overloaded-strings:
 
 OverloadedStrings
 ^^^^^^^^^^^^^^^^^
 
 When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using ``-XQualifiedStrings`` instead.
+
+.. _qualified-strings:
 
 QualifiedStrings
 ^^^^^^^^^^^^^^^^
@@ -404,13 +414,13 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
     * - ``Data.String.Experimental``
       - Re-exports ``Data.String.Interpolate.Class.Experimental`` and ``Data.String.Interpolate.Default.Experimental``
     * - ``Data.String.Interpolate.Class.Experimental``
-      - Defines the ``Interpolate`` class and instances as written in `Section 2.4 Machinery <#24machinery>`_
+      - Defines the ``Interpolate`` class and instances as written in :ref:`machinery`
     * - ``Data.String.Interpolate.Default.Experimental``
-      - Defines the classes and functions for the default ``s"..."`` syntax, as written in `Section 2.4 Machinery <#24machinery>`_
+      - Defines the classes and functions for the default ``s"..."`` syntax, as written in :ref:`machinery`
     * - ``Data.String.Interpolate.Basic.Experimental``
-      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See `Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_)
+      - Defines an interpolator that's the same as the default except interpolates values directly without automatic conversion with ``Interpolate`` (See :ref:`basic-interpolator`)
     * - ``Data.String.Interpolate.ShowS.Experimental``
-      - Defines an interpolator useful for implementing ``showsPrec`` (See `Section 10.4 Provided interpolator: ShowS <#104provided-interpolator-shows>`_)
+      - Defines an interpolator useful for implementing ``showsPrec`` (See :ref:`shows-interpolator`)
 
 Template Haskell
 ~~~~~~~~~~~~~~~~
@@ -419,6 +429,8 @@ We are intentionally not adding anything to Template Haskell, as one could just 
 
 Examples
 --------
+
+.. _parsing:
 
 Parsing
 ~~~~~~~
@@ -457,6 +469,8 @@ Parsing
     * - ``s"a ${b -- asdf} c"``
       - The rest of the string is commented out
 
+.. _composite-types:
+
 Composite types
 ~~~~~~~~~~~~~~~
 
@@ -478,7 +492,7 @@ Composite types
         fromString ":" <>
         interpolate col
 
-The ``Basic`` interpolator would be useful here, to reuse string interpolation syntax (`Section 10.3 Provided interpolator: Basic <#103provided-interpolator-basic>`_):
+The ``Basic`` interpolator would be useful here, to reuse string interpolation syntax (:ref:`basic-interpolator`):
 
 ::
 
@@ -525,7 +539,7 @@ An existing program containing ``s"..."`` will break when ``-XStringInterpolatio
 #. Easily mitigatable: just add a space, which improves readability anyway
 #. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
 
-Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See `Section 2 Proposed Change Specification <#2proposed-change-specification>`_ above.
+Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See :ref:`proposed-spec` above.
 
 Costs and Drawbacks
 -------------------
@@ -547,7 +561,7 @@ Alternatives
   * Pro: less likely to encounter type inference issues
   * Con: adds more noise to interpolate non-string values
   * This is what ``neat-interpolation`` does
-  * See `Section 10.1 Community Survey <#101community-survey>`_
+  * See :ref:`community-survey`
 
 * Reuse ``PrintfArg``
 
@@ -648,7 +662,7 @@ Delimiter-related Alternatives
 
 * Allow custom delimiters, which could be defined with Template Haskell or some other approach
 
-  * See `Section 10.1 Community Survey <#101community-survey>`_
+  * See :ref:`community-survey`
 
 Unresolved Questions
 --------------------
@@ -664,6 +678,8 @@ Endorsements
 Appendix
 --------
 
+.. _community-survey:
+
 Community Survey
 ~~~~~~~~~~~~~~~~
 
@@ -675,6 +691,8 @@ Performance consideration
 Strings are notorious for O(n^2) concatenations, but the current proposal builds with ``ShowS``, so it should remain linear. The only case where it might be O(n^2) is when nesting interpolated strings inside interpolated strings (although benchmarking still shows this to be linear in practice).
 
 Benchmarks: https://github.com/brandonchinn178/ghc-string-interpolation-prototypes/tree/main/bench
+
+.. _basic-interpolator:
 
 Provided interpolator: Basic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -710,6 +728,8 @@ This is particularly useful for ``Builder``, where users could explicitly conver
   render :: Person -> B.Builder
   render Person{..} = B.s"Person(name = ${B.fromLazyText name}, age = ${B.decimal age})"
 
+.. _shows-interpolator:
+
 Provided interpolator: ShowS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -741,7 +761,7 @@ Users could then write:
 Text
 ~~~~
 
-When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``StringBuilder`` then converts to ``Text`` with a final ``fromString``. As mentioned in `Section 2.5.2 QualifiedStrings <#252qualifiedstrings>`_, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
+When ``OverloadedStrings`` is enabled, the default interpolation builds up with ``StringBuilder`` then converts to ``Text`` with a final ``fromString``. As mentioned in :ref:`qualified-strings`, ``text`` should provide interpolators that reuse the built-in ``Interpolate`` class, probably using ``Builder`` to be as performant as possible:
 
 ::
 

--- a/proposals/0570-string-interpolation.rst
+++ b/proposals/0570-string-interpolation.rst
@@ -39,7 +39,7 @@ Most languages have support for interpolating variables and (usually) arbitrary 
 
     `Expected: ${x + y}, got: ${result}`
 
-This proposal proposes adding S-strings (like Scala's syntax) to Haskell.
+This proposal adds S-strings (like Scala's syntax) to Haskell.
 
 Motivation
 ----------
@@ -65,7 +65,7 @@ Most non-trivial projects build strings at some point: printing out logs, render
     Text.replace "${result}" (Text.show result) $
     "Expected: ${x + y}, got: ${result}"
 
-But each of these options leave much to be desired:
+But each of these options leaves much to be desired:
 
 * Manual interpolation (e.g. ``<>``, ``show``, ``unwords``, etc.) is annoying, especially for strings with a lot of interpolation. It's hard to see the overall structure of the string, especially when building up a ``Text``:
   ::
@@ -88,7 +88,7 @@ But each of these options leave much to be desired:
         , "(age: " <> T.pack (show age2) <> ")"
         ]
 
-* ``printf`` is partial and unsafe, which especially safety-conscious people might always stay away from anyway. Using a safer ``printf`` like ``formatting`` induces a third-party dependency, which is admittedly lightweight, but isn't as seamless of an integration as native string interpolation would be
+* ``printf`` is partial and unsafe, which especially safety-conscious people may prefer to avoid entirely. Using a safer ``printf`` like ``formatting`` induces a third-party dependency, which is admittedly lightweight, but isn't as seamless as native string interpolation would be
 
 * Quasiquotes induces a dependency on Template Haskell, which a lot of people avoid out of principle. Most QuasiQuoters also add a dependency on ``haskell-src-exts`` to parse arbitrary Haskell expressions, which could technically be avoided by using something like ``ghc-meta`` (`repo <https://github.com/noughtmare/ghc-meta>`_, `GHC issue <https://gitlab.haskell.org/ghc/ghc/-/issues/20862>`_), but this isn't in wide use yet.
 
@@ -111,7 +111,7 @@ This proposal introduces the ``-XStringInterpolation`` extension, which enables 
 High-level Overview
 ~~~~~~~~~~~~~~~~~~~
 
-At its core, this proposal proposes the following functionality:
+At this proposal's core, the following functionality is added:
 
 * The syntax ``s"age: ${age}"`` expands to a built-in implementation using a new ``Interpolate`` type class to interpolate values such as ``age``
 
@@ -119,7 +119,9 @@ At its core, this proposal proposes the following functionality:
 
   * Same technique as ``-XQualifiedStrings``
 
-* ``s"..."`` is exactly equivalent to ``Data.String.Experimental.s"..."``, where ``Data.String.Experimental`` is a new module in ``ghc-experimental``.
+* ``s"..."`` expands to ``Data.String.Experimental.s"..."``, where ``Data.String.Experimental`` is a new module in ``ghc-experimental``.
+
+  * The expansion is slightly modified when ``-XOverloadedStrings`` is enabled; see :ref:`overloaded-strings`
 
 Concretely, ``-XStringInterpolation`` enables the following syntax:
 
@@ -207,7 +209,7 @@ Update `Section 10.5 <https://www.haskell.org/onlinereport/haskell2010/haskellch
 Machinery
 ~~~~~~~~~
 
-The following code will live in ``ghc-experimental`` under ``Data.String.Experimental``. After the API has stablized, these might eventually live in ``base`` under ``Data.String``, alongside ``IsString``.
+The following code will live in ``ghc-experimental`` under ``Data.String.Experimental``. After the API has stabilized, these might eventually live in ``base`` under ``Data.String``, alongside ``IsString``.
 
 ::
 
@@ -300,14 +302,14 @@ The desugaring here respects ``RebindableSyntax``, so a project that wishes to u
 OverloadedStrings
 ^^^^^^^^^^^^^^^^^
 
-When ``-XOverloadedStrings`` is enabled, a final ``fromString`` is added after the ``interpolateFinalize`` call. This still constructs the string with ``StringBuilder`` -> ``String``, so users might prefer using ``-XQualifiedStrings`` instead.
+When ``-XOverloadedStrings`` is enabled, ``s"..."`` expands to ``fromString (Data.String.Experimental.s"...")`` instead. Note this still constructs the string via ``StringBuilder`` -> ``String`` before converting, so users wanting to avoid the intermediate ``String`` should prefer using ``-XQualifiedStrings`` instead.
 
 .. _qualified-strings:
 
 QualifiedStrings
 ^^^^^^^^^^^^^^^^
 
-When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, where ``[modid.]s"..."`` desugars to the same expressions, except resolving the ``interpolate*`` functions as ``[modid.]interpolate*``. If both ``-XOverloadedStrings`` and ``-XQualifiedStrings`` are enabled, ``-XOverloadedStrings`` is ignored for ``[modid.]s"..."`` constructs.
+When ``-XQualifiedStrings`` is enabled, you may qualify string interpolation, where ``[modid.]s"..."`` desugars to the same expressions, except resolving the ``interpolate*`` functions as ``[modid.]interpolate*``. ``[modid.]s"..."`` is unaffected by ``-XOverloadedStrings`` because the latter applies only to the non-qualified form ``s"..."``.
 
 Some examples:
 
@@ -404,7 +406,7 @@ When ``-XMultilineStrings`` is enabled, string interpolation may be used with mu
 ``ghc-experimental`` modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This proposal would be adding the following modules to ``ghc-experimental``, which would potentially be promoted to a proper library like ``base`` once the feature is stablized.
+This proposal would be adding the following modules to ``ghc-experimental``, which would potentially be promoted to a proper library like ``base`` once the feature is stabilized.
 
 .. list-table::
     :align: left
@@ -425,7 +427,7 @@ This proposal would be adding the following modules to ``ghc-experimental``, whi
 Template Haskell
 ~~~~~~~~~~~~~~~~
 
-We are intentionally not adding anything to Template Haskell, as one could just build the expression themselves. String interpolation is still supported in quotes, which will be desugared when translating to TH.
+We are intentionally not adding anything to Template Haskell, as one could just build the expansion directly. String interpolation is still supported in quotes, which will be desugared when translating to TH.
 
 Examples
 --------
@@ -528,7 +530,7 @@ If this instance did not take advantage of the polymorphism and was implemented 
         fromString (file <> ":" <> show line <> ":" <> show col) <>
         mempty
 
-Notice that the monomorphic implementation would concatenate the file/line/col as String and then lifting it up to TextBuilder, while the polymorphic implementation lifts file/line/col to TextBuilder immediately and concatenates as TextBuilder.
+Notice that the monomorphic implementation would concatenate the file/line/col as String and then lift it up to Text.Builder, while the polymorphic implementation lifts file/line/col to Text.Builder immediately and concatenates as Text.Builder.
 
 Effect and Interactions
 -----------------------
@@ -536,15 +538,15 @@ Effect and Interactions
 An existing program containing ``s"..."`` will break when ``-XStringInterpolation`` is enabled. While there's precedent for this (Template Haskell splices make ``$(...)`` different from ``$ (...)``), this is the first instance where whitespace matters for an alphanumeric identifier. But this is not a big deal:
 
 #. It's unlikely for someone to be naming a function as ``s`` in the first place
-#. Easily mitigatable: just add a space, which improves readability anyway
-#. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, Javascript/Typescript, etc. so it shouldn't be a big hurdle for newcomers
+#. Easy to mitigate: just add a space, which improves readability anyway
+#. Prefixing string literals like ``s"..."`` is common in other languages: Python, Scala, JavaScript/TypeScript, etc. so it shouldn't be a big hurdle for newcomers
 
 Interacts nicely with ``-XOverloadedStrings``, ``-XQualifiedStrings``, and ``-XMultilineStrings``. See :ref:`proposed-spec` above.
 
 Costs and Drawbacks
 -------------------
 
-Development and maintenance is of moderate effort. Learnability for novice users will go up, since novice users probably expect string interpolation to be available, and might be frustrated at the lack of support currently.
+Development and maintenance are of moderate effort. Learnability for novice users will go up, since novice users probably expect string interpolation to be available, and might be frustrated at the lack of support currently.
 
 One minor drawback is the whitespace sensitivity of ``s"``, as discussed in "Effect and Interactions".
 
@@ -615,7 +617,7 @@ Expansion-related Alternatives
 
 * Use ``M.fromString`` instead of ``interpolateRaw``, to more tightly connect ``StringInterpolation`` with ``QualifiedStrings``
 
-  * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementions *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
+  * While ``QualifiedStrings`` and ``StringInterpolation`` are closely related, and implementations *ought* to implement them consistently, the language feature should not enforce it, in the same way that typeclass laws are not enforced by the language
   * Even if we hardcoded ``fromString``, one could still devise a custom string interpolator that's inconsistent with ``M.fromString``; e.g. ``interpolateFinalize _ = "bad"``
 
 * Hardcode a wired-in ``Interpolate`` class with ``interpolateValue`` (and potentially ``interpolateRaw``)
@@ -633,7 +635,7 @@ Delimiter-related Alternatives
 
 * Allow ``$foo`` in addition to ``${foo}``
 
-  * This would complicate the syntax, and would also require interpolated string to escape bare ``$``.
+  * This would complicate the syntax, and would also require interpolated strings to escape bare ``$``.
 
 * Different quote delimiter
 
@@ -645,7 +647,7 @@ Delimiter-related Alternatives
 
 * No quote delimiter, always interpolate
 
-  * e.g. if we switch the delimiter to `\{...}`, which is currently invalid in a string
+  * e.g. if we switch the delimiter to ``\{...}``, which is currently invalid in a string
   * Used by `jq <https://jqlang.org/manual/#string-interpolation>`_
   * Downside is that you have to parse the string before figuring out how it should be desugared
 

--- a/proposals/0723-qualified-strings.rst
+++ b/proposals/0723-qualified-strings.rst
@@ -131,12 +131,19 @@ It is highly recommended that all types with ``IsString`` instances include a to
   instance S.IsString MyString where
     fromString = ...
 
-  -- Alternatively, this can be defined in aonther
+  -- Alternatively, this can be defined in another
   -- module like Data.MyString.Qualified
   fromString :: String -> MyString
   fromString = S.fromString
 
 Qualified multiline strings are only allowed if ``-XMultilineStrings`` is enabled. Qualified multiline strings are desugared to single line strings first, then desugared as a qualified string literal. See `Multiline Strings <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0569-multiline-strings.rst>`_ for more information.
+
+Laws
+~~~~
+
+If the following expression typechecks, it should hold:
+
+* ``Data.String.fromString "str" == M."str"``
 
 Lexical Structure
 ~~~~~~~~~~~~~~~~~

--- a/proposals/0723-qualified-strings.rst
+++ b/proposals/0723-qualified-strings.rst
@@ -141,7 +141,7 @@ Qualified multiline strings are only allowed if ``-XMultilineStrings`` is enable
 Laws
 ~~~~
 
-If the following expression typechecks, it should hold:
+If the following expression compiles, it should hold:
 
 * ``Data.String.fromString "str" == M."str"``
 


### PR DESCRIPTION
The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0570-string-interpolation.rst) has been accepted; the following discussion is mostly of historic interest.

---

## Status

* GHC branch with prototype: [`wip/interpolated-strings`](https://gitlab.haskell.org/ghc/ghc/-/compare/wip%2Fstrings...wip%2Finterpolated-strings?from_project_id=1&straight=false)
* Opened CLC proposal: https://github.com/haskell/core-libraries-committee/issues/416
* Last major revision: May 15 2026
* HIW 2026 slides: https://brandonchinn178.github.io/presentations/2026-06-05-hiw-string-interpolation.html

## Related discussions

* #569
* https://gitlab.haskell.org/ghc/ghc/-/issues/20862
* https://www.reddit.com/r/haskell/comments/i3f3ip/state_of_string_interpolation_in_haskell/