### PR TITLE
Import shadowing (under review)

### DIFF
--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -330,8 +330,11 @@ So this is a "-1"-impact change: it doesn't break existing code, and
 
 Alternatives
 ------------
-There are two alternative ways of referring to names defined at the
-current module's top level:
+
+Status quo
+~~~~~~~~~~
+Before this proposal, there are two alternative ways of referring to
+names defined at the current module's top level:
 
 * The imported names we want to shadow can be hidden from the import
   itself, using the ``import SomeModule hiding (someName)`` syntax
@@ -339,6 +342,45 @@ current module's top level:
 * The current module's name can be used to qualify names,
   i.e. ``CurrentModule.someName`` instead of just ``someName``.
 
+Ordered imports
+~~~~~~~~~~~~~~~
+Other languages like OCaml or Agda have a linear top-level scope. The
+Haskell equivalent of this would be that later ``import`` statements
+and top-level bindings shadow earlier ones. By way of example,
+supposing ``foo`` is exported by all of ``A``, ``B``, and ``C``:
+
+::
+   
+ module Mod where
+
+ import A
+ import B
+
+ -- Here, "foo" resolves to "B.foo"
+
+ foo = ...
+
+ -- Here, "foo" resolves to "Mod.foo"
+ 
+ import C
+
+ -- Here, "foo" resolves to "C.foo"
+
+This would be a complete departure from Haskell's usual permutation
+invariance of definitions. It is this proposal author's opinion that
+this would be too large a change to be up to the addition of a mere
+``LANGUAGE`` pragma.
+
+A full proposal for this would also need to answer hairy questions
+like:
+
+* If ``Mod`` exports ``foo``, which ``foo`` does that resolve to?
+
+* Can I import ``A`` again to make its ``foo`` shadow ``C.foo``?
+
+* Is it allowed to re-bind ``foo`` in ``Mod`` if there are
+  ``import`` statements between it and the previous binding of ``foo``?  
+ 
 Unresolved Questions
 --------------------
 **TODO: add later, from Proposal comments**

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -111,10 +111,12 @@ Consider an occurrence of a qualified name ``M.x``:
     qualified name ``M.x``, the occurrence is resolved to that
     entity.
 
-In both cases, Haskell 2010 regards cases (A) and (B) on equal
-footing: if exactly one of the two cases can be used to resolve the
-name, that case is used; if both cases can be used, then the
-occurrence is ambiguous and reported as such.
+In both cases, Haskell 2010 regards cases (A) and (B) on equal footing
+`as per Section 5.5.2
+<https://www.haskell.org/onlinereport/haskell2010/haskellch5.html#x11-1090005.5.2>`_:
+if exactly one of the two cases can be used to resolve the name, that
+case is used; if both cases can be used, then the occurrence is
+ambiguous and reported as such.
 
 Instead, we propose that when ``ImportShadowing`` is enabled,
 (A) and (B) are tried in order, i.e. if the (A) case resolves the

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -62,7 +62,25 @@ import list of ``Control.Exception``.
 We believe this is an improvement to the status quo because it is a
 natural extension of the idea behind the shadowing policy of local
 binders: that shadowing expresses the intention by the user to only
-care about the names that are defined "more nearby".
+care about the names that are defined "more nearby". A cursory search
+on `Stack Overflow <https://stackoverflow.com/>`_ finds lots of
+Haskell users who implicitly expected imports to be shadowed by
+top-level definitions:
+
+* https://stackoverflow.com/q/73788349/477476
+* https://stackoverflow.com/q/7761238/477476
+* https://stackoverflow.com/q/56047335/477476
+* https://stackoverflow.com/q/40964909/477476
+* https://stackoverflow.com/q/40314142/477476
+* https://stackoverflow.com/q/67246392/477476
+
+A second-order effect of the proposed extension is that it can lead to
+preemptive forward compatibility. Adding a new export to ``Prelude``
+can lead to breakage just by virtue of existing code defining and
+using top-level definitions with the same name. With
+``ImportShadowing``, the existing intra-module references keep their
+meaning and there is no migration needed to accomodate the new
+``Prelude`` names.
 
 Proposed Change Specification
 -----------------------------
