### PR TITLE
Allow arbitrary identifiers as fields in `OverloadedRecordDot` and `OverloadedRecordUpdate`

### DIFF
--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -269,23 +269,14 @@ follows:
      *aexp*   →    *aexp* _⟨*qcon*⟩ ``{`` *fbind* ₁ ``,`` … ``,`` *fbind* ₙ ``}`` 	    (labeled update, n  ≥  1)
 
 
-For reference, the existing ``OverloadedLabels`` extension adds the following
-productions (see `proposal #170 <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0170-unrestricted-overloadedlabels.rst>`_):
-
-[Overloaded label]
-:raw-html:`<br />`
-     *labelChar*   →   *small* | *large* | *digit* | ``'``
-:raw-html:`<br />`
-     *label*   →   ``#`` (*string* | *labelChar* {*labelChar*})
-:raw-html:`<br />`
-     *aexp*   →   *label*
-
 Under this proposal, the ``OverloadedRecordDot`` extension adds the following
 productions:
 
 [Field selection]
 :raw-html:`<br />`
-     *field*   →   (*string* | *labelChar* {*labelChar*})
+     *fieldChar*   →   *small* | *large* | *digit* | ``'``
+:raw-html:`<br />`
+     *field*   →   (*string* | *fieldChar* {*fieldChar*})
 :raw-html:`<br />`
      *fexp*   →   *fexp* *.ᵀ* *field*
 
@@ -295,19 +286,30 @@ productions:
 :raw-html:`<br />`
      *aexp*   →   ``(`` *projection* ``)``
 
+The grammar for the existing ``OverloadedLabels`` extension
+(see `proposal #170 <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0170-unrestricted-overloadedlabels.rst>`_)
+can then be restated (without change to the accepted language) as:
+
+[Overloaded label]
+:raw-html:`<br />`
+     *label*   →   ``#`` *field*
+:raw-html:`<br />`
+     *aexp*   →   *label*
 
 Under this proposal, the ``OverloadedRecordUpdate`` extension adds the following
-productions:
+productions (replacing the existing *aexp* production for record updates):
 
 [Field update]
 :raw-html:`<br />`
      *fieldToUpdate*   →   *fieldToUpdate* *.ᵀ* *field*   |   *field*
 :raw-html:`<br />`
-     *fbind*   →    *fieldToUpdate* ``=`` *exp*
+     *fbindUpdate*   →    *fieldToUpdate* ``=`` *exp*   |   *fieldToUpdate*
 :raw-html:`<br />`
-     *fbind*   →   *fieldToUpdate*
+     *aexp*   →    *aexp* _⟨*qcon*⟩ ``{`` *fbindUpdate* ₁ ``,`` … ``,`` *fbindUpdate* ₙ ``}`` 	    (labeled update, n  ≥  1)
 
-The *field* nonterminal includes *varid*, *reservedid*, *conid* and *string*.
+
+The *field* nonterminal overlaps with *varid*, *reservedid*, *conid* and *string*.
+No ambiguity arises thereby because *field* occurs only in very specific syntactic places.
 This nonterminal is used in the new expression syntax for overloaded field
 selection and update, so expressions such as the following are accepted:
 
@@ -315,16 +317,9 @@ selection and update, so expressions such as the following are accepted:
 - ``.Lbl``, even though ``Lbl`` starts with an uppercase character so it cannot be a traditional field name;
 - ``e { "_ some string! " = v }``, even though traditional field names cannot be arbitrary strings.
 
-Record updates are permitted to be nested under this proposal
-(e.g. ``e { foo.bar = baz }``, or ``e { foo.bar }`` with punning), and field
-names of updates may be reserved keywords (e.g. ``e { type = x }`` or
-``e { type }`` are allowed).
-
 This proposal changes only the accepted expressions for selection and update. It
 does not affect record data constructor declarations, record construction or
