### PR TITLE
Update nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,6 @@
 let
   np = import <nixpkgs> {};
-in np.mkShell { buildInputs = [ np.pythonPackages.sphinx ]; }
+in np.mkShell { buildInputs = [ np.python312Packages.sphinx
+                                np.python312Packages.myst-parser
+                              ];
+              }


### PR DESCRIPTION
Update nix shell build inputs to use python 312 packages, and add the myst-parser package.

This was apparently necessary to run `make html` when using nixpkgs `24.05pre622847.b211b392b848`.