### PR TITLE
'Fix quantification order' has been implemented

### DIFF
--- a/proposals/0640-tyop-quantification-order.rst
+++ b/proposals/0640-tyop-quantification-order.rst
@@ -4,7 +4,7 @@ Fix quantification order for (a `op` b) and (a %m -> b)
 .. author:: Vladislav Zavialov
 .. date-accepted::
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/23764
-.. implemented::
+.. implemented:: 9.12
 .. highlight:: haskell
 .. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/640>`_.
 .. sectnum::


### PR DESCRIPTION
Implemented in https://github.com/ghc/ghc/commit/d31fbf6c75440ec99c8bf47c592a10778a226957.

Please also add the https://github.com/ghc-proposals/ghc-proposals/labels/Implemented label to #640.