-pattern matching.  (While the changes to *fbind* allow more record constructions
-to parse, a construction such as ``C { type = e }}`` or ``C { foo.bar = e }``
-will continue to be rejected during name resolution.)
+pattern matching.
 
 Thus reserved keywords such as ``type`` cannot be defined as field names of
 normal record data constructors, but they are permitted in selection and update

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -213,6 +213,8 @@ Symbol Occurence
 [Field]
 :raw-html:`<br />`
      *field*   →   *varid* | *reservedid*
+     
+(We include *reservedid* so that ``foo.type`` is allowed. This does not affect what identifiers are allowed as record fields, where *reservedid*s such as ``type`` are not allowed.) 
 
 .. _section-1:
 

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -270,6 +270,12 @@ instance that makes a virtual field ``type`` available.
 2.5 Precedence
 ~~~~~~~~~~~~~~
 
+``M.x`` is parsed as a qualified name ``x`` in the module ``M``, not a selection
+of the field ``x`` from the nullary data constructor ``M``.  If the latter
+interpretation is desired for some reason, the user can write ``M."x"``.
+Similarly, ``M.do`` is parsed as a use of ``QualifiedDo`` from module ``M``
+rather than selection of the field ``do``.
+
 ``M.N.x`` looks ambiguous. It could mean:
 
 - ``(M.N).x`` that is, select the ``x`` field from the (presumably nullary) data constructor ``M.N``, or

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -2,7 +2,7 @@ Record Dot Syntax
 =================
 
 .. author:: Neil Mitchell and Shayne Fletcher
-.. date-accepted:: 2020-05-03, amended 2021-03-09
+.. date-accepted:: 2020-05-03, amended 2021-03-09 and 2025-05-13
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/18599
 .. implemented:: 9.2
 .. highlight:: haskell

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -77,26 +77,26 @@ This change adds new language extensions ``OverloadedRecordDot`` and
 
 If ``OverloadedRecordDot`` is on:
 
-- The expression ``.lbl`` means ``getField @"lbl"``;
-- The expression ``e.lbl`` means ``getField @"lbl" e``.
+- The expression ``.fld`` means ``getField @"fld"``;
+- The expression ``e.fld`` means ``getField @"fld" e``.
 
 If ``OverloadedRecordDot`` is not on, these expressions are parsed as
 uses of the function ``(.)``.
 
-If ``OverloadedRecordUpdate`` is on, the expression ``e{lbl = val}``
-means ``setField @"lbl" val``.
+If ``OverloadedRecordUpdate`` is on, the expression ``e{fld = val}``
+means ``setField @"fld" val``.
 
-If ``OverloadedRecordUpdate`` is not on, ``e{lbl = val}`` means just
+If ``OverloadedRecordUpdate`` is not on, ``e{fld = val}`` means just
 what it does in Haskell98.
 
 If ``OverloadedRecordDot`` and ``OverloadedRecordUpdate`` are both on:
 
-- The expression ``e{lbl₁.lbl₂ = val}`` means ``e{lbl₁ = (e.lbl₁){lbl₂ = val}}``;
-- The expression ``e{M.lbl = val}`` means ``setField @"M" (setField @"lbl" val (getField @"M" e)) e``;
+- The expression ``e{fld₁.fld₂ = val}`` means ``e{fld₁ = (e.fld₁){fld₂ = val}}``;
+- The expression ``e{M.fld = val}`` means ``setField @"M" (setField @"fld" val (getField @"M" e)) e``;
 
-otherwise the expression ``e{lbl₁.lbl₂ = val}`` is illegal, while
-the expression ``e{M.lbl = val}`` refers to the qualified name ``M.lbl``, i.e.
-the ``lbl`` field exported by the module ``M``.
+otherwise the expression ``e{fld₁.fld₂ = val}`` is illegal, while
+the expression ``e{M.fld = val}`` refers to the qualified name ``M.fld``, i.e.
+the ``fld`` field exported by the module ``M``.
 
 
 2.1.1 Syntax
