### PR TITLE
Amend or patterns (#522) to use p1 ; p2

### DIFF
--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -128,8 +128,8 @@ We give the static semantics in terms of *pattern types*. A pattern type has the
 Then the typing rule for Or patterns is:
 ::
 
-          Γ0, Σ0 ⊢ pat_i : τ ⤳ Γ0,Σi,Ψi
-    -----------------------------------------
+      Γ0, Σ0 ⊢ pat_i : τ ⤳ Γ0,Σi,Ψi
+    ---------------------------------
     Γ0, Σ0 ⊢ ( pat_i ) : τ ⤳ Γ0,Σ0,∅
 
 

--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -141,8 +141,8 @@ Informal semantics in the style of `Haskell 2010 chapter 3.17.2: Informal
 Semantics of Pattern Matching
 <https://www.haskell.org/onlinereport/haskell2010/haskellch3.html#x8-600003.17.2>`_:
 
-- Matching the pattern ``(p1; ... ; pk)`` against the value ``v`` is the result of matching ``v`` against ``p1`` if it is not a failure, or the result of
-  matching ``(p2; ... ; pk)`` against ``v`` otherwise. We require that ``p1``, …, ``pk`` bind no variables.
+- Matching the pattern ``(p1; ...; pk)`` against the value ``v`` is the result of matching ``v`` against ``p1`` if it is not a failure, or the result of
+  matching ``(p2; ...; pk)`` against ``v`` otherwise. We require that ``p1``, …, ``pk`` bind no variables.
 - Matching the pattern ``(p1)`` against the value ``v`` performs a normal pattern match.
 
 

--- a/proposals/0522-or-patterns.rst
+++ b/proposals/0522-or-patterns.rst
@@ -62,7 +62,7 @@ function we get
 
     stringOfT :: T -> Maybe String
     stringOfT (T1 s)        = Just s
-    stringOfT (T2{} ; T3{}) = Nothing
+    stringOfT (T2{}; T3{}) = Nothing
 
 This function doesn't match ``T4``, so we get our warning in the very first compile
 cycle or (even faster) in our IDE powered by a language server implementation.


### PR DESCRIPTION
Proposal #522 defines _or-patterns_, which match multiple patterns simultaneously. For example,

```
f (one of 3, 4, 5) = …
```
would match on all `3`, `4` and `5`.


After trying to amend #522 to adjust the syntax (in #585), some unhappiness was raised about the current `one of` syntax. We then made two votes to let the community decide the exact syntax that _or-patterns_ should follow.

[Vote 1](https://github.com/ghc-proposals/ghc-proposals/issues/587) decided that _or-patterns_ should have infix syntax and no prefix signalling like `one of` (with 55-15 votes).

In [Vote 2](https://github.com/ghc-proposals/ghc-proposals/issues/598), the options `(p1; p2)` and `(p1 | p2)` were compared. The result was roughly balanced, with a little bit more support towards `;` (48-43 votes).


So this amended proposal proposes the `(p1; p2)` syntax with `(p1 | p2)` being suggested as an alternative.


### Layout Rule

A good reason to vote for `(p1; p2)` is the use of the layout rule introduced by `of` (sources: [@bradrn](https://github.com/ghc-proposals/ghc-proposals/issues/598#issuecomment-1660466684), [@lierdakil](https://github.com/ghc-proposals/ghc-proposals/issues/598#issuecomment-1599210728)).
This makes it possible to write

```
f x = case x of
  A
  B
  C -> 3
  D
  E -> 4
  F -> 5
```

Or-Patterns could then appear *without* parentheses in some places and could make use of automatic `;` insertion when they are inside a layout block introduced by `of`.

Edit: this is now also a part of this proposal.