### PR TITLE
Extra MaybeField Selectors

### DIFF
--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -1,0 +1,107 @@
+Extra MaybeField Selectors
+====================
+
+.. author:: Viktor WW
+.. date-accepted::
+.. ticket-url:: 
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/639>`_.
+.. sectnum::
+.. contents::
+
+This proposal add safety and error-less runtime (on wrong use of field selector) by using ``ExtraMaybeFieldSelectors`` instead of partial field-selectors.
+
+
+Motivation
+----------
+
+Partial field-selectors could produce runtime errors and this is extremely weak design. Also duplicated partial field-selectors could have "magical" type of sub-types.
+
+This proposal add simplicity, safety and error-less runtime by using ``ExtraMaybeFieldSelectors`` instead of partial field-selectors.
+
+
+Proposed Change Specification
+-----------------------------
+
+Let we have next Sum-Type ``data`` ::
+
+  data Message 
+      = SendChat  { message :: Text,      user :: UserId,  uid :: UserId }
+      | Signup    { eventId :: EventId,   user :: UserId,  uid :: EventId }
+      | SendOrder { signalId :: SignalId, user :: UserId,  uid :: SignalId }
+
+
+This creates several functions (if ``NoFieldSelector`` is off): ::
+
+  message  :: Message -> Text     -- or runtime Error
+
+  eventId  :: Message -> EventId  -- or runtime Error
+
+  signalId :: Message -> SignalId -- or runtime Error
+
+  
+  user :: Message -> UserId
+
+  uid  :: Message -> "magical" (UserId | EventId | SignalId)
+
+
+We suggest a language extension: with ``ExtraMaybeFieldSelectors`` extra code is produced:
+  
+- For each partial selector ``<field>`` with type signature ``<field> :: <dataType> -> <fieldType>`` we create function ``<newname> :: <dataType> -> Maybe <fieldType>``
+
+- For each **unique** partial selector ``<field>`` we create function ``maybe<Field>`` function (with capitalized first letter of field-selector)
+  
+- For each **repetitive**/**duplicated** partial selector ``<field>`` we create function ``maybe<Construcor><Field>`` function (with capitalized first letter of field-selector)
+
+
+For this specipic example ``data Message`` next functions will be added  ::
+
+  maybeMessage  :: Message -> Maybe Text
+
+  maybeEventId  :: Message -> Maybe EventId
+
+  maybeSignalId :: Message -> Maybe SignalId
+
+  
+  maybeSendChatUser  :: Message -> Maybe UserId
+
+  maybeSignupUser    :: Message -> Maybe UserId
+
+  maybeSendOrderUser :: Message -> Maybe UserId
+
+  
+  maybeSendChatUid  :: Message -> Maybe UserId
+
+  maybeSignupUid    :: Message -> Maybe EventId
+
+  maybeSendOrderUid :: Message -> Maybe SignalId
+
+
+*Note: all this code is safe in use, it is error-less in runtime and have "ordinary" types in signatures.*
+
+
+Effect and Interactions
+-----------------------
+
+Any Effect and Interactions are unknown. But as "future possibilities", inside ``OverloadedRecordDot`` extension (or independently) we could add ``getMaybeField`` function.
+
+Costs and Drawbacks
+-------------------
+
+We expect the implementation and maintenance costs for this feature to be minimal.
+
+Backward Compatibility
+----------------------
+
+This proposal is fully backward compatible.
+
+Alternatives
+------------
+
+A partial alternative is `Partial Field Behavior #535 <https://github.com/ghc-proposals/ghc-proposals/pull/535>`_
+
+Implementation Plan
+-------------------
+
+It is unclear.

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -138,7 +138,7 @@ We expect this proposal could also affect ``HasField`` class ::
     hasField = fromJust . hasMaybeField
 	
     -- define just "hasField" makes "hasMaybeField" unsafe