@@ -108,22 +108,22 @@ In the event the language extensions ``OverloadedRecordDot`` and
 ======================= ==================================
 Expression              Equivalent
 ======================= ==================================
-``(.lbl)``              ``(\e -> e.lbl)``
-``(.lbl₁.lbl₂)``        ``(\e -> e.lbl₁.lbl₂)``
-``e.lbl``               ``getField @"lbl" e``
-``e.Lbl``               ``getField @"Lbl" e``
-``e."lbl₁ lbl₂"``       ``getField @"lbl₁ lbl₂"``
-``e.lbl₁.lbl₂``         ``(e.lbl₁).lbl₂``
-``e{lbl = val}``        ``setField @"lbl" e val``
+``(.fld)``              ``(\e -> e.fld)``
+``(.fld₁.fld₂)``        ``(\e -> e.fld₁.fld₂)``
+``e.fld``               ``getField @"fld" e``
+``e.fld``               ``getField @"fld" e``
+``e."fld₁ fld₂"``       ``getField @"fld₁ fld₂"``
+``e.fld₁.fld₂``         ``(e.fld₁).fld₂``
+``e{fld = val}``        ``setField @"fld" e val``
 ``e{"x.y" = val}``      ``setField @"x.y" e val``
-``e{lbl₁.lbl₂ = val}``  ``e{lbl₁ = (e.lbl₁){lbl₂ = val}}``
-``e.lbl₁{lbl₂ = val}``  ``(e.lbl₁){lbl₂ = val}``
-``e{lbl₁ = val₁}.val₂`` ``(e{lbl₁ = val₁}).val₂``
-``e{lbl₁}``             ``e{lbl₁ = lbl₁}`` [Note: requires ``NamedFieldPuns``]
-``e{lbl₁.lbl₂}``        ``e{lbl₁.lbl₂ = lbl₂}`` [Note: requires ``NamedFieldPuns``]
+``e{fld₁.fld₂ = val}``  ``e{fld₁ = (e.fld₁){fld₂ = val}}``
+``e.fld₁{fld₂ = val}``  ``(e.fld₁){fld₂ = val}``
+``e{fld₁ = val₁}.val₂`` ``(e{fld₁ = val₁}).val₂``
+``e{fld₁}``             ``e{fld₁ = fld₁}`` [Note: requires ``NamedFieldPuns``]
+``e{fld₁.fld₂}``        ``e{fld₁.fld₂ = fld₂}`` [Note: requires ``NamedFieldPuns``]
 ======================= ==================================
 
-- **Updating nested fields.** ``e{lbl = val}`` is the syntax of a standard H98 record update. It’s the nested form introduced by this proposal that is new : ``e{lbl1.lbl2 = val}``. However, in the event ``OverloadedRecordUpdate`` is in effect, note that ``e{lbl = val}`` desugars to ``setField @"lbl" e val``].
+- **Updating nested fields.** ``e{fld = val}`` is the syntax of a standard H98 record update. It’s the nested form introduced by this proposal that is new : ``e{fld1.fld2 = val}``. However, in the event ``OverloadedRecordUpdate`` is in effect, note that ``e{fld = val}`` desugars to ``setField @"fld" e val``].
 - **Punning.** With ``NamedFieldPuns``, the form ``e { x, y }`` means ``e { x=x, y=y }``. With ``OverloadedRecordUpdate`` this behaviour is extended to nested updates: ``e { a.b.c, x.y }`` means ``e { a.b.c=c, x.y=y }``. Note the variable that is referred to implicitly (here ``c`` and ``y``) is the last chunk of the field to update. So ``c`` is the last chunk of ``a.b.c``, and ``y`` is the last chunk of ``x.y``.
 
 2.1.2 Precedence
@@ -314,7 +314,7 @@ This nonterminal is used in the new expression syntax for overloaded field
 selection and update, so expressions such as the following are accepted:
 
 - ``e.type``, even though ``type`` would normally be a reserved keyword;