@@ -310,14 +328,6 @@ previously unaccepted programs accepted by the scope checker.
 So this is a "-1"-impact change: it doesn't break existing code, and
 "un-breaks" existing broken code.
 
-A second-order effect of this is that using this extension can lead to
-preemptive forward compatibility. Adding a new export to ``Prelude``
-can lead to breakage just by virtue of existing code defining and
-using top-level definitions with the same name. With
-``ImportShadowing``, the existing intra-module references keep their
-meaning and there is no migration needed to accomodate the new
-``Prelude`` names.
-
 Alternatives
 ------------
 There are two alternative ways of referring to names defined at the
@@ -344,18 +354,7 @@ For other Haskell compilers, the implementation plan depends on their
 current name resolution infrastructure.
 
 Endorsements
--------------
-A cursory search on `Stack Overflow <https://stackoverflow.com/>`_
-finds lots of Haskell users who implicitly expected imports to be
-shadowed by top-level definitions:
-
-* https://stackoverflow.com/q/73788349/477476
-* https://stackoverflow.com/q/7761238/477476
-* https://stackoverflow.com/q/56047335/477476
-* https://stackoverflow.com/q/40964909/477476
-* https://stackoverflow.com/q/40314142/477476
-* https://stackoverflow.com/q/67246392/477476
-
-As mentioned in the Drawbacks section, we also have positive
+------------
+As mentioned in the Drawbacks section, we have positive
 experience in a setting where ``ImportShadowing`` is always on in a
 large Haskell code base with lots of developers over a long time.

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -21,11 +21,11 @@ living in a scope that is "outside" the top-level one.
 
 Motivation
 ----------
-Currently, there is no way in Haskell to shadow an imported name. The
-only workaround is to avoid importing said name at all. For example,
-if we want to use some ``Control.Exception`` functions while also
-defining our own ``catch``, we have to import the former with an explicit
-hiding of ``catch``:
+Currently, there is no way in Haskell to shadow an imported name in
+the top-level scope. The only workaround is to avoid importing said
+name at all. For example, if we want to use some ``Control.Exception``
+functions while also defining our own ``catch``, we have to import the
+former with an explicit hiding of ``catch``:
 
 ::
 

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -66,6 +66,13 @@ care about the names that are defined "more nearby".
 
 Proposed Change Specification
 -----------------------------
