### PR TITLE
Add table of contents to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@ GHC.
 * `≡ List of implemented proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+label%3A%22Implemented%22>`_
 * `≡ List of all proposals <https://github.com/ghc-proposals/ghc-proposals/pulls?q=is%3Apr+-label%3Anon-proposal>`_
 
+Table of Contents
+=================
+.. contents:: :local:
+
 What is a proposal?
 -------------------
 


### PR DESCRIPTION
See preview here: https://github.com/ghc-proposals/ghc-proposals/blob/75fb64a7d71d9350025195cfb7b6bfcbeceb55e3/README.rst#table-of-contents

This patch also adds links from all subsequent sections to the TOC

I'm using level 1 header here because `:local:` directive builds TOC from headings of a lower level and without `:local:` `contents` directive will spawn text like `Contents` above the TOC that looks like plain text.