-- ``.Lbl``, even though ``Lbl`` starts with an uppercase character so it cannot be a traditional field name;
+- ``.fld``, even though ``fld`` starts with an uppercase character so it cannot be a traditional field name;
 - ``e { "_ some string! " = v }``, even though traditional field names cannot be arbitrary strings.
 
 This proposal changes only the accepted expressions for selection and update. It
@@ -599,7 +599,7 @@ leave this feature out.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There are no update sections. Should ``({a=})``, ``({a=b})`` or
-``(.lbl=)`` be an update section? While nice, we leave this feature out.
+``(.fld=)`` be an update section? While nice, we leave this feature out.
 
 7.4 Should pattern matching be extended?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -98,23 +98,18 @@ This proposal adds new language extensions ``OverloadedRecordDot`` and
 
   If ``OverloadedRecordDot`` is not on, these expressions are parsed as uses of the function ``(.)``.
 
-- **Field update.** If ``OverloadedRecordUpdate`` is on, the field update
-  ``e{fld = val}`` means ``setField @"fld" val``.
+- **Haskell98 field updates.** If ``OverloadedRecordUpdate`` is not on, then the
+  field update ``e{fld = val}`` means just what it does in Haskell98, regardless of
+  ``OverloadedRecordDot``.  Moreover, as Haskell98 specifies, the nested field update
+  ``e{fld₁.fld₂ = val}`` is illegal unless ``fld₁`` is a module qualifier ``M``, in
+  which case the field update ``e{M.fld = val}`` refers to the qualified name
+  ``M.fld``, i.e. the ``fld`` field exported by the module ``M``.
 
-  If ``OverloadedRecordUpdate`` is not on, ``e{fld = val}`` means just what it does in Haskell98.
+- **Overloaded field updates.** If ``OverloadedRecordUpdate`` is on:
 
-- **Nested field update.** If ``OverloadedRecordDot`` and ``OverloadedRecordUpdate`` are both on,
-  the field update ``e{fld₁.fld₂ = val}`` means ``e{fld₁ = (e.fld₁){fld₂ = val}}``.
-
-  If ``OverloadedRecordUpdate`` is on but ``OverloadedRecordDot`` is not, the
-  field update ``e{fld₁.fld₂ = val}`` is illegal.  In particular, an update
-  expression with a module-qualified field, such as ``e{M.x = val}``, is
-  illegal.
-
-  If ``OverloadedRecordUpdate`` is not on, the field update ``e{fld₁.fld₂ = val}``
-  is illegal unless ``fld₁`` is a module qualifier ``M``, in which case the
-  field update ``e{M.fld = val}`` refers to the qualified name ``M.fld``,
-  i.e. the ``fld`` field exported by the module ``M``.
+  - The field update ``e{fld = val}`` means ``setField @"fld" val``.
+  - If ``OverloadedRecordDot`` is also on, the nested field update ``e{fld₁.fld₂ = val}`` means ``e{fld₁ = (e.fld₁){fld₂ = val}}``.
+  - If ``OverloadedRecordDot`` is not on, the nested field update ``e{fld₁.fld₂ = val}`` is illegal, including the form ``e{ M.fld = val}``.
 
 - **Punning.** With ``NamedFieldPuns``, the form ``e { x, y }`` means ``e { x=x, y=y }``.
   With ``OverloadedRecordUpdate`` this behaviour is extended to nested

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -212,7 +212,7 @@ Symbol Occurence
 
 [Field]
 :raw-html:`<br />`
-     *field*   →   *varid*
+     *field*   →   *varid* | *reservedid*
 
 .. _section-1:
 

--- a/proposals/0282-record-dot-syntax.rst
+++ b/proposals/0282-record-dot-syntax.rst
@@ -6,7 +6,7 @@ Record Dot Syntax
 .. ticket-url:: https://gitlab.haskell.org/ghc/ghc/-/issues/18599
 .. implemented:: 9.2
 .. highlight:: haskell
