### PR TITLE
Modify multiline string proposal to remove one trailing newline

### DIFF
--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -119,6 +119,8 @@ A working prototype is available at `brandonchinn178/string-syntax <https://gith
 
    #. If the first character of the string is a newline, remove it
 
+   #. If the last character of the string is a newline, remove it
+
 #. After parsing, it becomes indistinguishable to the equivalent single-quoted string (modulo annotations for exact-printing)
 
 Common whitespace prefix calculation
@@ -207,6 +209,10 @@ Step 2vi - Since the first character is a newline character, we remove it and ar
 
   "..abc\\n\\n..def\\n\\nghi\\n....\\njkl\\n"
 
+Step 2vii - Since the last character is a newline character, we remove it and are left with the final result::
+
+  "..abc\\n\\n..def\\n\\nghi\\n....\\njkl"
+
 Step 3 - This gets treated as a normal string from now on, with the escaped ``\\n`` characters interpreted as usual.
 
 Ignore leading characters
@@ -230,7 +236,7 @@ The common prefix calculation ignores all characters preceding the first newline
     """
 
   -- equivalent to
-  s' = "Line 1\n   Line 2\nLine 3\n"
+  s' = "Line 1\n   Line 2\nLine 3"
 
 This implies that normal strings could also be written using ``"""``
 
@@ -255,7 +261,7 @@ String gaps are collapsed first and not included in the whitespace calculation
       """
 
   -- equivalent to
-  s' = "a b c d e\nf g\n"
+  s' = "a b c d e\nf g"
 
 Mixing tabs and spaces
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -272,7 +278,7 @@ In the following example, each line has 16 leading spaces after expanding tabs.
   ⇥"""
 
   -- equivalent to
-  s' = "a\nb\nc\n"
+  s' = "a\nb\nc"
 
 Leading newline
 ~~~~~~~~~~~~~~~
@@ -290,27 +296,24 @@ The specification strips exactly one leading newline, which is the behavior of l
     """
 
   -- equivalent to
-  s' = "\na\nb\nc\n"
+  s' = "\na\nb\nc"
 
 Trailing newline
 ~~~~~~~~~~~~~~~~
 
-As mentioned in the example in *Section 3.1 General Walkthrough*, trailing newlines are naturally included without any explicit rules. As a bonus, it does the same thing that ``unlines`` does. To avoid a trailing newline, put the closing ``"""`` immediately after the last line, or use a string gap:
+Similarly to a single leading newline being removed, a single trailing newline will also be removed. To keep the trailing newline, add a blank line after the last line:
 
 ::
 
-  x =
+  s =
     """
     a
     b
-    c"""
 
-  x2 =
     """
-    a
-    b
-    c\
-    \"""
+
+  -- equivalent to
+  s' = "a\nb\n"
 
 Indent every line
 ~~~~~~~~~~~~~~~~~
@@ -328,7 +331,7 @@ In the following example, desugaring ``s1`` into ``s1'`` removes the 2 spaces be
       c
     """
 
-  s1' = "a\nb\nc\n"
+  s1' = "a\nb\nc"
 
   s2 =
     """
@@ -344,7 +347,7 @@ In the following example, desugaring ``s1`` into ``s1'`` removes the 2 spaces be
     \&  c
     """
 
-  s2' = "  a\n  b\n  c\n"
+  s2' = "  a\n  b\n  c"
 
 Escaping triple quotes
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -379,7 +382,7 @@ Since escaped characters are resolved *after* calculating the common whitespace 
 
 ::
 
-  s' = " name\tage\n Alice\t20\n Bob\t30\n\t40\n"
+  s' = " name\tage\n Alice\t20\n Bob\t30\n\t40"
 
 Example from Fourmolu
 ~~~~~~~~~~~~~~~~~~~~~
@@ -434,6 +437,7 @@ With multiline strings:
       Aeson.Null -> pure PrintStyleInherit
       Aeson.String "" -> pure PrintStyleInherit
       _ -> PrintStyleOverride <$> Aeson.parseJSON v
+
     """
 
   adtParsePrinterOptType =
@@ -441,6 +445,7 @@ With multiline strings:
     \\s -> case s of
       "" -> pure PrintStyleInherit
       _ -> PrintStyleOverride <$> parsePrinterOptType s
+
     """
 
 While the double backslash is still required, I think the overall style is much better (could be resolved in a later proposal adding raw strings).
@@ -529,6 +534,7 @@ With multiline strings:
               [ "unknown value: " <> show s
               , "Valid values are: %s"
               ]
+
     """
     fieldTypeName
     fieldTypeName

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -230,7 +230,7 @@ The common prefix calculation ignores all characters preceding the first newline
     """
 
   -- equivalent to
-  s' = "Line 1\n   Line 2\nLine 3"
+  s' = "Line 1\n   Line 2\nLine 3\n"
 
 This implies that normal strings could also be written using ``"""``
 
@@ -328,7 +328,7 @@ In the following example, desugaring ``s1`` into ``s1'`` removes the 2 spaces be
       c
     """
 
-  s1' = "a\nb\nc"
+  s1' = "a\nb\nc\n"
 
   s2 =
     """
@@ -344,7 +344,7 @@ In the following example, desugaring ``s1`` into ``s1'`` removes the 2 spaces be
     \&  c
     """
 
-  s2' = "  a\n  b\n  c"
+  s2' = "  a\n  b\n  c\n"
 
 Escaping triple quotes
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -379,7 +379,7 @@ Since escaped characters are resolved *after* calculating the common whitespace 
 
 ::
 
-  s' = " name\tage\n Alice\t20\n Bob\t30\n\t40"
+  s' = " name\tage\n Alice\t20\n Bob\t30\n\t40\n"
 
 Example from Fourmolu
 ~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -112,6 +112,7 @@ A working prototype is available at `brandonchinn178/string-syntax <https://gith
 
       * See the "Common whitespace prefix calculation" section below for the specification of the calculation
       * If a line only contains whitespace, remove all of the whitespace
