### PR TITLE
Amend #134 (deprecated exports) in light of implementation

### DIFF
--- a/proposals/0134-deprecating-exports-proposal.rst
+++ b/proposals/0134-deprecating-exports-proposal.rst
@@ -6,137 +6,285 @@ Deprecating Exports
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/4879
 .. implemented::
 .. highlight:: haskell
-.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/134>`_.
+.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/134>`_, with `an amendment discussed here <https://github.com/ghc-proposals/ghc-proposals/pull/595>`_.
 .. contents::
 
-This is my GSoC 2018 project for Haskell.org
-
-The project should be helpful with easing the transition between different versions of code.
-This will be achieved by adding a support for a new deprecation pragma, which will allow the library writers to
-easily specify, which exports from a module are to be deprecated.
+This proposal introduces the ability to attach deprecation and warnings to
+top-level items in module export lists.
 
 Motivation
-------------
-As described in the ticket https://gitlab.haskell.org/ghc/ghc/issues/4879 there is sometimes a need to deprecate certain exports from a module.
+----------
+To help transition between different versions of libraries, it can be useful to
+deprecate re-exported identifiers, for example to signal that they will stop
+being exported in a future version, and to recommend alternatives (e.g. to import
+the identifiers from a different module, or to do something else entirely).
+
+This feature was originally requested in ticket https://gitlab.haskell.org/ghc/ghc/issues/4879.
 
 Proposed Change Specification
 -----------------------------
-The changes proposed are based on the first design option from the ticket https://gitlab.haskell.org/ghc/ghc/issues/4879
+The changes consist of the following aspects:
 
-The syntax would be as follows:
+* A new syntax for attaching warning and deprecations to exports,
 