-.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/282>`_ and  `amended by this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/405>`_.
+.. header:: This proposal was `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/282>`_ and  `amended by this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/405>`_ and `this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/668>`_.
 .. contents::
 
 
@@ -112,8 +112,8 @@ Expression              Equivalent
 ``e{lbl₁.lbl₂ = val}``  ``e{lbl₁ = (e.lbl₁){lbl₂ = val}}``
 ``e.lbl₁{lbl₂ = val}``  ``(e.lbl₁){lbl₂ = val}``
 ``e{lbl₁ = val₁}.val₂`` ``(e{lbl₁ = val₁}).val₂``
-``e{lbl₁}``             ``e{lbl₁ = lbl₁}`` [Note: requires ``NamedFieldUpdates``]
-``e{lbl₁.lbl₂}``        ``e{lbl₁.lbl₂ = lbl₂}`` [Note: requires ``NamedFieldUpdates``]
+``e{lbl₁}``             ``e{lbl₁ = lbl₁}`` [Note: requires ``NamedFieldPuns``]
+``e{lbl₁.lbl₂}``        ``e{lbl₁.lbl₂ = lbl₂}`` [Note: requires ``NamedFieldPuns``]
 ======================= ==================================
 
 - **Updating nested fields.** ``e{lbl = val}`` is the syntax of a standard H98 record update. It’s the nested form introduced by this proposal that is new : ``e{lbl1.lbl2 = val}``. However, in the event ``OverloadedRecordUpdate`` is in effect, note that ``e{lbl = val}`` desugars to ``setField @"lbl" e val``].
@@ -195,8 +195,7 @@ not enabled.
 2.3.2 Parsing
 ^^^^^^^^^^^^^
 
-The Haskell grammar is extended with the following productions. We use
-these notations:
+We use these notations:
 
 ====== ===========
 Symbol Occurence
@@ -205,56 +204,117 @@ Symbol Occurence
 *.ᵀ*   tight-infix
 ====== ===========
 
-2.3.2.1
+The relevant part of the lexical syntax (defined in `chapter 2 of the Haskell
+2010 report
+<https://www.haskell.org/onlinereport/haskell2010/haskellch2.html>`_) and the
+grammar of Haskell expressions (defined in `chapter 3 of the Haskell 2010 report
+<https://www.haskell.org/onlinereport/haskell2010/haskellch3.html>`_) is as
+follows:
 
 .. role:: raw-html(raw)
     :format: html
 
-[Field]
+[Variable]
 :raw-html:`<br />`
