### PR TITLE
Amend the named defaults proposal to allow WARNINGS pragmas on exports

### DIFF
--- a/proposals/0409-exportable-named-default.rst
+++ b/proposals/0409-exportable-named-default.rst
@@ -109,6 +109,18 @@ declarations.
 The syntactic extension to exports would be enabled by the same ``{-# LANGUAGE NamedDefaults #-}`` pragma. The new
 semantics of imports would be enabled by default with no ``LANGUAGE`` extension required.
 
+`WARNING` pragma on export
+--------------------------
+
+As with regular export items, the user can attach a ``WARNING`` pragma to an export of a default: ::
+
+  {-# LANGUAGE NamedDefaults #-}
+  module M ({-# WARNING "This default is deprecated, use explicit type applications" #-} default MyClass)
+
+The warning would triggered only if an importer actually uses the default to disambiguate a type. In other words, the
+pragma would replace a generic compiler warning about type defaults, enabled by ``-Wtype-defaults``, with a specific
+warning enabled by ``-Wdeprecations``.
+
 Subsumption
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This is a small amendment to the accepted [proposal #409](https://github.com/ghc-proposals/ghc-proposals/pull/409) as [requested](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11853#note_552605) by Simon PJ.