-    {#- MINIMAL hasMaybeField | hasField -#}
+    {-# MINIMAL hasMaybeField | hasField #-}
 	
   getMaybeField :: forall x r a . HasField x r a => r -> Maybe a
   getMaybeField = fmap snd . hasMaybeField @x

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -40,7 +40,7 @@ This creates several functions (if ``NoFieldSelector`` is off): ::
 
   signalId :: Message -> SignalId -- or runtime Error
   
-  user :: Message -> UserId -- from SendChat or Signup or runtime Error
+  user     :: Message -> UserId   -- from SendChat or Signup or runtime Error
 
 
 
@@ -51,25 +51,19 @@ We suggest a language extension: with ``ExtraMaybeFieldSelectors`` extra code is
   
 - For each *de-jure* Sum-Type: ``data`` with at least one ``|`` sign we create maybe-fields-selectors (or several constructors on GADTs definitions)
 
-- For each partial selector ``<field>`` with type signature ``<field> :: <dataType> -> <fieldType>`` we create function ``<newname> :: <dataType> -> Maybe <fieldType>``
-
-- For each **unique** partial selector ``<field>`` we create function ``maybeFs<Field>`` function (with capitalized first letter of field-selector), where "Fs" is short from "field-selector"
-  
-- For each **repetitive**/**duplicated** partial selector ``<field>`` we create function ``maybeDp<Constructor>Fs<Field>`` function (with capitalized first letter of field-selector), where "Dp" is short from "duplicated"
+- For each selector ``<field> :: <dataType> -> <fieldType>`` we create function ``<field>'maybe :: <dataType> -> Maybe (<fieldType>)``
 
 
 For this specific example ``data Message`` next functions will be added  ::
 
-  maybeFsMessage  :: Message -> Maybe Text
+  message'maybe  :: Message -> Maybe Text
 
-  maybeFsEventId  :: Message -> Maybe EventId
+  eventId'maybe  :: Message -> Maybe EventId
 
-  maybeFsSignalId :: Message -> Maybe SignalId
+  signalId'maybe :: Message -> Maybe SignalId
 
-  
-  maybeDpSendChatFsUser  :: Message -> Maybe UserId
+  user'maybe     :: Message -> Maybe UserId
 
-  maybeDpSignupFsUser    :: Message -> Maybe UserId
 
 
 *Note: all this code is safe in use, it is error-less in runtime.*
@@ -78,11 +72,11 @@ For this specific example ``data Message`` next functions will be added  ::
 Import, export
 ~~~~~~~~~~~~~~
 
-Sure, we could manually write functions for import and export. We suggest new syntax for field-depended mentioning by adding ``.maybe`` to data-type ::
+Sure, we could manually write functions for import and export. We suggest new syntax for field-depended mentioning by adding ``'maybe`` to data-type ::
 
   module M
-    ( S(x), S(x).maybe
-    , T(..), T(..).maybe
+    ( S(x), S(x)'maybe
+    , T(..), T(..)'maybe
     ) where 
     -- ...
 
@@ -92,11 +86,11 @@ Examples
 Several-parts field type
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If we have several-parts field type, than parentheses must be added to final type: ``<newname> :: <dataType> -> Maybe (<fieldType>)`` ::
+If we have several-parts field type, than parentheses must be added to final type: ``<field>'maybe :: <dataType> -> Maybe (<fieldType>)`` ::
 
   data OptionRec a = None | Some { fromSome :: Maybe a }
 
-  maybeFsFromSome :: OptionRec a -> Maybe (Maybe a)
+  fromSome'maybe :: OptionRec a -> Maybe (Maybe a)
 
 
 GADTs fields-selectors
@@ -114,91 +108,45 @@ If data type is written using GADTs, this extension create function for each fie
 
   -- (Foo A) and (Foo B) are de-facto not a Sum-Types, but they are de-jure a Sum-Type
 
-  maybeFsFooa :: Foo A -> Maybe ()
+  fooa'maybe :: Foo A -> Maybe ()
 
-  maybeFsFoob :: Foo B -> Maybe Int
+  foob'maybe :: Foo B -> Maybe Int
 
-  maybeFsFooc :: Foo C -> Maybe (Maybe Bool)
+  fooc'maybe :: Foo C -> Maybe (Maybe Bool)
 
-  maybeFsFood :: Foo C -> Maybe Char
+  food'maybe :: Foo C -> Maybe Char
 
 
 Effect and Interactions
 -----------------------
 
-We expect this proposal could also affect ``HasField`` class fro `158 Record SetField <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0158-record-set-field.rst>`_  ::
+We expect this proposal could also affect ``HasField`` class.  we add similar classes `HasMaybeField`/`SetMaybeField`  ::
 
-  class HasField (x :: k) r a | x r -> a where
-    
-    -- new function
-    hasMaybeField :: r -> Maybe (a -> r, a)
-    hasMaybeField = Just . hasField
-	
-    hasField :: r -> (a -> r, a)
-    hasField = fromJust . hasMaybeField
-	
-    -- defining just "hasField" makes "hasMaybeField" same unsafe as "hasField"
-    {-# MINIMAL hasMaybeField | hasField #-}
-	
-  getMaybeField :: forall x r a . HasField x r a => r -> Maybe a
-  getMaybeField = fmap snd . hasMaybeField @x
+ create additional  classes `HasMaybeField`/`SetMaybeField` 
 
-  setMaybeField :: forall x r a . HasField x r a => r -> a -> Maybe r
-  setMaybeField r a = fmap fst (hasMaybeField @x r) <*> (pure a)
-  
-  setMaybeFieldIgnore :: forall x r a . HasField x r a => r -> a -> r
-  setMaybeFieldIgnore r a = case setMaybeField @x r a of 
-     | Just rn -> rn
-     | Nothing -> r 
-
-  getField :: forall x r a . HasField x r a => r -> a
-  getField = snd . hasField @x
-
-  setField :: forall x r a . HasField x r a => r -> a -> r
-  setField = fst . hasField @x
-
-UPDATE for approved `583 HasField Redesign <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0583-hasfield-redesign.rst>`_ ::
-
-  type HasField :: forall {k} {r_rep} {a_rep} . k -> TYPE r_rep -> TYPE a_rep -> Constraint
-  class HasField x r a | x r -> a where
-    -- | Selector function to extract the field @x@ from the record @r@.
-    getField :: r -> a
-    getField = fromFust . getMaybeField
-
+  class HasMaybeField x r a | x r -> a where
     getMaybeField :: r -> Maybe a
-    getMaybeField = Just. getField
 
-    -- defining just "getField" makes "getMaybeField" same unsafe as "getField"
-    {-# MINIMAL getMaybeField | getField #-}
-
-
-
-  type SetField :: forall {k} {r_rep} {a_rep} . k -> TYPE r_rep -> TYPE a_rep -> Constraint
-  class SetField x r a | x r -> a where
-    -- | Change the value stored in the field @x@ of the record @r@.
-    modifyField :: (a -> a) -> r -> r
-    default modifyField :: (r_rep ~ LiftedRep, a_rep ~ LiftedRep, HasField x r a) => (a -> a) -> r -> r
-    modifyField f r = setField @x (f (getField @x r)) r
-
+  class SetMaybeField x r a | x r -> a where
     modifyMaybeField :: (a -> a) -> r -> Maybe r
-    default modifyMaybeField :: (r_rep ~ LiftedRep, a_rep ~ LiftedRep, HasField x r a) => (a -> a) -> r -> Maybe r
+    default modifyMaybeField :: (r_rep ~ LiftedRep, a_rep ~ LiftedRep, HasMaybeField x r a) => (a -> a) -> r -> Maybe r
     modifyMaybeField f r = (\fn -> setMaybeField @x fn r) <$> (f <$> (getMaybeField @x r))
 
-    -- | Update function to set the field @x@ in the record @r@.
-    setField :: a -> r -> r
-    -- setField = fromJust . setMaybeField
-    default setField :: a_rep ~ LiftedRep => a -> r -> r
-    setField v = modifyField @x (\ _ -> v)
+    setMaybeField :: a -> r -> r
+    default setMaybeField :: a_rep ~ LiftedRep => a -> r -> Maybe r
+    setMaybeField v = modifyMaybeField @x (\ _ -> v)
 
-    setMaybeField :: a -> r -> Maybe r
-    setMaybeField = Just . setField
+    {-# MINIMAL modifyMaybeField | setMaybeField #-}
 
-    -- Haskell DO NOT suport right now several "default" strategies 
-    -- like "MINIMAL modifyField | setField | modifyMaybeField | setMaybeField"
-    -- so now we ignore "MINIMAL setMaybeField | setField | modifyField" 
-    -- and now we ignore "MINIMAL setMaybeField | setField" 
-    -- and use instead as was:
-    {-# MINIMAL modifyField | setField  #-}
+And we instead of writting ``r { user = blah } :: r`` write ``r { user'maybe = blah } :: Maybe r`` and for updating several fields we desugars with Maybe-Monad ::
+
+  r { user'maybe = blah, message'maybe = bar }
+
+  -- desugars (this is not optimal desugaring)
+  do
+    r1 <- r  { user'maybe = blah }
+    r2 <- r1 { message'maybe = bar }
+    return r2
 
 We expect this proposal affects ``OverloadedRecordDot`` and ``OverloadedRecordUpdate`` extensions for maybe-selectors.
 
@@ -223,15 +171,15 @@ A partial alternative is `Partial Field Behavior #535 <https://github.com/ghc-pr
 Unresolved Questions
 --------------------
 
-Name-collision is possible, but it is highly unlikely (with "FsFs" collisions) ::
+Name-collision is possible, but it is highly unlikely (with "``'maybe``" in fields names) ::
 
   data T
-    = A   {fsB :: Int, b   :: Char}
-    | AFs {b   :: Char, fsB :: Int}
+    = A {f'maybe :: Int, f   :: Char}
+    | B {f   :: Char, f'maybe :: Int}
 
-  maybeDpAFsFsB  :: T -> Maybe Int -- Dp + A + Fs + FsB
+  f'maybe :: T -> Maybe Char
 
-  maybeDpAFsFsB  :: T -> Maybe Int -- Dp + AFs + Fs + B
+  f'maybe'maybe  :: T -> Maybe Int
 
 
 Implementation Plan

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -156,7 +156,7 @@ We expect this proposal could also affect ``HasField`` class ::
   setField = fst . hasField @x
 
 
-We expect this proposal affects ``OverloadedRecordDot`` and``OverloadedRecordUpdate`` extensions for maybe-selectors.
+We expect this proposal affects ``OverloadedRecordDot`` and ``OverloadedRecordUpdate`` extensions for maybe-selectors.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -137,7 +137,7 @@ We expect this proposal could also affect ``HasField`` class ::
     hasField :: r -> (a -> r, a)
     hasField = fromJust . hasMaybeField
 	
-    -- define just "hasField" makes "hasMaybeField" unsafe
+    -- defining just "hasField" makes "hasMaybeField" same unsafe as "hasField"
     {-# MINIMAL hasMaybeField | hasField #-}
 	
   getMaybeField :: forall x r a . HasField x r a => r -> Maybe a

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -46,6 +46,9 @@ This creates several functions (if ``NoFieldSelector`` is off): ::
   uid  :: Message -> "magical" (UserId | EventId | SignalId)
 
 
+Extra functions
+~~~~~~~~~~~~~~~
+
 We suggest a language extension: with ``ExtraMaybeFieldSelectors`` extra code is produced:
   
 - For each partial selector ``<field>`` with type signature ``<field> :: <dataType> -> <fieldType>`` we create function ``<newname> :: <dataType> -> Maybe <fieldType>``
@@ -80,11 +83,24 @@ For this specipic example ``data Message`` next functions will be added  ::
 
 *Note: all this code is safe in use, it is error-less in runtime and have "ordinary" types in signatures.*
 
+Import, export
+~~~~~~~~~~~~~~
+
+Sure, we could manually write functions for import and export. We suggest new syntax for field-depended mentioning ::
+
+  module M
+    ( S(x), S(x).maybe
+    , T(..), T(..).maybe
+    ) where 
+    -- ...
+
 
 Effect and Interactions
 -----------------------
 
-Any Effect and Interactions are unknown. But as "future possibilities", inside ``OverloadedRecordDot`` extension (or independently) we could add ``getMaybeField`` function.
+We expect this proposal affects ``OverloadedRecordDot`` extension for maybe-selectors.
+
+We expect this proposal affects ``DisambiguateRecordFields`` extension for reading only maybe-selectors.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -156,7 +156,7 @@ We expect this proposal could also affect ``HasField`` class ::
   setField = fst . hasField @x
 
 
-We expect this proposal affects ``OverloadedRecordDot`` extension for maybe-selectors.
+We expect this proposal affects ``OverloadedRecordDot`` and``OverloadedRecordUpdate`` extensions for maybe-selectors.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -165,7 +165,9 @@ This proposal is fully backward compatible.
 Alternatives
 ------------
 
-A partial alternative is `Partial Field Behavior #535 <https://github.com/ghc-proposals/ghc-proposals/pull/535>`_
+1) Alternative naming. Maybe instead of ``'maybe`` should be used another "suffix", like ``#maybe``.
+
+2) A partial alternative is `Partial Field Behavior #535 <https://github.com/ghc-proposals/ghc-proposals/pull/535>`_
 
 
 Unresolved Questions

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -145,9 +145,11 @@ We expect this proposal could also affect ``HasField`` class ::
 
   setMaybeField :: forall x r a . HasField x r a => r -> a -> Maybe r
   setMaybeField r a = fmap fst (hasMaybeField @x r) <*> (pure a)
-
+  
   setMaybeFieldIgnore :: forall x r a . HasField x r a => r -> a -> r
-  setMaybeFieldIgnore r a = fromJust $ (setMaybeField @x r a) <|> (Just r)
+  setMaybeFieldIgnore r a = case setMaybeField @x r a of 
+     | Just rn -> rn
+     | Nothing -> r 
 
   getField :: forall x r a . HasField x r a => r -> a
   getField = snd . hasField @x

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -143,10 +143,11 @@ We expect this proposal could also affect ``HasField`` class ::
   getMaybeField :: forall x r a . HasField x r a => r -> Maybe a
   getMaybeField = fmap snd . hasMaybeField @x
 
-  setMaybeField :: forall x r a . HasField x r a => r -> a -> r
-  setMaybeField r a = case hasMaybeField @x r of
-		Nothing     -> r    -- do not update if wrong field-selector
-		Just (f, _) -> f a
+  setMaybeField :: forall x r a . HasField x r a => r -> a -> Maybe r
+  setMaybeField r a = fmap fst (hasField @x r) <*> (pure a)
+
+  setMaybeFieldIgnore :: forall x r a . HasField x r a => r -> a -> r
+  setMaybeFieldIgnore r a = fromJust $ (setMaybeField @x r a) <|> (Just r)
 
   getField :: forall x r a . HasField x r a => r -> a
   getField = snd . hasField @x

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -120,9 +120,7 @@ If data type is written using GADTs, this extension create function for each fie
 Effect and Interactions
 -----------------------
 
-We expect this proposal could also affect ``HasField`` class.  we add similar classes `HasMaybeField`/`SetMaybeField`  ::
-
- create additional  classes `HasMaybeField`/`SetMaybeField` 
+We expect this proposal could also affect ``HasField`` class.  We add similar classes `HasMaybeField`/`SetMaybeField`  ::
 
   class HasMaybeField x r a | x r -> a where
     getMaybeField :: r -> Maybe a
@@ -138,15 +136,13 @@ We expect this proposal could also affect ``HasField`` class.  we add similar cl
 
     {-# MINIMAL modifyMaybeField | setMaybeField #-}
 
+
 And we instead of writting ``r { user = blah } :: r`` write ``r { user'maybe = blah } :: Maybe r`` and for updating several fields we desugars with Maybe-Monad ::
 
   r { user'maybe = blah, message'maybe = bar }
 
-  -- desugars (this is not optimal desugaring)
-  do
-    r1 <- r  { user'maybe = blah }
-    r2 <- r1 { message'maybe = bar }
-    return r2
+  -- desugars
+  r  { user'maybe = blah } >>= \r1 -> r1 { message'maybe = bar }
 
 We expect this proposal affects ``OverloadedRecordDot`` and ``OverloadedRecordUpdate`` extensions for maybe-selectors.
 

--- a/proposals/0000-extra_maybe_field_selectors.rst
+++ b/proposals/0000-extra_maybe_field_selectors.rst
@@ -144,7 +144,7 @@ We expect this proposal could also affect ``HasField`` class ::
   getMaybeField = fmap snd . hasMaybeField @x
 
   setMaybeField :: forall x r a . HasField x r a => r -> a -> Maybe r
-  setMaybeField r a = fmap fst (hasField @x r) <*> (pure a)
+  setMaybeField r a = fmap fst (hasMaybeField @x r) <*> (pure a)
 
   setMaybeFieldIgnore :: forall x r a . HasField x r a => r -> a -> r
   setMaybeFieldIgnore r a = fromJust $ (setMaybeField @x r a) <|> (Just r)


### PR DESCRIPTION
**Extra MaybeField Selectors**

This proposal add safety and error-less runtime by using `ExtraMaybeFieldSelectors` instead of partial field-selectors.

A bit alternative to #535

[Rendered](https://github.com/VitWW/ghc-proposals/blob/extra-maybe-field-selectors/proposals/0000-extra_maybe_field_selectors.rst)