### PR TITLE
Sized literals have been implemented

### DIFF
--- a/proposals/0451-sized-literals.rst
+++ b/proposals/0451-sized-literals.rst
@@ -4,7 +4,7 @@ Sized primitive literals
 .. author:: Sylvain Henry
 .. date-accepted:: 2022-04-23
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/21422
-.. implemented::
+.. implemented:: 9.8
 .. highlight:: haskell
 .. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/451>`_.
 .. contents::


### PR DESCRIPTION
Sized literals have been implemented in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10320.

Please also add the https://github.com/ghc-proposals/ghc-proposals/labels/Implemented label to #451.