-::
+* The ability to decide when to emit deprecation warnings, which involves:
+
+  - deciding which exported identifiers are deprecated, and
+  - deciding when to emit warnings at use-sites of imported deprecated
+    identifiers.
+
+Syntax changes
+~~~~~~~~~~~~~~
+We introduce the following syntax in module export lists: ::
 
     module Data.List
     (  ...
         {-# DEPRECATED "Exported from Data.String instead" #-}
         lines,
-        ...t
-    ) where
-    ...
-
-The deprecation pragma would have an effect on an export that immediately follows it, only top level exports would be considered.
-
-The semantics are also described in the aforementioned ticket as follows:
-
-You would get a deprecation warning:
-
-* If you explicitly import a deprecated export: ::
-
-    import Data.List (lines)
-* If you refer to the deprecated export, when fully importing a module: ::
-
-    import Data.List
-    foo = lines
-* If you import the same symbol from different modules and only some of them are deprecated exports then referring to the symbol won't give a deprecation warning. For example the following should not give deprecation warnings: ::
-
-    import Data.List
-    import Data.String
-    foo = lines
-
-* However, in the above example, you would get a deprecation warning if you were to refer to the `lines` symbol by name ::
-
-    foo = Data.String.lines
-
-* It is also important that the warning is not triggered whenever a name is used within a hiding clause, i.e.: ::
-
-    module A ( {-# DEPRECATED "blah" #-} x ) where { x = True }
-    module B where { import A hiding (x) }
-
-* A symbol exported by a module is deprecated if all export specifiers for that symbol have a DEPRECATED pragma. It is an error if a symbol is exported multiple times with DEPRECATED pragmas where the deprecation messages differ ::
-
-    -- only T(C) is deprecated
-    module M
-      ( {-# DEPRECATED "don't use the constructor" #-} T(C)
-      , T(D)  -- or T, pattern D
-      ) where
-
-    data T = C ...
-    pattern D ...
-
-    -- T is deprecated
-    module M
-      ( {-# DEPRECATED "don't use the constructor" #-} T(C)
-      , {-# DEPRECATED "don't use the constructor" #-} T(D)  -- or T, pattern D
-      ) where
-
-    data T = C ...
-    pattern D ...
-
-    -- error
-    module M
-      ( {-# DEPRECATED "message1" #-} T(C)
-      , {-# DEPRECATED "message2" #-} T(D)  -- or T, pattern D
-      ) where
-
-    data T = C ...
-    pattern D ...
-
-
-Effect and Interactions
------------------------
-If implemented correctly, this should not cause any side-effects as the GHC could only display warning messages as a result of the pragma.
-All the other behaviour is expected to remain the same.
-
-
-Costs and Drawbacks
--------------------
-The mentors expect that I would be able to finish the project in 6 weeks.
-Unless the unforeseen occurs, I think this is a reasonable estimate and I intend to do my best to stick to this schedule.
-
-Alternatives
-------------
-As far as I know there are no real alternatives to this feature.
-
-Right now you can only specify that an export from a module is deprecated in a comment, however, the GHC would not bring that up during compile time.
-You can also remove the export altogether but the whole point of deprecation warning is to still allow the users to use the method before it is finally removed.
-
-
-Unresolved questions
---------------------
-UPDATE: The proposed design now does not have an export identifier and so the question below is resolved.
-
-There are 2 different proposed designs:
-
-1 ::
-
-    module Data.List
-    (  ...
-        {-# DEPRECATE lines "Exported from Data.String instead" #-}
-        , lines
         ...
     ) where
     ...
 
-2 ::
+The deprecation pragma has an effect on the export item that immediately
+follows it. Deprecation pragmas are only allowed on top-level exports items.
+This means we would reject the following: ::
 
-    {-# DEPRECATE_EXPORT lines "Exported from Data.String instead" #-}
+    module M ( T ( {-# DEPRECATED "msg" #-} fld ) ) where { .. }
+
+Emitting warnings
+~~~~~~~~~~~~~~~~~
+A deprecated export indicates the intention for a module to stop exporting
+a certain identifier in the future.
+
+Suppose we have: ::
+
+  module M ( {-# DEPRECATED "msg" #-} foo, ... ) where { .. }
+
+  module N where { import M; ... }
+
+The general principle (which will be refined in the subsequent sections) is
+that GHC should emit a deprecation warning about ``foo`` in module ``N``
+**if and only if** removing the export item ``foo`` from the
+export list of ``M`` would break ``N``. That is, it should be the case that:
+
+#. ``foo`` is only made available in ``M`` through that export item (i.e.
+   removing the deprecated export item would genuinely cause breakage;
+   ``foo`` is not made available through other export items).
+
+#. Uses of ``foo`` in ``N`` should only come from the import of ``M``; ``foo``
+   is not available through other imports.
+
+We will now make these two requirements more precise.
+
+Attaching warnings to exports
++++++++++++++++++++++++++++++
+An identifier ``i`` exported by a module ``M`` is considered to be deprecated with
+message "msg" if every export item of ``M`` that exports ``i`` has a deprecation
+pragma with message "msg".
+
+In practice:
+
+* If all of the export items of ``M`` exporting ``i`` have a deprecation pragma
+  with message "msg", mark ``i`` as a deprecated export of ``M`` with deprecation
+  message "msg".
+
+* If some of the export items of ``M`` exporting ``i`` are not deprecated,
+  mark ``i`` as a **non**-deprecated export of ``M``. If, in addition, some
+  export items exporting ``i`` are deprecated, emit a warning that we are
+  discarding some deprecation messages.
+
+* If several of the export items of ``M`` exporting ``i`` have deprecation
+  pragmas, but the messages are not all the same, emit a
+  "conflicting deprecation messages" error.
+
+To illustrate, suppose that we have: ::
+
+  module A where { data T = C | D }
+
+The above specification leads us to decide which deprecation messages
+to attach to various exported identifiers: ::
+
+    module B1
+      ( {-# DEPRECATED "don't use C" #-} T(C)
+      , T(D)
+      ) where { import A }
+
+      -- Result: only the constructor C of T is deprecated, with message "don't use C".
+      --         We emit a warning that T itself will not be deprecated,
+      --         because it is explicitly exported twice, once with a deprecation
+      --         and once without.
 
 
-I am leaning towards the first one as it readily shows next to an export that it is being deprecated but I am very open to any discussion regarding this.
+    module B2
+      ( {-# DEPRECATED "msg" #-} T(C)
+      , {-# DEPRECATED "msg" #-} T(D)
+      ) where { import A }
 
+    -- Result: T, C and D are all deprecated, with message "msg".
+
+
+    module B3
+      ( {-# DEPRECATED "msg1" #-} T(C)
+      , {-# DEPRECATED "msg2" #-} T(D)
+      ) where { import A }
+
+    -- Result: error, because T has two conflicting deprecation messages,
+    --         "msg1" and "msg2".
+
+
+    module B4
+      ( {-# DEPRECATED "msg" #-} T(C)
+      , module A
+      ) where { import A }
+
+    -- Result: T and C are not deprecated: they are made available twice, once
+    --         with a deprecation and once without. We emit a warning that we are
+    --         discarding a DEPRECATED pragma.
+
+
+    module B5
+      ( {-# DEPRECATED "msg1" #-} T(C)
+      , {-# DEPRECATED "msg2" #-} module A
+      ) where { import A }
+
+    -- Result: error because of conflicting deprecation messages
+
+
+To re-export a whole module while deprecating a single identifier,
+one might proceed as follows ::
+
+  -- U.hs
+  module U where { bad = "bad"; ... }
+
+  -- V.hs
+  module V ( module U, {-# DEPRECATED "msg" #-} U2.bad ) where
+    import U hiding (bad)
+    import qualified U as U2 (bad)
+
+  -- W.hs
+  module W where { import V (bad) }
+
+This is in keeping with the general principle that we should get a warning in
+``W`` precisely when removing the deprecated export of ``bad`` in ``V`` would
+cause breakage. Contrast with example ``B4`` above, where removing the deprecated
+export would not cause breakage downstream (in modules importing ``B4``):
+``C`` is still exported by ``B4`` thanks to  the whole-module re-export of ``A``.
+
+Warning at use-sites
+++++++++++++++++++++
+We emit deprecation warnings for an imported identifier with an export
+deprecation in the following situations:
+
+#. In an import declaration which explicitly imports the deprecated identifier,
+
+#. In an occurrence (including a re-export) of an identifier which is in scope
+   only through imports which attach deprecations to the identifier.
+   In this case, all deprecation messages are emitted as warnings.
+
+To illustrate, suppose we have: ::
+
+  module A where { foo :: Int }
+  module B ( {-# DEPRECATED "msg1" #-} foo ) where { import A }
+  module C ( {-# DEPRECATED "msg2" #-} foo ) where { import A }
+
+Then we get the following behaviour: ::
+
+  -- Import lists
+  module M1 where
+    import B ( foo ) -- Warning "msg1": explicit import of a deprecated identifier
+
+  module M2 where
+    import B hiding ( foo ) -- no warning: we are explicitly hiding the deprecated "foo"
+
+
+  -- Occurrences
+  module M3 where
+    import B  -- no warning here; "foo" is not explicitly mentioned
+    bar = foo -- warning "msg1" here
+
+  module M4 where
+    import A
+    import B
+    bar = foo -- no warning: foo is in scope through both A and B,
+              -- and A.foo is not deprecated
+
+  module M5 where
+    import A
+    import B
+    bar = B.foo -- warning "msg1": B.foo is in scope through the import of B,
+                -- which deprecates "foo"
+
+  module M6 where
+    import B
+    import C
+    bar = foo -- two warnings, "msg1" and "msg2"
+
+
+  -- Re-exports
+  module M7
+    ( foo ) -- warning "msg1": B deprecates foo
+    where
+      import B
+
+  module M8
+    ( module B ) -- warning "msg1" for the implicit re-export of foo
+    where
+      import B
+
+  module M9
+    ( module B, module C ) -- emit deprecation warnings with the two messages "msg1" and "msg2"
+                           -- (NB: not an error for conflicting messages, as these are an occurrences)
+    where
+      import B
+      import C
+
+  module M10
+    ( module A, module B ) -- no warning: foo is deprecated by B but not by A
+    where
+      import A
+      import B
+
+
+Effect and Interactions
+-----------------------
+If implemented correctly, this should not cause any side-effects. The only
+observable change in behaviour is that GHC will emit additional warnings
+arising from deprecations in export lists. All the other behaviour is expected
+to remain the same.
+
+Costs and Drawbacks
+-------------------
+The implementation cost is rather low: changes are mostly confined to:
+
+* processing of export lists (``GHC.Tc.Gen.Export``),
+* renaming of imports (``GHC.Rename.Names.filterImports``),
+* emission of warnings when looking up identifiers (``GHC.Rename.Env.addUsedGREs``).
+
+Alternatives
+------------
+As far as I know, there are no real alternatives to this feature.
+
+One option is to mark deprecations in comments, but these would not be raised
+by GHC during compilation.
+
+Another option is to manually re-define identifiers and attach deprecation
+information to them before re-exporting them, e.g. ::
+
+  module U where { foo :: Int }
+  module V ( foo ) where
+    import qualified U
+
+    {-# DEPRECATED "msg" #-}
+    foo = U.foo
+
+This is very impractical, especially as it can give rise to spurious name clash
+errors.
+
+Unresolved questions
+--------------------
+None at this time.
 
 Implementation Plan
 -------------------
-I would aim to implement the proposed changes as part of my GSoC 2018 commitment.
-To achieve this, I will maintain regular communications with my mentors Matthew Pickering and Erik de Castro Lopo and the broader GHC developer community.
+This proposal is being implemented by Bartłomiej Cieślar in
+https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10283.


### PR DESCRIPTION
The implementation of the deprecated exports proposal in [GHC MR !10283](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10283) has surfaced several subtleties that were not explicitly considered in the original proposal #134, which this amendment aims to clarify. Chiefly:

  - We should be more specific about how we decide exactly which identifiers in an export list are deprecated. In particular, specify how to handle a combination of implicit and explicit exports.
  - If an identifier is in scope in several different ways, each with a distinct deprecation message, GHC should emit *all* the messages as warnings.

[Rendered](https://github.com/sheaf/ghc-proposals/blob/amend-dep-exports/proposals/0134-deprecating-exports-proposal.rst)