### PR TITLE
Namespace-specified imports

### DIFF
--- a/proposals/0000-namespace-specified-imports.rst
+++ b/proposals/0000-namespace-specified-imports.rst
@@ -1,0 +1,554 @@
+Namespace-specified imports
+===========================
+
+.. author:: Adam Gundry, Artyom Kuznetsov, Chris Dornan
+.. date-accepted::
+.. ticket-url::
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/581>`_.
+.. sectnum::
+.. contents::
+
+This proposal supports users who wish to write code without relying on punning,
+by allowing imports to be limited to either the type or data namespace.
+Moreover it clarifies the specification of ``ExplicitNamespaces`` and related
+extensions.
+
+This topic has been discussed at length previously (see in particular `proposal
+#214 <https://github.com/ghc-proposals/ghc-proposals/pull/214>`_, `proposal #236
+<https://github.com/ghc-proposals/ghc-proposals/pull/236>`_ and `proposal #270
+<https://github.com/ghc-proposals/ghc-proposals/pull/270>`_).  The current
+proposal draws heavily from this previous work and benefits from efforts to
+address these issues by Richard Eisenberg, Artyom Kuznetsov and Vladislav
+Zavialov (amongst others).  This proposal is an attempt to systematise previous
+ideas around ``ExplicitNamespaces`` and namespace-specified imports, primarily
+from `proposal #270 <https://github.com/ghc-proposals/ghc-proposals/pull/270>`_.
+In order to keep it narrowly focused, it does not address warnings for the use
+of punning (since those are covered by `proposal #270
+<https://github.com/ghc-proposals/ghc-proposals/pull/270>`_) nor changes outside
+of import/exports.
+
+
+Motivation
+----------
+
+Background
+~~~~~~~~~~
+
+Haskell has two namespaces:
+
+* the *type namespace*, including the names of type constructors, type
+  synonyms, type families and type classes;
+
+* the *data namespace*, including the names of term-level values, functions,
+  data constructors and pattern synonyms.
+
+This separation allows us to define data constructors and type
+constructors whose names coincide:
+
+.. code:: haskell
+
+   data T = T
+
+(Similarly, with the ``TypeOperators`` extension it is possible to define
+term-level operators and type families whose names coincide.)
+
+At use sites, GHC infers which ``T`` is referred to from the context:
+
+.. code:: haskell
+
+   t :: T  -- type-level T
+   t = T   -- term-level T
+
+The use of identical names for type-level and term-level entities is called
+*punning*.  Haskell makes heavy use of punning in its built-in syntax and common
+types.
+
+However, there are various contexts in which an occurrence of a name may refer
+either to the type namespace or the data namespace, and it is not always clear
+which is meant. In particular, the following may mention both type-level and
+term-level entities:
+
+* Import and export lists
+
+* Fixity declarations
+
+* ``WARNING``, ``DEPRECATED`` and ``ANN`` pragmas
+
+* Types, when using the ``DataKinds`` extension to reference a data constructor
+  at the type level
+
+* Template Haskell name quotes
+
+The simplest way to avoid namespace ambiguity is to avoid punning entirely, so
+there is no need for the context to determine which namespace is meant.
+`Proposal #270 <https://github.com/ghc-proposals/ghc-proposals/pull/270>`_
+introduces warnings ``-Wpuns`` and ``-Wpun-bindings`` to alert users (who opt in
+to the warnings) when they are introducing or relying on punning.
+
+However, given the pervasive use of punning in the Haskell ecosystem, even users
+who wish to avoid punning will inevitably end up importing modules which make
+use of it. Thus we need mechanisms to disambiguate the namespace on import or at
+use sites.
+
+
+Mechanisms for disambiguating puns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Various mechanisms for disambiguating punned identifiers exist already:
+
+* The ``DataKinds`` extension introduces the tick syntax (``'``) to select
+  entities from the data namespace in a type-level context:
+
+  .. code:: haskell
+
+      p1 :: Proxy T   -- Refers to the type constructor T
+      p1 = Proxy
+
+      p2 :: Proxy 'T  -- Refers to the data constructor T
+      p2 = Proxy
+
+* ``TemplateHaskell`` name quotes use ``'`` for the data namespace and ``''``
+  for the type namespace.
+
+* `Proposal #65
+  <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0065-type-infix.rst>`_
+  allows fixity declarations, ``WARNING`` and ``DEPRECATED`` pragmas to be
+  modified with a ``value`` or ``type`` namespace specifier.  (This proposal
+  has been accepted but not yet implemented at the time of writing.)
+
+* ``ANN`` pragmas refer to the data namespace by default, but may use the
+  ``type`` keyword to refer to the type namespace.
+
+* The ``ExplicitNamespaces`` extension allows the ``type`` keyword to be used
+  in an import or export list to select the type namespace, typically when
+  using ``TypeOperators`` to define an operator that would otherwise be
+  imported/exported in the data namespace.
+
+* The ``PatternSynonyms`` extension allows the ``pattern`` keyword to be used
+  in an import or export list to select the data namespace, typically when
+  referring to a pattern synonym.  (However, it may also refer to a data
+  constructor without its parent type constructor, a form of import/export
+  which is not otherwise possible.)
+
+However, the status quo has some problems:
+
+* It is confusing and inconsistent that a prefix ``'`` has one meaning in terms
+  (``TemplateHaskell`` name quotes) and a completely different meaning in types
+  (with ``DataKinds``, use the data namespace rather than the type namespace).
+
+* The data namespace is referred to by ``value`` in `proposal #65
+  <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0065-type-infix.rst>`_
+  but ``pattern`` in import/export lists when using ``PatternSynonyms``.  We
+  should pick a consistent keyword to refer to it, in the interests of
+  simplicity.
+
+* Users should not be required to enable ``PatternSynonyms`` and use the
+  ``pattern`` keyword if all they actually want is to refer to a data
+  constructor in an import/export list.
+
+* The ``ExplicitNamespaces`` extension allows ``type`` to be used with a name
+  in the data namespace (if it is unambiguous), see `GHC issue #22581
+  <https://gitlab.haskell.org/ghc/ghc/-/issues/22581>`_.
+
+* When users wishing to avoid punning are importing modules that define punned
+  entities, they must make careful use of explicit import lists,
+  ``ExplicitNamespaces`` and ``PatternSynonyms`` to avoid importing the same
+  name into both namespaces.  It would be much simpler if they could
+  selectively import "all names in the type namespace" or "all names in the
+  data namespace" (perhaps with different module qualifiers).
+
+
+
+Solution Overview
+~~~~~~~~~~~~~~~~~
+
+To help programmers deal with the external code that uses punning we propose to
+introduce namespace-specified import syntax, guarded behind the
+``ExplicitNamespaces`` extension. The syntax introduces two keywords as part of
+imports, ``data`` and ``type``:
+
+.. code:: haskell
+
+   import qualified Data.Proxy type as T   -- import only the type namespace
+   import qualified Data.Proxy data as D   -- import only the data namespace
+
+This avoids needing to name each item individually, but otherwise has the same
+effect as writing out an explicit import list, like this:
+
+.. code:: haskell
+
+   import qualified Data.Proxy as T (type Proxy)   -- import only the Proxy type
+   import qualified Data.Proxy as D (data Proxy)   -- import only the Proxy constructor
+
+For consistency, this proposal introduces ``data`` as a namespace specifier
+within an import list, guarded by ``ExplicitNamespaces``.  (This replaces the
+existing use of ``pattern`` in import lists, guarded by ``PatternSynonyms``.)
+Moreover, this proposal modifies `proposal #65
+<https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0065-type-infix.rst>`_
+to use ``data`` rather than ``value`` as the keyword for the data namespace in
+fixity declarations and pragmas.
+
+This proposal does not directly make changes to the tick syntax, or provide an
+equivalent at use sites. However it should reduce the need for disambiguating
+promoted data constructors using ticks, because namespace-specified qualified
+imports can be used instead.
+
+
+Proposed Change Specification
+-----------------------------
+
+Allow ``data`` namespace specifier in import/export lists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``ExplicitNamespaces`` is enabled, anywhere the ``type`` keyword may appear
+in an import or export list, the ``data`` keyword may also appear.  Call such an
+occurrence a *namespace specifier*. Any import/export of an identifier with a
+namespace specifier will be taken to refer only identifiers in the given
+namespace.  It is an error to use a namespace specifier if the identifier is not
+in scope in the given namespace.
+
+More precisely, the existing grammar of import/export items accepted by GHC is
+essentially the following (after some minor simplifications): ::
+
+      export -> qcname_ext ['(' qcname_ext_w_wildcard_1, ..., qcname_ext_w_wildcard_n ')']
+             |  'module' modid
+             |  'pattern' qcon  -- with PatternSynonyms
+
+      qcname_ext_w_wildcard -> qcname_ext
+                            |  '..'
+
+      qcname_ext -> qvar
+                 |  qtycon
+                 | 'type' oqtycon  -- with ExplicitNamespaces
+
+This proposal extends ``qcname_ext`` as follows: ::
+
+      qcname_ext -> qvar
+                 |  qtycon
+                 | 'type' oqtycon  -- with ExplicitNamespaces
+                 | 'data' qvarcon  -- with ExplicitNamespaces
+
+Notice that:
+
+* ``module`` and ``pattern`` are valid only at the top level of the export,
+  whereas ``type`` and ``data`` are valid either at the top or nested inside a
+  type constructor or typeclass name.
+
+* ``data`` may be followed by a data constructor name or a variable name (with
+  the latter including record selectors, in particular).
+
+
+Deprecate use of ``pattern`` in import/export lists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since the ``data`` specifier introduced above subsumes uses of the ``pattern``
+keyword in import/export lists that are permitted under ``PatternSynonyms``, we
+propose a new warning ``-Wpattern-namespace-specifier`` that warns when the
+``pattern`` namespace specifier is used.
+
+Initially this warning will be added to ``-Wcompat``.  Three releases after this
+proposal is implemented, the warning will be added to ``-Wall``.
+
+We do not currently propose increasing the severity of the warning beyond
+``-Wall``, or removing support for ``pattern`` in import/export lists entirely,
+because the simplification to the compiler does not seem worth the backwards
+compatibility cost.
+
+
+Namespace-specified imports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the ``ExplicitNamespaces`` extension is enabled, the syntax of import
+declarations is extended to include a namespace specifier immediately after the
+module identifier.
+
+More concretely, in the grammar accepted by GHC, ::
+
+      importdecl -> 'import' [src] ['safe'] ['qualified'] [package] modid ['qualified'] ['as' modid] [impspec]
+
+is changed to ::
+
+      importdecl -> 'import' [src] ['safe'] ['qualified'] [package] modid [namespace] ['qualified'] ['as' modid] [impspec]
+
+      namespace  -> 'data'
+                 |  'type'
+
+With a namespace specified in the import, only identifiers belonging to the
+corresponding namespace will be brought into the scope, as if an explicit import
+list was given mentioning only those identifiers (with the namespace specifier
+on each item).
+
+If an import declaration uses both a namespace specifier and an explicit import
+list, the explicit import list may not mention a different namespace specifier,
+nor an identifier that is not available in the given namespace, otherwise a name
+resolution error will be reported.  It is allowed to redundantly specify the
+same namespace specifier on the import declaration and on an individual item.
+
+If an import declaration uses a namespace specifier but no explicit import list,
+it is not an error for the declaration to bring no names into scope,
+e.g. because the ``data`` specifier was used on a module that exports only type
+names. (GHC may of course warn that such an import is redundant.)
+
+
+Use ``data`` specifier in fixity declarations and ``WARNING``/``DEPRECATED`` pragmas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This proposal changes `GHC Proposal #65
+<https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0065-type-infix.rst>`__
+to use the ``data`` namespace specifier instead of ``value``.  (The specific
+changes are thanks to Vladislav Zavialov and form part of the PR.)
+
+That proposal has not yet been implemented, so this is not a breaking change.
+
+
+Examples
+---------
+
+
+Import/export lists with namespace specifiers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces, TypeFamilies #-}
+   {-# OPTIONS_GHC -Wpattern-namespace-specifier #-}
+   module M
+     ( D            -- Accepted: exports data family D
+     , data D       -- Accepted: exports data constructor D
+     , C(type D)    -- Accepted: exports class C and data family D
+     , D(data f)    -- Accepted: exports data family D and field f
+     , pattern D    -- Accepted: exports data constructor D but emits warning
+     , T(data D)    -- Accepted: exports type T and data constructor D
+     , data f       -- Accepted: exports field f
+     , data v       -- Accepted: exports term v
+     , type T (..)  -- Accepted: exports type T and all its constructors
+     , T(pattern D) -- Rejected: pattern keyword cannot be used in sub-list
+     , data T       -- Rejected: T not in scope in data namespace
+     , type E       -- Rejected: E not in scope in type namespace
+     ) where
+
+   class C a where
+     data D a
+
+   instance C Int where
+     data D Int = E { f :: Int }
+
+   data T = D | D2
+
+   v = ()
+
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces #-}
+   module M
+     ( (+)       -- Accepted: exports value-level function
+     , data (+)  -- Accepted: exports value-level function
+     , type (+)  -- Accepted: exports type family
+     ) where
+
+   import Prelude (data (+))
+   import GHC.TypeLits (type (+))
+
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces #-}
+   module M
+     ( type (+++) (data X)  -- Accepted: exports data type (+++) and its constructor
+     , (+++) (X)            -- Rejected: variable (+++) cannot have a sub-list
+     ) where
+
+   (+++) = (+)
+
+   data a +++ b = X
+
+
+Namespace-specified imports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The same module can be imported with different qualifiers for the type namespace
+and data namespace:
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces #-}
+   import Data.Proxy type as T
+   import Data.Proxy data as D
+
+   -- This is accepted:
+   f :: T.Proxy Int
+   f = D.Proxy
+
+   -- This is accepted too, because both names are in scope unqualified:
+   g :: Proxy Int
+   g = Proxy
+
+   -- This is rejected, because the type T.Proxy cannot be used at the term level:
+   h :: T.Proxy Int
+   h = T.Proxy
+
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces, ImportQualifiedPost #-}
+   import Data.Proxy type qualified as T
+   import Data.Proxy data qualified as D
+
+   -- This is accepted:
+   f :: T.Proxy Int
+   f = D.Proxy
+
+   -- This is rejected, because the names are in scope only with qualifiers:
+   g :: Proxy Int
+   g = Proxy
+
+
+It is possible to use both a namespace-specified import and an explicit import
+list, provided they are consistent:
+
+.. code:: haskell
+
+   {-# LANGUAGE ExplicitNamespaces #-}
+   import Data.Proxy type (data Proxy)      -- Rejected (inconsistent namespace specifiers)
+   import Data.Proxy data (data Proxy)      -- Accepted (redundant but consistent)
+   import Data.Proxy type (Proxy)           -- Accepted (imports type constructor)
+   import qualified Data.Proxy as D (Proxy) -- Accepted (imports data constructor qualified)
+
+
+
+Effect and Interactions
+-----------------------
+
+This proposal makes ``ExplicitNamespaces`` more coherent and more useful for
+avoiding punning via qualified imports.
+
+In an export list, it is not possible to export the entire contents of a
+module's type namespace or data namespace.  If this is desired, exports must be
+listed individually.
+
+
+
+Costs and Drawbacks
+-------------------
+
+This proposal introduces new syntax for namespace-specified imports, however its
+meaning is consistent with the existing namespace specifiers on individual
+import items.  By making the ``ExplicitNamespaces`` extension more consistent it
+should become easier to learn.
+
+The implementation and maintenance cost of this proposal is expected to be
+relatively low.
+
+
+Backwards Compatibility
+-----------------------
+
+This proposal is mostly backwards compatible, except that code may
+theoretically rely on using ``type`` with a data constructor, which is
+accepted in existing GHC versions but rejected under this proposal (see `GHC
+issue #22581 <https://gitlab.haskell.org/ghc/ghc/-/issues/22581>`_).  For
+example, the following import is accepted today but will be rejected under
+this proposal: ::
+
+  import Data.Functor.Product ( Product ( type Pair ) )
+
+Given that this is essentially a bug, it seems unlikely that user code relies
+on it. Moreover it can be fixed by simply removing the bogus ``type``
+namespace specifier. Thus we do not expect significant breakage from this
+change.
+
+Existing code that uses the ``pattern`` keyword (with ``PatternSynonyms``) in
+import/export lists and uses ``-Wcompat`` (or eventually ``-Wall``) will
+receive a warning from ``-Wpattern-namespace-specifier`` until it migrates to
+use ``data`` instead (with ``ExplicitNamespaces``).  In the future we may wish
+to remove support for ``pattern`` as a namespace specifier entirely, but doing
+so is not part of this proposal, so this is not a breaking change.
+
+
+Alternatives
+------------
+
+* We could use ``value``, ``term``, ``pattern``, or any other keyword instead of
+  ``data`` to denote the data namespace.  It seems preferable to use ``data`` as
+  it is an existing keyword (unlike ``value`` and ``term``) and unlike
+  ``pattern`` it more clearly refers to the data namespace.  However this may
+  lead to beginner confusion if expressions like ``import M (data f)`` are used,
+  since ``data`` refers to the namespace rather than a datatype.
+
+* There are alternatives to the import syntax proposed here, for example
+  `proposal #340 <https://github.com/ghc-proposals/ghc-proposals/pull/340>`_
+  proposes ``import M as (T, D)`` syntax. More examples of alternative syntax:
+
+  - ``import M as {T, D}``
+  - ``import M type as T data as D``
+  - ``import M as (type T, data D)``
+
+* Instead of introducing new syntax we could use the existing syntax for
+  explicit import lists:
+
+  .. code:: haskell
+
+     import Data.Proxy( Proxy ) qualified as T
+     import Data.Proxy( pattern Proxy ) qualified as D
+
+  However it is significantly less convenient: you can’t import all the
+  things at once without manually listing every single one of them.
+
+* This proposal does not introduce a way to disambiguate namespaces at use
+  sites, corresponding to the prefix ``'`` syntax used by ``DataKinds`` and the
+  prefix ``'`` and ``''`` used by ``TemplateHaskell``.  Instead, disambiguation
+  must happen at the level of imports, and cannot be used for definitions within
+  the same module. `Proposal #214
+  <https://github.com/ghc-proposals/ghc-proposals/pull/214>`_ suggested using
+  prefix ``data.`` and ``type.`` systematically for this purpose.  However, that
+  would be syntactically noisy and there was difficulty gathering consensus for
+  that approach.
+
+* Rather than modifying ``ExplicitNamespaces`` to allow namespace-specified
+  imports, we could introduce a new extension ``NamespacedImports``.  This would
+  make it clearer whether code depends on the new feature, or whether the older
+  version of ``ExplicitNamespaces`` was enough.  However the general consensus
+  seems to favour reducing the number of extensions over avoiding change to
+  existing extensions.
+
+* GHC currently rejects an attempt to import/export a data constructor or
+  pattern synonym at the top level, such as in the following, with a "Not in
+  scope: type constructor or class" or "Module ... does not export" message:
+
+  .. code:: haskell
+
+     module M ( D ) where
+     data T = D
+
+  In principle there is no ambiguity here, so this could be accepted without
+  requiring the ``data`` keyword. Similarly, exporting a type operator currently
+  requires the ``type`` specifier, even if there is no conflicting term-level
+  operator. However these cases are comparatively rare, and the keywords make
+  the program clearer to the reader, so we propose continuing to require them.
+  GHC's error messages should be improved to point users in the right direction
+  (see GHC issues `#20007 <https://gitlab.haskell.org/ghc/ghc/-/issues/20007>`_,
+  `#21826 <https://gitlab.haskell.org/ghc/ghc/-/issues/21826>`_).
+
+* ``import M (T(data D))`` is technically redundant as ``import M (T(D))``
+  refers to the constructor ``D`` by default. It is currently necessary to use
+  ``data`` as a namespace specifier only at the top level.  However it seems
+  best to allow ``data`` to be used consistently with ``type``.
+
+
+Unresolved Questions
+--------------------
+
+None
+
+
+Implementation Plan
+-------------------
+
+A `draft of new GHC User's Guide documentation for ExplicitNamespaces
+<https://github.com/cdornan/ExplicitNamespaces-doc/pull/1>`_, reflecting the
+changes in this proposal, is in progress.
+
+Support with the implementation of this proposal would be welcome.


### PR DESCRIPTION
The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0581-namespace-specified-imports.rst) has been accepted; the following discussion is mostly of historic interest.

--------------------------------------------

This proposal allows imports to be limited to either the type or data namespace. Moreover it clarifies the specification of
`ExplicitNamespaces` and related extensions. This is heavily derived from #270. Thanks to @Hithroc and @cdornan for collaborating on this! This also includes changes originally prepared by @int-index amending proposal #65.

[Rendered](https://github.com/adamgundry/ghc-proposals/blob/namespace-specified-imports/proposals/0000-namespace-specified-imports.rst).
[Work-in-progress user's guide section with these changes](https://github.com/cdornan/ExplicitNamespaces-doc/pull/1).