+      * Don't remove common whitespace immediately after the delimiter, see the example in *Section 3.2 Ignore leading characters*
 
    #. Join the string back with ``\n`` delimiters
 
@@ -246,6 +247,18 @@ This implies that normal strings could also be written using ``"""``
   s = """hello world"""
   s' = "hello world"
 
+Because characters immediately after the ``"""`` delimiter should be included verbatim, common whitespace will NOT be removed.
+
+::
+
+  s =
+    """    hello
+    world
+    """
+
+  -- equivalent to
+  s' = "    hello\nworld"
+
 String gaps
 ~~~~~~~~~~~
 
@@ -298,6 +311,29 @@ The specification strips exactly one leading newline, which is the behavior of l
   -- equivalent to
   s' = "\na\nb\nc"
 
+The leading newline is removed in step (vi); it has to be done at the end and not the beginning, because any characters on the same line as the opening delimiter should be included verbatim, and removing the leading newline early would treat the first line differently, without more logic.
+
+::
+
+  s1 =
+    """    a
+    b
+    c
+    """
+
+  s2 =
+    """
+    a
+    b
+    c
+    """
+
+  -- In the current proposal, these are equivalent to
+  -- the below. If leading newline were removed at the
+  -- beginning, both would result in s1'.
+  s1' = "    a\nb\nc"
+  s2' = "a\nb\nc"
+
 Trailing newline
 ~~~~~~~~~~~~~~~~
 
@@ -314,6 +350,8 @@ Similarly to a single leading newline being removed, a single trailing newline w
 
   -- equivalent to
   s' = "a\nb\n"
