### PR TITLE
Amend 281 visible forall to work without ScopedTypeVariables

### DIFF
--- a/proposals/0281-visible-forall.rst
+++ b/proposals/0281-visible-forall.rst
@@ -343,8 +343,6 @@ Part I: Proposed Change Specification
    follows type-level name resolution rules (i.e. uses of punned identifiers
    resolve to the type namespace), both at binding sites and at use sites.
 
-   Without ``ScopedTypeVariables``, no type variable may be bound in a pattern.
-
    The ``ScopedTypeVariables`` extension has no effect on variables introduced
    by ``forall a ->``.
 


### PR DESCRIPTION
This amendment removes the requirement to enable the `ScopedTypeVariables` extension to write code of the following form:

```haskell
f :: forall x -> Show x => x -> String
f (type t) = show @t
```

Here `type t` binds a type variable named `t`, which is then used on the right-hand side in a type application `@t`. This entire arrangement already relies on `ExplicitNamespaces` to use the `type` namespace specifier and `RequiredTypeArguments` to typecheck it against the `forall x ->`. There is no need to require `ScopedTypeVariables` on top of that, especially since we are trying to move away from it (#448)