### PR TITLE
Or-pattern syntax (amends #522)

### DIFF
--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -92,8 +92,6 @@ Similar to ``case of``, ``of`` introduces a layout block and implicitly adds ope
   - ``one of {1;2}``
   - ``one of 1;2``
 
-When ``k=0``, we only allow ``one of {}``, not ``one of`` however.
-
 Some examples that this new grammar produces: ::
 
   case e of (one of T1; T2{}; T3 a b) -> ...
@@ -102,7 +100,7 @@ Some examples that this new grammar produces: ::
                     T2{}
                     T3 a b) -> ...
                     
-  case e of (one of {}) -> ...
+  case e of (one of) -> ...
 
   f :: (Int, Int) -> Int
   f (5, one of {6;7})

--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -1,4 +1,4 @@
-Or Patterns
+Or Patterns (Amended)
 ==============
 
 .. author:: David Knothe, Ömer Sinan Ağacan, Sebastian Graf 
@@ -6,7 +6,7 @@ Or Patterns
 .. ticket-url::
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/todo>`_.
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/585>`_.
 .. sectnum::
 .. contents::
 

--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -87,7 +87,7 @@ Or patterns extension adds one more production: ::
 
 ``one`` is a conditional keyword in patterns, but can still be used for variable patterns.
 
-Similar to ``case of``, ``of`` introduces a layout block and implicitly adds opening and closing curly braces when not explicitly given. Therefore, both of these are equivalent:
+As stated in the Haskell report and for consistency with ``case of``, ``of`` introduces a layout block and implicitly adds opening and closing curly braces when not explicitly given. Therefore, both of these are equivalent:
 
   - ``one of {1;2}``
   - ``one of 1;2``


### PR DESCRIPTION
This is an amendment to proposal #522.

We propose three changes to the current `one of` syntax:
 1. change syntax from `one of 1, 2, ...` to `one of {1; 2; ...}` and make `one of` subject to the [layout rule](https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-210002.7). This means that we don't require the curly braces, so `one of 1;2;...` is also good.
 2. put production into `pat` instead of `apat` and without parentheses around it
 3. allow or-pattern to have 0 or 1 arguments.

Why?

### 1. `one of {...}` syntax

Similar to `case of`, we want to make use of layout blocks. Writing explicit `{}` around the pattern gives a much nicer grouping for code readers. Previously, one could misread `(one of 1, 2)` as `((one of 1), 2)`. Now, `one of {1;2}` makes this impossible.

Still, the `{}` are optional. This allows us to write or-patterns in a multilined fashion:
```hs
f (one of 1
          2
          3) -> ...
```

`of` layout automatically inserts `{}` and `;`.

### 2. put production unparenthesized into `pat`:

This allows one-of to appear:
- unparenthesized inside tuples: `f (3, one of {1;2}, 5) = 1`
- unparenthesized inside right sides of view-pats: `f (head -> one of {1;2}) = 3`

which feels more natural than having `()` around.

The rule is not too relaxed; this e.g. is still forbidden: `f one of 2;3 = 4`

### 3. or-pats with 0 or 1 arguments

This was requested by @eyeinski and seems like a nice thing to have. It may make sense to write an empty or-pattern and only later filling it with values. Also, similar to `-XEmptyCase`, the value is evaluated before the pattern match fails.

An empty or-pattern will give a redundant pattern match warning.