### PR TITLE
Linear types amendment: Linear lets

### DIFF
--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -7,6 +7,7 @@ Linear Types
 .. implemented:: 9.0 (technology preview)
 .. highlight:: haskell
 .. header:: This proposal was `discussed at pull request #111<https://github.com/ghc-proposals/ghc-proposals/pull/111>`_, `amended by pull request #356<https://github.com/ghc-proposals/ghc-proposals/pull/356>`_ and `pull request #392<https://github.com/ghc-proposals/ghc-proposals/pull/392>`_.
+.. sectnum::
 .. contents::
 
 This proposal previously underwent a round of review `at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/91>`_.

--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -917,7 +917,7 @@ to where bindings.*
 
 Note on terminology: following the Haskell 2010 report, a function
 binding is a binding of the form ``f arg1…argn =`` with at least one
-arguments. The other binding is called pattern bindings. In particular
+argument. The other binding form is called a pattern binding. In particular
 ``let x =`` is a pattern binding (as opposed to how it is in GHC's
 implementation, where ``let x =`` would be a ``FunBind``). This
 proposal will be using the terminology “non-variable pattern”
@@ -979,7 +979,7 @@ with multiplicity ``p`` and the variables of ``pat`` must be consumed
 in ``body`` with multiplicity ``p`` (if ``pat`` has some non-linear
 fields, then the variables are scaled appropriately as per
 `Constructors & pattern-matching`_). The pattern ``pat`` can be an
-arbitrary, nested, pattern.
+arbitrary, nested, pattern, as long as the binding is strict.
 
 Here are a few examples that illustrate the typing rules
 
@@ -1037,7 +1037,7 @@ Variables in non-variable multiplicity-annotated let-patterns are bound to
 monomorphic types (see `Let bindings and polymorphism`_ for the
 reasoning and a discussion). Unannotated non-variable let-patterns are
 inferred to be unrestricted (by default, since ``-XLinearTypes``
-implies ``-XNoMonoLocalBinds``, only toplevel bindings, which are
+implies ``-XMonoLocalBinds``, only toplevel bindings, which are
 always unrestricted anyway, are inferred to be polymorphic).
 
 ::
@@ -1418,8 +1418,8 @@ Let bindings and polymorphism
 It's specified that multiplicity annotated non-variable pattern
 bindings are never generalised (see `Non-variable linear patterns are
 monomorphic`_). This section elaborates why it's problematic to
-generalise such bindings. It wouldn't be unsound, to the best of my
-knowledge, to allow generalised linear pattern, this restrictions
+generalise such bindings. It wouldn't be unsound, to the best of Arnaud's
+knowledge, to allow generalised linear patterns. This restriction
 follows, instead, from the necessary limitations of the type-checker,
 as well as the choice of intermediate language (an untyped intermediate
 language would let us paper over this issue, I believe).
@@ -2463,7 +2463,7 @@ having ``-XMonoLocalBinds`` is to make (2) irrelevant though. Because
 it feels rather unpredictable. Because ``-XMonoLocalBinds`` is quite
 standard already, being more or less necessary for ``-XGADTs`` and
 ``-XTypeFamilies``, so it feels unnecessary to add extra worries by
-not not implying ``-XMonoLocalBinds``.
+not implying ``-XMonoLocalBinds``.
 
 %Many annotated patterns
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0111-linear-types.rst
+++ b/proposals/0111-linear-types.rst
@@ -2485,6 +2485,33 @@ it's a type family?) that are hard to justify. In particular since we
 take ``-XMonoLocalBinds`` for granted, where generalisation doesn't
 occur anyway.
 
+Restrictions of multiplicity-annotated let bindings
+---------------------------------------------------
+
+The proposal specifies that a multiplicity annotated non-variable let binding ``let %p pat``
+must be such that ``pat = !pat'`` even if ``p = 'Many``. It is easy to
+lift this restriction on two dimension:
+
+- We can say, instead, that patterns not of the form ``!pat'`` emit a
+  ``p ~ 'Many`` constraint instead. They already do (for the sake of
+  inference), so this is strictly less code.
+- We can generalise to more strict patterns. For instance, we don't
+  need to require a ``!`` if ``-XStrict`` is on, we can have patterns
+  of the form ``(!pat')`` (with additional parentheses). This is a few
+  lines of codes, inference actually already does this in my
+  implementation, so it's already paid for (though it does annoyingly
+  mostly duplicate another definition of strict pattern which I
+  couldn't find a way to factor as a single function, I don't like
+  this).
+
+The reason that motivated the stronger restriction is to improve error
+messages, because we can then error out with “multiplicity-annotated
+let-bound patterns must be of the form !pat”, instead of the more
+mysterious “Couldn't unify 'Many with 'One”
+(see `#23586 <https://gitlab.haskell.org/ghc/ghc/-/issues/23586>`_).
+But maybe the additional restrictions are more surprising than the
+error messages are helpful.
+
 The Core corner
 ===============
 


### PR DESCRIPTION
Would be best consumed using the rich diff view, except it doesn't appear to work. Fortunately, this is almost entirely added section, so I can point to them individually.

- [Specification of linear lets](https://github.com/tweag/ghc-proposals/blob/linear-lets/proposals/0111-linear-types.rst#let-and-where-bindings)
  - In addition to the above, `LinearTypes` is proposed to imply `MonoLocalBinds`
- [Effects and interaction](https://github.com/tweag/ghc-proposals/blob/linear-lets/proposals/0111-linear-types.rst#let-bindings-and-polymorphism)
- [Alternatives](https://github.com/tweag/ghc-proposals/blob/linear-lets/proposals/0111-linear-types.rst#id13)

This is a rather straightforward amendment which specifies multiplicity-annotated let bindings which, for reasons unknown to me, were only implied before. Pretty much all the choices are forced, the design space is really tiny. In consequence I intend to leave this open for comments a few work days before I submit it to the committee.

@simonpj , you may want to take part of the pre-committee reviews.