+
+The trailing newline is removed in step (vii); it has to be done at the end and not the beginning, because the closing delimiter is probably indented at the same level, so the newline character isn't the last character until after stripping whitespace. Removing the trailing newline at the beginning would require pulling up some of the whitespace stripping logic as well.
 
 Indent every line
 ~~~~~~~~~~~~~~~~~

--- a/proposals/0569-multiline-strings.rst
+++ b/proposals/0569-multiline-strings.rst
@@ -351,6 +351,83 @@ Similarly to a single leading newline being removed, a single trailing newline w
   -- equivalent to
   s' = "a\nb\n"
 
+In addition to being symmetric with stripping a single leading newline, stripping a single trailing newline has the benefit of composing better + behaving better with ``putStrLn``.
+
+::
+
+  s1 =
+    """
+    line 1
+    line 2
+    """
+
+  s2 = "line 3"
+
+  s3 =
+    """
+    line 4
+    line 5
+    """
+
+  putStrLn $ unlines [s1, s2, s3]
+
+  {-
+  Without stripping trailing newline:
+     "line 1\n"
+  ++ "line 2\n"
+  ++ "\n"
+  ++ "line 3\n"
+  ++ "line 4\n"
+  ++ "line 5\n"
+  ++ "\n"
+
+  With stripping trailing newline:
+     "line 1\n"
+  ++ "line 2\n"
+  ++ "line 3\n"
+  ++ "line 4\n"
+  ++ "line 5\n"
+  -}
+
+This is even more beneficial if we ever add string interpolation as well (See the "Out of scope" section for more details).
+
+::
+
+  s1 =
+    """
+    line 1
+    line 2
+    """
+
+  s2 =
+    """
+    line 3
+    line 4
+    """
+
+  putStrLn
+    s"""
+    ${s1}
+    ${s2}
+    """
+
+  {-
+  Without stripping trailing newline:
+     "line 1\n"
+  ++ "line 2\n"
+  ++ "\n"
+  ++ "line 3\n"
+  ++ "line 4\n"
+  ++ "\n"
+  ++ "\n"
+
+  With stripping trailing newline:
+     "line 1\n"
+  ++ "line 2\n"
+  ++ "line 3\n"
+  ++ "line 4\n"
+  -}
+
 The trailing newline is removed in step (vii); it has to be done at the end and not the beginning, because the closing delimiter is probably indented at the same level, so the newline character isn't the last character until after stripping whitespace. Removing the trailing newline at the beginning would require pulling up some of the whitespace stripping logic as well.
 
 Indent every line


### PR DESCRIPTION
After thinking through this more, I think it makes more sense for exactly one trailing newline to be stripped, the same as exactly one leading newline is stripped.

Current proposal: https://github.com/ghc-proposals/ghc-proposals/blob/424b22fd7fb15c56aa4fbdfa1ed86d3f5245eda2/proposals/0569-multiline-strings.rst

## Motivation for change

### Abstract motivation

The abstract reason why I think the trailing newline should be omitted is to be consistent with the leading newline. One behavior I think most people in the original thread agreed with is that most of the time, the developer doesn't intend the newline right after the `"""` delimiter to be included. If a leading newline is intended, I think most people think it's more obvious when there's an explicitly blank line in between:

```
x = """

  This has exactly one leading newline
  """
```
I think it makes the overall feature more consistent and intuitive to have the same behavior for both beginning and end.

### Practical motivation

Practically speaking, I think it composes a bit better, e.g.
```
s1 =
  """
  line 1
  line 2
  """

s2 = "line 3"

s3 =
  """
  line 4
  line 5
  """

putStrLn $ unlines [s1, s2, s3]

{-
Old behavior:
   "line 1\n"
++ "line 2\n"
++ "\n"
++ "line 3\n"
++ "line 4\n"
++ "line 5\n"
++ "\n"

New behavior:
   "line 1\n"
++ "line 2\n"
++ "line 3\n"
++ "line 4\n"
++ "line 5\n"
-}
```

But then again, perhaps this is contrived, and people would just use `concat` instead.