### PR TITLE
 Allow constraint tuples and synonyms in typeclass instance head (under review)

### DIFF
--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -1,0 +1,91 @@
+---
+author: Grigorii Gerasev
+date-accepted: ""
+ticket-url: ""
+implemented: ""
+---
+
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
+**After creating the pull request, edit this file again, update the number in
+the link, and delete this bold sentence.**
+
+# Proposal title
+
+Allow constraints type synonyms in deriving heads again.
+
+## Motivation
+
+Most of Haskell projects do a lot of `stock` and `anyclass` deriving
+for repeating classes. Most of time there is some default list
+of classes to be defived.
+
+Making type synonym for that seems like the obvious thing to do,
+jet it does not work.
+
+It worked at some moment for any instances,
+but was disabled due to wrong behaviour in some cases:
+https://gitlab.haskell.org/ghc/ghc/-/issues/13267
+
+Seems like only phantom param case is relevant for deriving instances case.
+
+## Proposed Change Specification
+
+Accept type synonyms in deriving heads, by rewriting it to regular constraints.
+
+## Examples
+
+```
+type Synonym x = (Show x, Eq x)
+
+-- Should works exactly the same
+derive instance ... => (Synonym x)
+derive instance ... => (Show x, Eq x)
+```
+
+Non-standalone instances do not have explicit params,
+so rewriting implementation may be little different.
+But they have same seamantics as standalone instances with holes,
+so it should be the same.
+
+## Effect and Interactions
+
+I do not know any.
+May be some linters depend on instance head being class.
+
+## Costs and Drawbacks
+
+May be some rewriting implementations may make errors less clear,
+due to AST changed inside. Seems not likely and treatible.
+
+## Backward Compatibility
+
+No breakage. This was working before.
+
+## Alternatives
+
+1. Use CPP preprocessor variable, which breaks type-safety
+   and may which lead to surprising error messages
+2. Use Template Haskell, which have its own problems and is less simple for beginners
+
+## Unresolved Questions
+
+Are there any other "wrong" cases other than phantom params?
+
+## Implementation Plan
+
+GHC does some processing to convert AST into EarlyDeriveSpec.
+As part of that before or in `makeDerivSpecs` function
+one could rewrite type synonyms. So all types and later logic
+will remain the same.
+
+The only question is how to check if rewriting will be correct.
+Another question is handling of recursive type synonyms.
+
+1. If the phantom params is the only case, one could forbid only them
+2. If there might be complex cases GHC may just rewrite synonims and
+   check if result is correct for later stages usual way
+
+I (Gregory Gerasev @uhbif19) could try to implement that.
+
+## Endorsements
+

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -13,29 +13,37 @@ This proposal is [discussed at this pull request](https://github.com/ghc-proposa
 
 Most of Haskell projects do a lot of `stock` and `anyclass` deriving
 for same list of common classes. This involves a lot of code duplication.
-
 Such usecase would be natually covered by defining type synonym
-for tuple of such reused classes, but GHC does not support deriving
-neither for constraint synonyms, nor for tuples.
+for tuple of such reused classes.
+Examples section has
+[code sample how this could look](#common-derived-instances-usecase).
 
-This may be unexpected for user, because both of this constructs
-are supported in the context of an instance, but not in the head of an instance
+But GHC does not support deriving neither for constraint synonyms,
+nor for tuples.
+This behaviour is inconsistent and may be unexpected for user,
+because both of this constructs are supported in the context of an instance,
+but not in the head of an instance.
+For example in instance looking like `instance Context MyData => Head MyData`,
+`Context` can be synonym to tuple of constraints, while `Head` cannot.
 
 Another usecase is typeclasses which are semantically same as composition of
 multiple classes. They too could be replaced by constraint synonym instances.
+See [detailed code sample](#tuple-of-classes-instance-usecase).
 
-Case of constraint synonyms in instance head worked at some point in time,
-but was disabled due to wrong user-facing error messages in some cases.
-Reasoning for that is covered in Note "Instances and constraint synonyms"
-and [issue 13267](https://gitlab.haskell.org/ghc/ghc/-/issues/13267).
-
-Relevant SA question (was provided by @yaitskov):
-https://stackoverflow.com/questions/28037837/deriving-clause-with-arbitrary-constraint-aliases
+There is already
+[existing SA question](https://stackoverflow.com/questions/28037837/deriving-clause-with-arbitrary-constraint-aliases),
+asking about GHC proposal with similar scope and usecase
+(was provided by @yaitskov).
 
 ## Proposed Change Specification
 
 The proposal requires two new declarations to be allowed in head of the instance:
 constraint tuple and constraint synonym.
+
+Case of constraint synonyms in instance head worked at some point in time,
+but was disabled due to wrong user-facing error messages in some cases.
+Reasoning for that is covered in Note "Instances and constraint synonyms"
+and [issue 13267](https://gitlab.haskell.org/ghc/ghc/-/issues/13267).
 
 New semantics can be described by two purely syntactic rewrites,
 translating all new constructions away from instance declaration:
@@ -47,9 +55,10 @@ translating all new constructions away from instance declaration:
    split such declarations into multiple.
 
 This should work the same for any kind of instances:
-stanalone derived instances with or without explicit context,
-non-standalone derived instances
-and user-defined instances.
+
+* Stanalone derived instances with or without explicit context
+* Non-standalone derived instances
+* User-defined instances
 
 Thus, the proposal does not introduce any changes to instance semantics,
 only the allowed syntax and error messages would be improved.

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -63,12 +63,20 @@ Main usecase:
 type ToFromJSON x = (ToJSON x, FromJSON x)
 
 -- Allowed by this proposal
-derive instance ... => (ToFromJSON x)
+derive instance ... => (ToFromJSON MyData)
+
+-- Allowed by this proposal and working same as example above
+data MyData = MkMyData deriving (ToFromJSON)
 
 -- Should work the same with syntax allowed before proposal
-derive instance ... => ToJSON x
-derive instance ... => FromJSON x
+derive instance ... => ToJSON MyData
+derive instance ... => FromJSON MyData
 ```
+
+Non-standalone instances do not have explicit params,
+so rewriting implementation may be little different.
+But they have just the same samantics as standalone instances with holes,
+covered by examples before, so could be handled the same.
 
 Instance context case is simpler:
 
@@ -95,11 +103,6 @@ Last example may be not the most natural,
 because `MyContainer` would probably have `ToFromJSON` conditional instance
 anyway. But my goal was to show instance context changes separately,
 while more natural examples involve instance head as well.
-
-Non-standalone instances do not have explicit params,
-so rewriting implementation may be little different.
-But they have just the same samantics as standalone instances with holes,
-covered by examples before, so could be handled the same.
 
 ## Effect and Interactions
 

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -16,7 +16,7 @@ for repeating classes. Most of time there is some default list
 of classes to be defined.
 
 Making type synonym for that seems like the obvious thing to do,
-because jet it does not work.
+yet it does not work.
 
 There are two constructions forbidden now, but required for that usecase:
 
@@ -29,18 +29,18 @@ Reasoning for that is covered in Note "Instances and constraint synonyms"
 and [issue 13267](https://gitlab.haskell.org/ghc/ghc/-/issues/13267).
 
 Main usecase only affect deriving instances head,
-but another usecase is usage of tuples/synonims in context of any instance.
+but another usecase is usage of tuples/synonyms in context of any instance.
 It seems to be less common, but natural to cover in same proposal
-to allow tuples/synonims anywhere in instance declaration,
+to allow tuples/synonyms anywhere in instance declaration,
 leading to more consistent semantics.
 
 ## Proposed Change Specification
 
-Proposal requires two purely syntaxic rewrites for in instance declarations
+Proposal requires two purely syntaxic rewrites for instance declarations
 to happen:
 
 1. Apply all type synonyms in instance declarations.
-   This should be done recrusively, until no type synonim is present anymore.
+   This should be done recursively, until no type synonym is present anymore.
 2. For any constraint tuple in derived instance head,
    split such declarations into multiple.
 
@@ -131,11 +131,10 @@ For deriving instances there are two alternatives:
 
 For user-defined instances one may define type class instead of synonym:
 
-```haskellb
+```haskell
 class (ToJSON x, FromJSON x) => ToFromJSON x
 
 instance (ToJSON x, FromJSON x) => ToFromJSON x
-```
 
 While this trick works, Haskell begginers may be not aware of it,
 and it makes less clear API.
@@ -157,7 +156,7 @@ Also implementation paths are similar any may be switched later.
 The main question is how to check that constraint synonym rewriting
 will lead to correct code.
 
-There are two principial solutions to that:
+There are two principal solutions to that:
 
 1. Check that rewriting will be correct before applying it.
    In this context this probably amounts to checking for each referenced

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -5,9 +5,7 @@ ticket-url: ""
 implemented: ""
 ---
 
-This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/0>).
-**After creating the pull request, edit this file again, update the number in
-the link, and delete this bold sentence.**
+This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/597).
 
 # Proposal title
 

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -7,83 +7,194 @@ implemented: ""
 
 This proposal is [discussed at this pull request](https://github.com/ghc-proposals/ghc-proposals/pull/597).
 
-# Proposal title
-
-Allow constraints type synonyms in deriving heads again.
+# Allow constraint tuples and synonyms in typeclass instances
 
 ## Motivation
 
 Most of Haskell projects do a lot of `stock` and `anyclass` deriving
 for repeating classes. Most of time there is some default list
-of classes to be defived.
+of classes to be defined.
 
 Making type synonym for that seems like the obvious thing to do,
-jet it does not work.
+because jet it does not work.
 
-It worked at some moment for any instances,
-but was disabled due to wrong behaviour in some cases:
-https://gitlab.haskell.org/ghc/ghc/-/issues/13267
+There are two constructions forbidden now, but required for that usecase:
 
-Seems like only phantom param case is relevant for deriving instances case.
+* Constraint synonyms
+* Constraint tuples
+
+Synonyms worked at some moment,
+but was disabled due to wrong behaviour in some cases.
+Reasoning for that is covered in Note "Instances and constraint synonyms"
+and [issue 13267](https://gitlab.haskell.org/ghc/ghc/-/issues/13267).
+
+Main usecase only affect deriving instances head,
+but another usecase is usage of tuples/synonims in context of any instance.
+It seems to be less common, but natural to cover in same proposal
+to allow tuples/synonims anywhere in instance declaration,
+leading to more consistent semantics.
 
 ## Proposed Change Specification
 
-Accept type synonyms in deriving heads, by rewriting it to regular constraints.
+Proposal requires two purely syntaxic rewrites for in instance declarations
+to happen:
+
+1. Apply all type synonyms in instance declarations.
+   This should be done recrusively, until no type synonim is present anymore.
+2. For any constraint tuple in derived instance head,
+   split such declarations into multiple.
+
+After that rewrites happen, existing GHC semantics is applied to result,
+with same error messages or produced code.
+
+There are two cases not covered by this rewrites:
+
+1. Using tuples in instance context leads to nested tuples.
+   But they already have the same semantics as flatten tuples,
+   so this is concern only affecting AST handling.
+2. Syntax and need for user-defined instances of class tuples is not clear.
+   So tuples in user-defined instances head remain forbidden.
 
 ## Examples
 
-```haskell
-type Synonym x = (Show x, Eq x)
+Main usecase:
 
--- Should works exactly the same
-deriving instance ... => (Synonym x)
-deriving instance ... => (Show x, Eq x)
+```haskell
+type ToFromJSON x = (ToJSON x, FromJSON x)
+
+-- Allowed by this proposal
+derive instance ... => (ToFromJSON x)
+
+-- Should work the same with syntax allowed before proposal
+derive instance ... => ToJSON x
+derive instance ... => FromJSON x
 ```
+
+Instance context case is simpler:
+
+```haskell
+class ToFromJSON x => MyProtocolEncoding x where
+   ...
+
+data MyContainer x = ...
+
+-- Allowed by this proposal
+instance
+   (MyProtocolEncoding x, ToFromJSON (MyContainer x)) =>
+   MyContainer x where
+   ...
+
+-- Should work the same with syntax allowed before proposal
+instance
+   (MyProtocolEncoding x, ToJSON (MyContainer x), FromJSON (MyContainer x)) =>
+   MyContainer x where
+   ...
+```
+
+Last example may be not the most natural,
+because `MyContainer` would probably have `ToFromJSON` conditional instance
+anyway. But my goal was to show instance context changes separately,
+while more natural examples involve instance head as well.
 
 Non-standalone instances do not have explicit params,
 so rewriting implementation may be little different.
-But they have same seamantics as standalone instances with holes,
-so it should be the same.
+But they have just the same samantics as standalone instances with holes,
+covered by examples before, so could be handled the same.
 
 ## Effect and Interactions
 
-I do not know any.
-May be some linters depend on instance head being class.
+There is already extension named `TypeSynonymInstances`,
+but it does not cover constraint synonym case.
+Probably, constraint synonyms should be guarded by this extension as well
+and documentation updated on that.
+
+It may be, that some linters depend on current syntaxic restrictions,
+but I am not aware on any specific cases.
 
 ## Costs and Drawbacks
 
-May be some rewriting implementations may make errors less clear,
-due to AST changed inside. Seems not likely and treatible.
+Main concern is that rewriting implementations may make errors less clear.
+I propose to mitigate if this happens by adding context to errors,
+same as it done for instances resolving now.
 
 ## Backward Compatibility
 
-No breakage. This was working before.
+No breakage. Part of this even was working before.
 
 ## Alternatives
 
-1. Use CPP preprocessor variable, which breaks type-safety
-   and may which lead to surprising error messages
+For deriving instances there are two alternatives:
+
+1. Use CPP preprocessor variable, which breaks type-safety,
+   may lead to surprising error messages and is less composable
 2. Use Template Haskell, which have its own problems and is less simple for beginners
+
+For user-defined instances one may define type class instead of synonym:
+
+```haskellb
+class (ToJSON x, FromJSON x) => ToFromJSON x
+
+instance (ToJSON x, FromJSON x) => ToFromJSON x
+```
+
+While this trick works, Haskell begginers may be not aware of it,
+and it makes less clear API.
 
 ## Unresolved Questions
 
-Are there any other "wrong" cases other than phantom params?
+* Are there any other "wrong" cases not covered in existing issue?
+* Which implementation approach to use?
+
+I think all those questions are not blocking,
+because they never lead to bad semantics,
+only potential problems are slightly less-clear type errors.
+Also implementation paths are similar any may be switched later.
 
 ## Implementation Plan
 
-GHC does some processing to convert AST into EarlyDeriveSpec.
-As part of that before or in `makeDerivSpecs` function
-one could rewrite type synonyms. So all types and later logic
-will remain the same.
+### Main approaches
 
-The only question is how to check if rewriting will be correct.
-Another question is handling of recursive type synonyms.
+The main question is how to check that constraint synonym rewriting
+will lead to correct code.
 
-1. If the phantom params is the only case, one could forbid only them
-2. If there might be complex cases GHC may just rewrite synonims and
-   check if result is correct for later stages usual way
+There are two principial solutions to that:
 
-I (Gregory Gerasev @uhbif19) could try to implement that.
+1. Check that rewriting will be correct before applying it.
+   In this context this probably amounts to checking for each referenced
+   type synonym if it belongs to some list of known bad cases.
+2. Optimistically apply transformation and check for errors in later stages
+
+Also we can just do both.
+
+### Potential problems
+
+Main potential problems with first approach
+would be being unsafe or being too restrictive.
+
+These problems, especially being too restictive,
+are amplified by problem of cascading:
+handling synonyms application producing jet another synonyms.
+This would affect both calculation of referenced type synonyms
+and possible generative effects.
+In particular this leads to question if to check referenced type synonyms
+once or after each reduction pass.
+Another concern would be if reduction strategy affects user-facing errors.
+
+Solution 2, on other hand cannot be unsafe or too restrictive by design.
+Also it may lead to GHC code simplification,
+because now there are multiple codepaths
+need to handle type synonims differently.
+
+The potential problem for solution 2 would be error messages clarity.
+Since checks are applied to rewritten code,
+they might miss original context or show non-original AST.
+I believe such problems could be solved by means of
+tracking relation to original AST.
+
+### Proposed solution
+
+I believe second approach is more simple to reason and implement.
+I (Gregory Gerasev @uhbif19) could try to provide such implementation.
 
 ## Endorsements
 

--- a/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
+++ b/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md
@@ -32,12 +32,12 @@ Accept type synonyms in deriving heads, by rewriting it to regular constraints.
 
 ## Examples
 
-```
+```haskell
 type Synonym x = (Show x, Eq x)
 
 -- Should works exactly the same
-derive instance ... => (Synonym x)
-derive instance ... => (Show x, Eq x)
+deriving instance ... => (Synonym x)
+deriving instance ... => (Show x, Eq x)
 ```
 
 Non-standalone instances do not have explicit params,


### PR DESCRIPTION
```
Most of Haskell projects do a lot of `stock` and `anyclass` deriving
for repeating classes. Most of time there is some default list
of classes to be defived.

Making type synonym for that seems like the obvious thing to do,
jet it does not work.

It worked at some moment for any instances,
but was disabled due to wrong behaviour in some cases:
https://gitlab.haskell.org/ghc/ghc/-/issues/13267

Seems like only phantom param case is relevant for deriving instances case.
```

I think this should work not only for heads and not only for deriving instances, but lets begin with this case, cuz I seem to roughly understand how this works.

Some previous discussion (as part of unrelated issue): https://gitlab.haskell.org/ghc/ghc/-/issues/23522#note_505273

Rendered: https://github.com/uhbif19/ghc-proposals/blob/uhbif19/allow-constraint-type-synonyms-in-deriving-heads/proposals/0000-allow-constraint-type-synonyms-in-deriving-heads.md