### PR TITLE
Amend sized literals to support deriving Show

### DIFF
--- a/proposals/0451-sized-literals.rst
+++ b/proposals/0451-sized-literals.rst
@@ -136,6 +136,9 @@ literals.
 
 (This can probably be factored with ``@signed_suffix`` and ``@unsigned_suffix``).
 
+For types such as ``data T = MkT Int8# deriving Show``, the derived instance
+should use the extended literal syntax.
+
 Examples
 --------
 


### PR DESCRIPTION
GHC supports deriving `Show` for constructors containing fields of types `{Int,Word}{8,16,32}#`.

For example, given 

```haskell
data T = MkT Int8# deriving Show
x = show $ MkT (intToInt8# 42#)
```

we have `x == "MkT (intToInt8# 42#)"`. This has been supported since the introduction of `Int8#` etc. in GHC 8.8.

This is rather clumsy. At that time, there was no better way of referring to a number of type `Int8#`. But since #451 we can form literals of those types directly: `MkT 42#Int8`.

I'm proposing to change deriving `Show` to use that syntax.

* `Show` is supposed to use the normal form (literals and data constructors, no functions).
* The current method doesn't support `Int64#`. A naive adaptation is wrong on 32-bit: think about `intToInt64# BIG#`. Using sized literals removes the `Int#` indirection and everything just works. Therefore, I'm also proposing to add support for `Int64#` and `Word64#`, which will work in the same way as `{Int,Word}{8,16,32}#`.

Deriving Show for other unboxed fields (`Char#`, `Int#` etc.) is unaffected.

This change is technically changing the behavior of GHC, so I'm submitting it as an amendement to sized literals. It is still minor and I don't expect much breakage: `{Int,Word}{8,16,32}#` are relatively new.

I have already implemented this change in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10673/diffs.