### PR TITLE
Impact analysis for #581 Namespace-specified imports

### DIFF
--- a/proposals/0581-namespace-specified-imports.rst
+++ b/proposals/0581-namespace-specified-imports.rst
@@ -559,6 +559,12 @@ on it. Moreover it can be fixed by simply removing the bogus ``type``
 namespace specifier. Thus we do not expect significant breakage from this
 change.
 
+To estimate the actual impact, we modified GHC 9.10.1 to reject invalid uses of
+the ``type`` namespace specifier in import lists and compiled 3182 packages
+(`full list <https://gist.githubusercontent.com/int-index/189e4f5147a7b64ee847c9ace5e4ed24/raw/1beb733ca2c1ea5d55abbb66671e1f0b2e987012/enforce-children-import-namespaces>`_)
+using the patched compiler. There have been no build failures, confirming our
+hypothesis that the breakage is observed only in artificial examples.
+
 Existing code that uses the ``pattern`` keyword (with ``PatternSynonyms``) in
 import/export lists and uses ``-Wcompat`` (or eventually ``-Wall``) will
 receive a warning from ``-Wpattern-namespace-specifier`` until it migrates to


### PR DESCRIPTION
I performed an impact analysis for the proposed bugfix of [#22581](https://gitlab.haskell.org/ghc/ghc/-/issues/22581) by compiling 3182 packages with a modified variant of GHC 9.10.1. Here's the patch:

```diff
diff --git a/compiler/GHC/Rename/Names.hs b/compiler/GHC/Rename/Names.hs
index 015e4d7ae3..0e23063063 100644
--- a/compiler/GHC/Rename/Names.hs
+++ b/compiler/GHC/Rename/Names.hs
@@ -1637,17 +1637,27 @@ lookupChildren all_kids rdr_items
     oks   = [ ok      | Succeeded ok   <- mb_xs ]
     oks :: [[LocatedA GlobalRdrElt]]
 
+    doOne :: LIEWrappedName GhcPs -> MaybeErr (LIEWrappedName GhcPs) [LocatedA GlobalRdrElt]
     doOne item@(L l r)
        = case (lookupFsEnv kid_env . occNameFS . rdrNameOcc . ieWrappedName) r of
            Just [g]
              | not $ isRecFldGRE g
+             , check_ns r (nameNameSpace (gre_name g))  -- TODO: Dedicated error message
              -> Succeeded [L l g]
            Just gs
              | all isRecFldGRE gs
              -> Succeeded $ map (L l) gs
            _ -> Failed    item
 
+    check_ns :: IEWrappedName GhcPs -> NameSpace -> Bool
+    check_ns IEName{}    _  = True
+    check_ns IEType{}    ns = isTcClsNameSpace ns
+
+    -- Can't happen because it's not a valid parse:
+    check_ns IEPattern{} _  = panic "lookupChildren: IEPattern"
+
     -- See Note [Children for duplicate record fields]
+    kid_env :: FastStringEnv [GlobalRdrElt]
     kid_env = extendFsEnvList_C (++) emptyFsEnv
               [(occNameFS (occName x), [x]) | x <- all_kids]
```

This change is sufficient to make GHC reject the reported test case:

```
ghci> :set -XExplicitNamespaces 
ghci> import Data.Functor.Product ( Product ( Pair ) )       -- ok
ghci> import Data.Functor.Product ( Product ( type Pair ) )  -- bad
<interactive>:4:31: error: [GHC-10237]
    In the import of ‘Data.Functor.Product’:
      an item called ‘Product’ is exported, but it does not export any children
      (constructors, class methods or field names) called ‘Pair’.
```

----

**Results:** in real-world code, no breakage was observed.