-     *field*   →   *varid* | *reservedid*
-     
-(We include *reservedid* so that ``foo.type`` is allowed. This does not affect what identifiers are allowed as record fields, where *reservedid*s such as ``type`` are not allowed.) 
-
-.. _section-1:
-
-2.3.2.2
-
-
-[Field to update]
+     *varid*   →    (*small* {*small* | *large* | *digit* | ``'``})_⟨*reservedid*⟩
 :raw-html:`<br />`
-     *fieldToUpdate*   →   *fieldToUpdate* *.ᵀ* *field*   |   *field*
-
-.. _section-2:
-
-2.3.2.3
-
-
-[Field selectors]
+     *qvar*   →    *qvarid* | ``(`` *qvarsym* ``)``
 :raw-html:`<br />`
-     *aexp*   →   *( projection )*
+     *qvarid*   →    [*modid* ``.``] *varid*
+
+[Function application expression]
 :raw-html:`<br />`
-     *projection*   →   *.ᴾ* *field*   |   *projection* *.ᵀ* *field*
+     *fexp*   →    [*fexp*] *aexp*
 
-.. _section-3:
+[Field binding]
+:raw-html:`<br />`
+     *fbind*   →    *qvar* ``=`` *exp*
 
-2.3.2.4
+[Expression]
+:raw-html:`<br />`
+     *aexp*   →    *qvar* (variable)
+:raw-html:`<br />`
+     *aexp*   →    *gcon* (general constructor)
+:raw-html:`<br />`
+     *aexp*   →    *literal*
+:raw-html:`<br />`
+     *aexp*   →    ``(`` *exp* ``)``    (parenthesized expression)
+:raw-html:`<br />`
+     *aexp*   →    ``(`` *exp* ₁ ``,`` … ``,`` *exp* ₖ ``)`` 	    (tuple, k ≥ 2)
+:raw-html:`<br />`
+     *aexp*   →    ``[`` *exp* ₁ ``,`` … ``,`` *exp* ₖ ``]`` 	    (list, k ≥ 1)
+:raw-html:`<br />`
+     *aexp*   →    ``[`` *exp* ₁ [``,`` *exp* ₂] ``..`` [*exp* ₃] ``]`` 	    (arithmetic sequence)
+:raw-html:`<br />`
+     *aexp*   →    ``[`` *exp* ``|`` *qual* ₁ ``,`` … ``,`` *qual* ₙ ``]`` 	    (list comprehension, n ≥ 1)
+:raw-html:`<br />`
+     *aexp*   →    ``(`` *infixexp* *qop* ``)`` 	    (left section)
+:raw-html:`<br />`
+     *aexp*   →    ``(`` *qop* _⟨``-``⟩ *infixexp* ``)`` 	    (right section)
+:raw-html:`<br />`
+     *aexp*   →    *qcon* ``{`` *fbind* ₁ ``,`` … ``,`` *fbind* ₙ ``}`` 	    (labeled construction, n ≥ 0)
+:raw-html:`<br />`
+     *aexp*   →    *aexp* _⟨*qcon*⟩ ``{`` *fbind* ₁ ``,`` … ``,`` *fbind* ₙ ``}`` 	    (labeled update, n  ≥  1)
 
+
+For reference, the existing ``OverloadedLabels`` extension adds the following
+productions:
+
+[Overloaded label]
+:raw-html:`<br />`
+     *aexp*   →   ``#`` {*small* | *large* | *digit* | ``'``}
+:raw-html:`<br />`
+     *aexp*   →   ``#`` *string*
+
+
+Under this proposal, the ``OverloadedRecordDot`` extension adds the following
+productions:
 
 [Field selection]
 :raw-html:`<br />`
+     *field*   →   *small* {*small* | *large* | *digit* | ``'`` }
+:raw-html:`<br />`
      *fexp*   →   *fexp* *.ᵀ* *field*
 
-.. _section-4:
+[Field selector]
+:raw-html:`<br />`
+     *projection*   →   *.ᴾ* *field*   |   *projection* *.ᵀ* *field*
+:raw-html:`<br />`
+     *aexp*   →   ``(`` *projection* ``)``
 
-2.3.2.5
 
+Under this proposal, the ``OverloadedRecordUpdate`` extension adds the following
+productions:
 
 [Field update]
 :raw-html:`<br />`
-     *fbind*   →    *field* *.ᵀ* *fieldToUpdate* *=* *exp*
+     *fieldToUpdate*   →   *fieldToUpdate* *.ᵀ* *field*   |   *field*
 :raw-html:`<br />`
-     *fbind*   →   *field* *.ᵀ* *fieldToUpdate*
+     *fbind*   →    *fieldToUpdate* ``=`` *exp*
+:raw-html:`<br />`
+     *fbind*   →   *fieldToUpdate*
+
+The new *field* nonterminal is equivalent to *varid | reservedid*.  This
+nonterminal is used in the new expression syntax for overloaded field selection,
+so expressions such as ``e.type`` are accepted, even though ``type`` would
+normally be a reserved keyword.
+
+Record updates are permitted to be nested under this proposal
+(e.g. ``e { foo.bar = baz }``, or ``e { foo.bar }`` with punning), and field
+names of updates may be reserved keywords (e.g. ``e { type = x }`` or
+``e { type }`` are allowed).
+
+This proposal changes only the accepted expressions for selection and update. It
+does not affect record data constructor declarations, record construction or
+pattern matching.  (While the changes to *fbind* allow more record constructions
+to parse, a construction such as ``C { type = e }}`` or ``C { foo.bar = e }``
+will continue to be rejected during name resolution.)
+
+Thus reserved keywords such as ``type`` cannot be defined as field names of
+normal record data constructors, but they are permitted in selection and update
+syntax. This is useful because the user may define a custom ``HasField``
+instance that makes a virtual field ``type`` available.
+
 
 3. Examples
 -----------
@@ -302,6 +362,50 @@ and yet more (as tests) are available in the examples directory of `this
 repository <https://github.com/ndmitchell/record-dot-preprocessor>`__.
 Those tests include infix applications, polymorphic data types,
 interoperation with other extensions and more.
+
+
+Reserved keywords and other special field names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inclusion of *reservedid* in *field* means that the following is accepted:
+
+.. code:: haskell
+
+   data Foo = Foo { fooType :: FooType }
+
+   instance HasField "type" Foo FooType where
+     getField = fooType
+
+   instance SetField "type" Foo FooType where
+     setField t foo = foo { fooType = t }
+
+   e :: Foo -> FooType
+   e foo = foo.type            -- Translates to getField @"type" foo
+
+   f :: FooType -> Foo -> Foo
+   f t foo = foo { type = t }  -- Translates to setField @"type" t foo
+
+However the following continue to be rejected:
+
+.. code:: haskell
+
+   data Foo = Foo { type :: FooType }  -- Error: record datatype field cannot be reserved word
+
+   x foo = foo.TYPE     -- Error: field must start with a lowercase letter
+
+   y foo = foo."type"  -- Error: field cannot be double-quoted
+
+The latter two are slightly inconsistent with ``OverloadedLabels``, which
+permits ``#TYPE`` and ``#"type"`` as labels.
+
+Since ``_`` is a *reservedid*, the following expressions are accepted:
+
+.. code:: haskell
+
+    e._          -- Translates to getField @"_" e
+    (._)         -- Translates to getField @"_"
+    e { _ = x }  -- Translates to setField @"_" x e
+
 
 4. Effect and Interactions
 --------------------------
@@ -533,6 +637,22 @@ NB: the difference between (2) and (3) is tiny: only whether we have ``Overloade
 We think ``RecordDotSyntax`` will enable these extensions plus some
 extension that allows multiple field names, e.g. ``NoFieldSelectors``.
 Which final extension that is has not yet been determined.
+
+
+7.9 Why permit field names that are reserved identifiers?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Haskell does not permit reserved identifiers such as ``type``, ``case``, etc. to
+be used as record field names in record declarations.  This remains the case
+under this proposal.
+
+However, the proposal allows such identifiers to be used in the new syntactic
+forms such as overloaded record selection, for example ``e.type`` is accepted.
+This is primarily intended for users who define their own ``HasField``
+instances. Such "virtual fields"  do not necessarily correspond to Haskell
+variable names and hence there seems to be no good reason to restrict them to
+the *varid* syntax.
+
 
 8. Unresolved issues
 --------------------


### PR DESCRIPTION
This should enable the use of `HasField "type" s a` instances to be used with `OverloadedRecordDot` - `foo.type`.

This shows up for us in our database models. They include a type name prefix `data Foo = Foo { fooType :: FooType }`, and we have a TH step that removes that for `HasField` instances - `instance HasField "type" Foo FooType`. But we cannot write `foo.type` because it is a parse error.

Cf [this GHC ticket](https://gitlab.haskell.org/ghc/ghc/-/issues/24174), a change to the grammar here is necessary to make this change in general.

[Rendered](https://github.com/parsonsmatt/ghc-proposals/blob/patch-1/proposals/0282-record-dot-syntax.rst)