+Occurrences of an identifier in the code of a module and in its export
+list are looked up in an environment containing all the global
+definitions in that module. If that lookup fails, then the identifier
+is looked up in an environment containing all the definitions imported
+by import statements (including the implicit import of the
+``Prelude``, if any).
+
 In Haskell 2010, all imported names and all top-level definitions in
 the current module together make up a single unified top-level
 scope. With this proposed alternative policy, there are two top-level

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -1,0 +1,311 @@
+Import shadowing
+================
+
+.. author:: Gergo Erdi
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/652>`_.
+.. sectnum::
+.. contents::
+
+Local binders are allowed to shadow names defined in outer
+scopes. Here, we propose that top-level binders should also be allowed
+to shadow imported names, basically treating imported modules as
+living in a scope that is "outside" the top-level one.
+
+
+Motivation
+----------
+Currently, there is no way in Haskell to shadow an imported name. The
+only workaround is to avoid importing said name at all. For example,
+if we want to use some ``Control.Exception`` functions while also
+defining our own ``catch``, we have to import the former with an explicit
+hiding of ``catch``:
+
+::
+
+ module Example1 where
+
+ import Control.Exception hiding (catch)
+
+ catch :: Fish -> IO Food
+ catch fish = ...
+
+ goFishing :: IO Food
+ goFishing = bracket goToCabin goHome $ catch salmon
+
+Without hiding ``catch``, this results in a name resolution conflict
+in the definition of ``goFishing``:
+
+::
+
+ Ambiguous occurrence `catch'
+ It could refer to
+    either `Control.Exception.catch',
+           imported from `Control.Exception' at Example1.hs:1:1-24
+           (and originally defined in `GHC.IO')
+        or `Example1.catch', defined at Example1.hs:7:1
+
+Our proposal is an alternative name resolution policy exposed as a
+language extension tentatively named ``ImportShadowing``. It allows
+definitions from the current module's top-level scope to shadow names
+from imported modules. So in this example, the occurrence of ``catch``
+in the definition of ``goFishing`` resolves to the definition in
+``Example1`` even when ``catch`` is not explicitly hidden from the
+import list of ``Control.Exception``.
+
+We believe this is an improvement to the status quo because it is a
+natural extension of the idea behind the shadowing policy of local
+binders: that shadowing expresses the intention by the user to only
+care about the names that are defined "more nearby".
+
+Proposed Change Specification
+-----------------------------
+In Haskell 2010, all imported names and all top-level definitions in
+the current module together make up a single unified top-level
+scope. With this proposed alternative policy, there are two top-level
+scopes instead: one consisting of all imported names, and a second
+one, *under* this first one, that consists of all top-level definitions
+from the current module.
+
+To model these two name resolution approaches, we can desugar the
+Haskell 2010 name resolution policy for a given module to a single
+nested ``let``-block, e.g. for the following program:
+ 
+::
+
+ module Mod (fun1, fun2) where
+
+ import A hiding (overridden)
+ import qualified B
+
+ overridden = ... importedFromA ...
+ fun1 = ... overridden ...
+ fun2 = ... B.importedFromB ... fun1 ...
+
+we can write out its explicit scoping as:
+
+::
+
+ let
+   -- imports from A
+   importedFromA = ...
+
+   -- imports from B
+   B.importedFromB = ...
+
+   -- defined in Mod
+   overridden = ... importedFromA ...
+   fun1 = ... overridden ...
+   fun2 = ... B.importedFromB ... fun1 ...
+ in
+   -- exports of Mod
+   (fun1, fun2)
+
+With our proposed scheme, the same program with ``ImportShadowing``
+turned on can be modeled as a two nested ``let`` blocks:
+
+::
+
+ let
+   -- imported from A
+   importedFromA = ...
+
+   -- imports from B
+   B.importedFromB = ...
+
+ in
+   -- defined in Mod
+   let
+     overridden = ... importedFromA ...
+     fun1 = ... overridden ...
+     fun2 = ... B.importedFromB ... fun1 ...
+   in
+     -- exports of Mod
+     (fun1, fun2)
+
+Of course, in this example, there is no observable difference between
+the two desugarings, since our module ``Mod`` was already well-scoped
+with the Haskell 2010 shadowing rules. However, if we change the
+program slightly by importing all of ``A`` wholesale:
+
+::
+
+ module Mod (fun1, fun2) where
+
+ import A
+ import qualified B
+
+ overridden = ... importedFromA ...
+ fun1 = ... overridden ...
+ fun2 = ... B.importedFromB ... fun1 ...
+
+then the desugaring using Haskell 2010 semantics leads to the
+following invalid program (note the two bindings of ``overridden`` in
+the same ``let``):
+
+::
+
+ let
+   -- imports from A
+   importedFromA = ...
+   overriden = ...
+
+   -- imports from B
+   B.importedFromB = ...
+
+   -- defined in Mod
+   overridden = ... importedFromA ...
+   fun1 = ... overridden ...
+   fun2 = ... B.importedFromB ... fun1 ...
+ in
+   -- exports of Mod
+   (fun1, fun2)
+
+Whereas the ``ImportShadowing`` version is valid:
+
+::
+
+ let
+   -- imported from A
+   importedFromA = ...
+   overridden = ...
+
+   -- imports from B
+   B.importedFromB = ...
+
+ in
+   -- defined in Mod
+   let
+     overridden = ... importedFromA ... -- This shadows the imported "overridden"!
+     fun1 = ... overridden ...
+     fun2 = ... B.importedFromB ... fun1 ...
+   in
+     -- exports of Mod
+     (fun1, fun2)
+
+Examples
+--------
+This extension shines especially when shadowing names defined in the
+``Prelude``, since hiding ``Prelude`` imports otherwise requires
+changing to an explicit import for ``Prelude``: we can go from
+
+::
+
+ module Mod where
+
+ import Prelude hiding (zip)
+
+ zip = ...
+
+to just
+
+::
+
+ module Mod where
+
+ zip = ...
+
+The above example is taken directly from `the "Import" page of the
+Haskell Wiki <https://wiki.haskell.org/Import>`_.
+   
+Effect and Interactions
+-----------------------
+Beside intra-module references, the other place where top-level
+bindings can be used is export specifications. It feels natural to
+resolve exports in the same scope used for the module. For example, if
+we have something like
+
+::
+
+ module A (foo) where
+
+ import B -- This exports "foo"
+
+ foo = ...
+
+then the ``foo`` exported by ``A`` should be the one defined in
+``A``'s top-level.
+
+
+Costs and Drawbacks
+-------------------
+The usual drawback of language extensions leading to some language
+fragmentation.
+
+Users new to Haskell seem to find this idea intuitive. We have
+gathered decade+-long experience with a Haskell compiler that uses
+import shadowing (and doesn't even let users turn it off), with a
+Haskell code base of several million lines of code that sees work from
+both experienced Haskell developers as well as people with a
+non-software-engineering background whose introduction to Haskell was
+via this compiler. There's no record of either novices (learning only
+the import-shadowing behaviour) or experienced Haskellers (who are
+used to imports being in the same scope as top-level definitions) ever
+getting into trouble due to this difference to Haskell 2010.
+
+
+Backward Compatibility
+----------------------
+Haskell 2010 doesn't have a mechanism for shadowing imported names,
+and valid Haskell 2010 programs retain their exact meanings with
+``ImportShadowing`` turned on. The proposed extension only makes
+previously unaccepted programs accepted by the scope checker.
+
+So this is a "-1"-impact change: it doesn't break existing code, and
+"un-breaks" existing broken code.
+
+A second-order effect of this is that using this extension can lead to
+preemptive forward compatibility. Adding a new export to ``Prelude``
+can lead to breakage just by virtue of existing code defining and
+using top-level definitions with the same name. With
+``ImportShadowing``, the existing intra-module references keep their
+meaning and there is no migration needed to accomodate the new
+``Prelude`` names.
+
+Alternatives
+------------
+There are two alternative ways of referring to names defined at the
+current module's top level:
+
+* The imported names we want to shadow can be hidden from the import
+  itself, using the ``import SomeModule hiding (someName)`` syntax
+
+* The current module's name can be used to qualify names,
+  i.e. ``CurrentModule.someName`` instead of just ``someName``.
+
+Unresolved Questions
+--------------------
+**TODO: add later, from Proposal comments**
+
+Implementation Plan
+-------------------
+For GHC specifically, it already has a similar name resolution policy,
+only used by the GHCi REPL. Implementing ``ImportShadowing`` is as
+easy as switching to the GHCi shadowing mechanism, plus some extra
+fiddling around disambiguating exported names.
+
+For other Haskell compilers, the implementation plan depends on their
+current name resolution infrastructure.
+
+Endorsements
+-------------
+A cursory search on `Stack Overflow <https://stackoverflow.com/>`_
+finds lots of Haskell users who implicitly expected imports to be
+shadowed by top-level definitions:
+
+* https://stackoverflow.com/q/73788349/477476
+* https://stackoverflow.com/q/7761238/477476
+* https://stackoverflow.com/q/56047335/477476
+* https://stackoverflow.com/q/40964909/477476
+* https://stackoverflow.com/q/40314142/477476
+* https://stackoverflow.com/q/67246392/477476
+
+As mentioned in the Drawbacks section, we also have positive
+experience in a setting where ``ImportShadowing`` is always on in a
+large Haskell code base with lots of developers over a long time.

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -220,25 +220,27 @@ to just
 
 The above example is taken directly from `the "Import" page of the
 Haskell Wiki <https://wiki.haskell.org/Import>`_.
-   
+
 Effect and Interactions
 -----------------------
-Beside intra-module references, the other place where top-level
-bindings can be used is export specifications. It feels natural to
-resolve exports in the same scope used for the module. For example, if
-we have something like
+* Beside intra-module references, the other place where top-level
+  bindings can be used is export specifications. It feels natural to
+  resolve exports in the same scope used for the module. For example, if
+  we have something like
 
-::
+  ::
 
- module A (foo) where
+   module A (foo) where
 
- import B -- This exports "foo"
+   import B -- This exports "foo"
 
- foo = ...
+   foo = ...
 
-then the ``foo`` exported by ``A`` should be the one defined in
-``A``'s top-level.
+  then the ``foo`` exported by ``A`` should be the one defined in
+  ``A``'s top-level.
 
+* Top-level bindings that shadow imported names should be regarding as
+  shadowing bindings for the purposes of ``-Wname-shadowing``.
 
 Costs and Drawbacks
 -------------------

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -66,13 +66,36 @@ care about the names that are defined "more nearby".
 
 Proposed Change Specification
 -----------------------------
-Occurrences of an identifier in the code of a module and in its export
-list are looked up in an environment containing all the global
-definitions in that module. If that lookup fails, then the identifier
-is looked up in an environment containing all the definitions imported
-by import statements (including the implicit import of the
-``Prelude``, if any).
+Consider an occurrence of an unqualified name ``x``, not bound locally
+(by ``let``, lambda, a ``case`` alternative, etc). There are two
+possible sources of resolving it:
 
+(A) If there is a top-level binding of ``x`` then the occurrence is
+    resolved to that binding.
+
+(B) If the import declarations bring into scope a unique entity with
+    unqualified name ``x``, the occurrence is resolved to that entity.
+
+Consider an occurrence of a qualified name ``M.x``:
+
+(A) If the module is called ``M`` and there is a top-level binding of
+    ``x``, the occurrence is resolved to that binding
+
+(B) If the import declarations bring into scope a unique entity with
+    qualified name ``M.x``, the occurrence is resolved to that
+    entity.
+
+In both cases, Haskell 2010 regards cases (A) and (B) on equal
+footing: if exactly one of the two cases can be used to resolve the
+name, that case is used; if both cases can be used, then the
+occurrence is ambiguous and reported as such.
+
+This proposal instead tries (A) and (B) in order, i.e. if the (A) case
+resolves the occurrence, then that is used, and the (B) case is only
+checked otherwise.
+
+Alternative perspective: desugaring into ``let`` bindings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In Haskell 2010, all imported names and all top-level definitions in
 the current module together make up a single unified top-level
 scope. With this proposed alternative policy, there are two top-level

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -85,6 +85,8 @@ meaning and there is no migration needed to accomodate the new
 Proposed Change Specification
 -----------------------------
 
+A new language extension ``ImportShadowing`` is added.
+
 When ``ImportShadowing`` is enabled, the following changes take place:
 
 Resolution of references in module body

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -87,8 +87,6 @@ Proposed Change Specification
 
 When ``ImportShadowing`` is enabled, the following changes take place:
 
-.. _spec-body:
-
 Resolution of references in module body
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -252,7 +250,8 @@ Export lists
 
 References in a module's export specification are resolved in the same
 scope as that used for references in the module body, as per
-:ref:`spec-body`. For example if we have something like
+`Resolution of references in module body`_. For example if we have
+something like
 
 ::
 

--- a/proposals/0000-import-shadowing.rst
+++ b/proposals/0000-import-shadowing.rst
@@ -239,6 +239,24 @@ Effect and Interactions
   then the ``foo`` exported by ``A`` should be the one defined in
   ``A``'s top-level.
 
+* When modules are reexported wholesale, shadowing doesn't come into
+  play and the original module's contents are exported:
+
+  ::
+
+   module A (module B) where
+
+   import B -- this exports "foo"
+
+   foo = ...
+
+  Here, it is ``B.foo`` that is (re-)exported by ``A``, not ``A.foo``.
+
+  If both ``module B`` and ``foo`` are exported, then that is the same
+  category of error as without this extension exporting ``module B``
+  and ``module C`` with conflicting names, and should be reported the
+  same way.
+   
 * Top-level bindings that shadow imported names should be regarding as
   shadowing bindings for the purposes of ``-Wname-shadowing``.
 


### PR DESCRIPTION
Local binders are allowed to shadow names defined in outer scopes. Here, we propose that top-level binders should also be allowed to shadow imported names, basically treating imported modules as living in a scope that is "outside" the top-level one.

[Rendered here](https://github.com/gergoerdi/ghc-proposals/blob/mu/import-shadowing/proposals/0000-import-shadowing.rst)