### PR TITLE
Splitting out stable subsets from `template-haskell` (`template-haskell-lift` and `template-haskell-quasiquote`)

### DIFF
--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -240,9 +240,6 @@ Whereas with the split packages, you only need to update your bounds if the inte
 Unresolved Questions
 --------------------
 
-- Should the modules live in the ```TemplateHaskell.`` or the ``Language.Haskell.TH.`` namespace?
-- Should these packages live in the GHC repository, in another repository on the GHC Gitlab, or on GitHub?
-
 Implementation Plan
 -------------------
 Teo Camarasu has implemented an `MR <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13569>`_

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -58,10 +58,9 @@ This puts pressure on the Template Haskell syntax trees to be able to express th
 Whenever a new syntactic construct is added to GHC, we also want to introduce a corresponding change to the Template Haskell syntax tree types.
 As we expect GHC's internal AST to regularly evolve with each major version of GHC, it is likely that each new major release of GHC will force a new major release of the ``template-haskell`` library.
 
-.. note::
-   In ``template-haskell-2.18``, a new field was added to the ``ConP`` constructor of ``Pat`` to express the possibility of a list of type applications as part of a constructor pattern.
-   End-users then had to update their code to account for this change. ``yesod`` uses ``ConP`` in some code for generating typeclass instances.
-   The code had to be changed to pass an extra ``[]`` argument. See: `the PR to yesod <https://github.com/yesodweb/yesod/pull/1754/files#diff-b0e5dbc5d4ca2998772f987cc5f27c5fc761b34549bdecc93892bbe142d89d26R30>`_.
+In ``template-haskell-2.18``, a new field was added to the ``ConP`` constructor of ``Pat`` to express the possibility of a list of type applications as part of a constructor pattern.
+End-users then had to update their code to account for this change. ``yesod`` uses ``ConP`` in some code for generating typeclass instances.
+The code had to be changed to pass an extra ``[]`` argument. See: `the PR to yesod <https://github.com/yesodweb/yesod/pull/1754/files#diff-b0e5dbc5d4ca2998772f987cc5f27c5fc761b34549bdecc93892bbe142d89d26R30>`_.
 
 When upgrading GHC, users are often also forced to upgrade to the new GHC bundled ``template-haskell`` library.
 
@@ -132,19 +131,18 @@ On the other hand, the small interfaces exposed by ``template-haskell-lift`` and
 They rarely change and if they don't change between two versions of GHC, then we can accommodate both for free.
 If they do change, then it's likely that we can use ``CPP`` to expose to shim over GHC internals and expose a consistent interface.
 
-.. note::
-   For instance, `Overloaded Quotations proposal <./0246-overloaded-bracket.rst>`_ changed the type of the ``lift`` method of ``Lift`` from ``lift :: a -> Q a`` to ``lift :: Qoute m => a -> m a``.
+For instance, `Overloaded Quotations proposal <./0246-overloaded-bracket.rst>`_ changed the type of the ``lift`` method of ``Lift`` from ``lift :: a -> Q a`` to ``lift :: Qoute m => a -> m a``.
 
-   Suppose ``template-haskell-lift`` existed at the time and ``template-haskell-lift-0.1`` corresponded to the old interface and ``template-haskell-lift-0.2`` corresponded to the new interface.
-   Further suppose that GHC-9.0 ships with ``template-haskell-lift-0.1`` and GHC-9.2 ships with and implements the interface of ``template-haskell-lift-0.2``.
+Suppose ``template-haskell-lift`` existed at the time and ``template-haskell-lift-0.1`` corresponded to the old interface and ``template-haskell-lift-0.2`` corresponded to the new interface.
+Further suppose that GHC-9.0 ships with ``template-haskell-lift-0.1`` and GHC-9.2 ships with and implements the interface of ``template-haskell-lift-0.2``.
 
-   Our argument in this section is that it is convenient to make the following possible:
+Our argument in this section is that it is convenient to make the following possible:
 
-   * ``template-haskell-lift-0.1`` can be compiled with GHC-9.2
-   * ``template-haskell-lift-0.2`` can be compiled with GHC-9.0
+* ``template-haskell-lift-0.1`` can be compiled with GHC-9.2
+* ``template-haskell-lift-0.2`` can be compiled with GHC-9.0
 
-   This allows an end-user to upgrade from GHC-9.0 to GHC-9.2 without having to change their version of ``template-haskell-lift``, and allows a package to support both versions of the compiler without introducing ``CPP``.
-   And it allows a user to upgrade from ``template-haskell-lift-0.1`` to ``template-haskell-lift-0.2`` without upgrading their compiler.
+This allows an end-user to upgrade from GHC-9.0 to GHC-9.2 without having to change their version of ``template-haskell-lift``, and allows a package to support both versions of the compiler without introducing ``CPP``.
+And it allows a user to upgrade from ``template-haskell-lift-0.1`` to ``template-haskell-lift-0.2`` without upgrading their compiler.
 
 
 Depending on boot libraries from ```template-haskell``

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -270,7 +270,7 @@ This risk would be diminished if the majority of users used both the ``Lift`` an
 so it would be equivalent to updating the bounds for ``template-haskell-stable``. But, this is not the case. The vast majority of the packages that depend on this interface only use ``Lift``.
 Some use only ``QuasiQuoter``, and others use both.
 
-We also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
+We should also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
 We can look back on the *past* stability of these interfaces, but we cannot know their *future* stability.
 Part of the motivation of this proposal is to make it easier to accommodate future changes to these interfaces.
 Our aim here isn't to split these interfaces out in order to fix them in stone, but to make it easier for end-users to cope with future changes,

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -196,7 +196,7 @@ Unresolved Questions
 
 Implementation Plan
 -------------------
-Teo Camarasu has implemented a `MR <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13569>`_
+Teo Camarasu has implemented an `MR <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13569>`_
 and is happy to take on the work of finishing it and submitting patches to boot libraries.
 
 Endorsements

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -233,7 +233,7 @@ The main issue with this alternative is that it would force a change on basicall
 This would be a large and wide ranging breaking change.
 
 Another issue is that the ``Lift`` interface has changed much more frequently in the past than the ``Quasiquoter`` interface.
-If either of these changed in the future, then every user would have to update their upper bounds. ]
+If either of these changed in the future, then every user would have to update their upper bounds.
 Whereas with the split packages, you only need to update your bounds if the interface you actually depend on has changed.
 
 

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -122,7 +122,7 @@ Currently each version of ``template-haskell`` is tightly coupled to a specific 
 For instance, GHC-9.12.1 ships with ``template-haskell-2.23``. It is not possible to compile ``template-haskell-2.23`` with an earlier version of a compiler.
 So, a maintainer cannot upgrade to ``template-haskell-2.23`` without upgrading to GHC-9.12. And vice versa.
 
-Historically, there was a strong technical reason for this. ``template-haskell`` used to include wired-in identifiers referred to by GHC.
+Historically, there was a strong technical reason for this. ``template-haskell`` used to define wired-in identifiers referred to by GHC.
 As of GHC-9.12, these have been `moved <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12479>`_ to ``ghc-internal``.
 
 It should be possible to use, for instance ``CPP``, to make ``template-haskell`` compatible with multiple versions of GHC. But the large interface exposed by this package makes it difficult.
@@ -177,7 +177,7 @@ Proposed Library Change Specification
 -------------------------------------
 
 We propose to publish two new libraries: ``template-haskell-lift`` and ``template-haskell-quasiquoter``.
-These will be shipped with GHC. So, they would be boot libraries, but wouldn't include any wired-in identifiers.
+These will be shipped with GHC. So, they would be boot libraries, but wouldn't define any wired-in identifiers.
 In other words, they would behave as ``bytestring`` or ``containers``, not like ``ghc-internal``.
 
 They will also be published to and buildable from Hackage.
@@ -260,8 +260,7 @@ They have evolved independently of each other in the past, and they are likely t
 The majority of the users of ``Lift`` do not depend on ``QuasiQuoter``, and they would suffer from unnecessary version bumps if the two interfaces were packaged together.
 The `PVP <https://pvp.haskell.org/>`_ dictates that if any interface in a package changes in a breaking way, then the entire package needs to bump its major version.
 
-By keeping them apart, users can benefit from their independently versioned.
-A user could pick and choose which versions they depend on from each package.
+Independently versioning these packages allows a user to pick and choose the version of each package.
 This allows us to minimise the breakage from backwards- and/or forwards-compatible changes.
 
 We also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
@@ -276,7 +275,7 @@ If two interfaces are tightly coupled, it makes sense to group them into one pac
 These two interfaces are related in being parts of the overall Template Haskell feature set, but are otherwise conceptually independent.
 They could evolve independently. We could imagine the interface of ``Lift`` changing without impacting ``QuasiQuoter`` and vice versa.
 
-In light of the complexities surrounding ``Lift`` in the `Explicit Level Imports <./0682-explicit-level-imports.rts>` proposal,
+In light of the complexities surrounding ``Lift`` in the `Explicit Level Imports <./0682-explicit-level-imports.rst>`_ proposal,
 having a distinct ``template-haskell-lift`` package also helps document that a package is depending on this interface.
 
 Including ``DeriveLift`` as part of the interface of ``template-haskell-lift``

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -38,7 +38,8 @@ Motivation
 ----------
 This proposal aims to reduce the maintenance burden for packages that depend on ``template-haskell``.
 First, we sketch the relationship between GHC's internal AST and ``template-haskell``, and how this leads to frequent breaking changes.
-Second, we show how our general strategy improves this situation. Third, we show the benefits of publishing packages for the specific parts of the interface we describe.
+Second, we show how our general strategy improves this situation.
+Third, we show the benefits of publishing packages for the specific parts of the interface we describe.
 
 .. _why TH unstable:
 Why ``template-haskell`` is unstable
@@ -123,6 +124,7 @@ We propose to publish two new libraries: ``template-haskell-lift`` and ``templat
 These will be shipped with GHC.
 They will also be buildable from Hackage.
 They will be buildable with at a *minimum* the last 3 versions of GHC.
+The current version of the libraries are compatible with GHC 8.10 and later.
 
 Their interfaces will be as follows:
 
@@ -155,7 +157,7 @@ The idea to use this less verbose namespace for the new stable interfaces is tha
 
 Effect and Interactions
 -----------------------
-This works towards removing the special case for ``template-haskell`` in (GR1), but on its own it doesn't achieve it.
+This works towards removing the special case for ``template-haskell`` in (GR1) from `Principles for GHC <../principles.rst>`_, but on its own it doesn't achieve it.
 There should be no interactions with other proposals.
 
 
@@ -163,25 +165,34 @@ Costs and Drawbacks
 -------------------
 This proposal requires the GHC team to maintain two packages for the conceivable future.
 This should be a relatively small cost as we expect these packages to be relatively stable.
-Teo Camarasu is happy to take on any maintainance work necessary for these packages for the conceivable future,
+Teo Camarasu is happy to take on any maintainance work necessary for these packages for the forseeable future,
 but someone else would have to take over if they are no longer able to.
 
 
 Backward Compatibility
 ----------------------
-As this proposal deals exclusively with creating new packages, there are no backwards compatibilty worries.
+As this proposal deals exclusively with creating new packages, there are no backwards compatibility worries.
 
 
 Alternatives
 ------------
-The design space for improving ``template-haskell`` stability is vast.
-TODO: finish off this section
+The majority of the breaking changes to ``template-haskell`` comes from changes to the TH AST.
+An alternative approach would be to simplify move the TH AST into a new package, and keep ``template-haskell``
+as the remaining interface.
+
+The main issue with this alternative is that it would force a change on basically all users but type (A).
+This would be a large and wide ranging breaking change.
+
+Another issue is that the ``Lift`` interface has changed much more frequently in the past than the ``Quasiquoter`` interface.
+If either of these changed in the future, then every user would have to update their upper bounds. ]
+Whereas with the split packages, you only need to update your bounds if the interface you actually depend on has changed.
+
 
 Unresolved Questions
 --------------------
 
-- Should the modules live in the ``TemplateHaskell.`` or the ``Language.Haskell.TH.`` namespace?
-- Should these packages live in the GHC repo, in another repository on Gitlab, or on GitHub?
+- Should the modules live in the ```TemplateHaskell.`` or the ``Language.Haskell.TH.`` namespace?
+- Should these packages live in the GHC repository, in another repository on the GHC Gitlab, or on GitHub?
 
 Implementation Plan
 -------------------

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -238,6 +238,9 @@ As this proposal deals exclusively with creating new packages, there are no back
 
 Alternatives
 ------------
+
+Remove the Template Haskell ASTs from ``template-haskell``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The majority of the breaking changes to ``template-haskell`` comes from changes to the TH AST.
 An alternative approach would be to simplify move the TH AST into a new package, and keep ``template-haskell``
 as the remaining interface.
@@ -248,6 +251,37 @@ This would be a large and wide ranging breaking change.
 Another issue is that the ``Lift`` interface has changed much more frequently in the past than the ``Quasiquoter`` interface.
 If either of these changed in the future, then every user would have to update their upper bounds.
 Whereas with the split packages, you only need to update your bounds if the interface you actually depend on has changed.
+
+Just one stable package
+^^^^^^^^^^^^^^^^^^^^^^^
+This proposal splits out two interfaces from ``template-haskell`` into two packages.
+An alternative would be to split them into one new package, perhaps called ``template-haskell-stable``.
+
+This would be simpler as it would lead to fewer packages.
+Yet, it would reduce the benefits from this proposal, especially if we choose to continue with this strategy of splitting out interfaces from ``template-haskell`` in the future.
+
+`PVP <https://pvp.haskell.org/>`_ dictates that if any interface in a package changes in a breaking way, then the entire package needs to bump its major version.
+The most unstable interface in a package determines the package's overall stability.
+The more interfaces a package contains, the greater the risk of a frequent breaking changes.
+If we choose to continue splitting interfaces out of the ``template-haskell`` package, this risk will grow further if we choose to put them into ``template-haskell-stable``.
+Eventually ``template-haskell-stable`` might no longer be stable at all.
+
+This risk would be diminished if the majority of users used both the ``Lift`` and ``QuasiQuoter`` interfaces. In that case, users would need to update their bounds if either package had a major release,
+so it would be equivalent to updating the bounds for ``template-haskell-stable``. But, this is not the case. The vast majority of the packages that depend on this interface only use ``Lift``.
+Some use only ``QuasiQuoter``, and others use both.
+
+We also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
+We can look back on the *past* stability of these interfaces, but we cannot know their *future* stability.
+Part of the motivation of this proposal is to make it easier to accommodate future changes to these interfaces.
+Our aim here isn't to split these interfaces out in order to fix them in stone, but to make it easier for end-users to cope with future changes,
+and to eliminate unnecessary work when the subset of the interface they depend on hasn't actually changed.
+
+Rather we should be looking at how interfaces are related. We should look at relations of tight coupling.
+If two interfaces are tightly coupled, it makes sense to group them into one package as changes to one will force changes to the other.
+
+These two interfaces are related in being parts of the overall Template Haskell feature set, but are otherwise conceptually independent.
+They could evolve independently. We could imagine the interface of ``Lift`` changing without impacting ``QuasiQuoter`` and vice versa.
+
 
 
 Unresolved Questions

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -181,11 +181,14 @@ These will be shipped with GHC. So, they would be boot libraries, but wouldn't i
 In other words, they would behave as ``bytestring`` or ``containers``, not like ``ghc-internal``.
 
 They will also be published to and buildable from Hackage.
-They can be built with the version of GHC they are bundled with, but should additionally be buildable with the previous and next version of GHC also.
-Concretely if ``template-haskell-0.1`` is shipped with GHC-9.14, then it should also be buildable with GHC-9.12 and GHC-9.16.
-This is merely a minimum and we wish to have as broad a support range as feasible, eg, the current version of the libraries are compatible with GHC-8.10 up to GHC-9.12 (the present release).
+They can be built with the version of GHC they are bundled with, but should additionally be buildable with the previous and next version of GHC.
+Concretely if ``template-haskell-0.1`` is shipped with GHC-9.14, then there should be minor releases (``template-haskell-0.1.*``) that can be built with GHC-9.12 and GHC-9.16.
+We wish to have as broad a support range as feasible, eg, the current version of the libraries are compatible with GHC-8.10 up to GHC-9.12 (the present release).
+We acknowledge that this might not always be possible, and that these interfaces might need to change in the future in ways that cannot be shimmed over.
 
-Their interfaces will be as follows:
+These packages only depend on ``ghc-internal`` and ``base``. Crucially they do not depend on ``template-haskell``.
+
+Their initial interfaces will be as follows:
 
 ``template-haskell-lift``::
 
@@ -213,8 +216,6 @@ Their interfaces will be as follows:
 
 Note that these modules are in the ``TemplateHaskell.`` namespace rather than the ``Language.Haskell.TH.`` namespace.
 The idea to use this less verbose namespace for the new stable interfaces is thanks to Adam Gundry.
-
-These packages only depend on ``ghc-internal`` and ``base``. Crucially they do not depend on ``template-haskell``.
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -16,11 +16,11 @@ Splitting out stable interfaces from ``template-haskell``
 
 The ``template-haskell`` library exposes the user facing interfaces to Template Haskell (TH), GHC's metaprogramming facility.
 It is tightly coupled to GHC's internals.
-It is bundled with GHC, we call this being a `boot library`.
+It is one of the libraries that come bundled with GHC. We call this being a `boot library`.
 Each release of GHC ships with a new major version of ``template-haskell``, which is the only version that is supported by that compiler.
 
 ``template-haskell`` is used very widely in the ecosystem, including by many dependencies of the compiler itself.
-When a new version of GHC is released, a large amount of packages have to raise their upper bounds on ``template-haskell``.
+When a new version of GHC is released, a large number of packages have to raise their upper bounds on ``template-haskell``.
 This is a large amount of work that is needlessly coupled to the release of GHC.
 
 This proposal aims to avoid this cycle of breaking changes to the ecosystem.

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -15,12 +15,11 @@ Splitting out stable interfaces from ``template-haskell``
 
 
 The ``template-haskell`` library exposes the user facing interfaces to Template Haskell (TH), GHC's metaprogramming facility.
-It is tightly coupled to GHC's internals.
-It is one of the libraries that come bundled with GHC. We call this being a `boot library`.
-Each release of GHC ships with a new major version of ``template-haskell``, which is the only version that is supported by that compiler.
 
-``template-haskell`` is used very widely in the ecosystem, including by many dependencies of the compiler itself.
-When a new version of GHC is released, a large number of packages have to raise their upper bounds on ``template-haskell``.
+Since template-haskell re-exports a diverse set of symbols from GHC's internals,
+in practice every GHC release comes with a new major version of the template-haskell package.
+Since template-haskell is used very widely in the ecosystem,
+a large number of packages have to raise their upper bounds on template-haskell in response to a GHC release.
 This is a large amount of work that is needlessly coupled to the release of GHC.
 
 This proposal aims to avoid this cycle of breaking changes to the ecosystem.

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -1,0 +1,191 @@
+Splitting out stable interfaces from ``template-haskell``
+========================================================
+
+.. author:: Teo Camarasu
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/696>`_.
+.. sectnum::
+.. contents::
+
+
+The ``template-haskell`` library exposes the user facing interfaces to Template Haskell (TH), GHC's metaprogramming facility.
+It is tightly coupled to GHC's internals.
+Each release of GHC ships with a new major version of ``template-haskell``, which is the only version that is supported by that compiler.
+
+``template-haskell`` is used very widely in the ecosystem, including by many dependencies of the compiler itself.
+When a new version of GHC is released, a large amount of packages have to raise their upper bounds on ``template-haskell``.
+This is a large amount of work that is needlessly coupled to the release of GHC.
+
+This proposal aims to avoid this cycle of breaking changes to the ecosystem.
+We present both an open-ended strategy, and a concrete step in line with that strategy.
+
+Our strategy is to split out smaller, coherent packages with more stable interfaces from ``template-haskell``.
+Each of these packages can be versioned independently and can more easily be made compatible with a wider range of GHC versions.
+We do not propose to remove from ``template-haskell`` these parts of the interface, rather a version of ``template-haskell`` will re-export the interfaces from the more refined packages.
+
+Concretely, we propose introducing the following two libraries:
+* ``template-haskell-lift``, exposes the ``Lift`` typeclass and compatibility functions. Users who make use of the ``DerivingLift`` language extension only need to depend on this package in order to derive instances of ``Lift`` or manually give instances using ``TemplateHaskellQuotes``.
+* ``template-haskell-quasiquote`` exposes the ``Quasiquoter`` datatype, which allows libraries to expose their own custom quasiquoters.
+
+Motivation
+----------
+This proposal aims to reduce the maintenance burden for packages that depend on ``template-haskell``.
+First, we sketch the relationship between GHC's internal AST and ``template-haskell``, and how this leads to frequent breaking changes.
+Second, we show how our general strategy improves this situation. Third, we show the benefits of publishing packages for the specific parts of the interface we describe.
+
+.. _why TH unstable:
+Why ``template-haskell`` is unstable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Template Haskell exposes an interface for manipulating Haskell syntax trees.
+At the core of this interface is a set of types for representing these syntax trees: ``Type``, ``Expr``, ``Pat``, etc.
+These are defined in the ``ghc-internal`` package, but exposed to end-users via the ``template-haskell`` library.
+In order to implement Template Haskell, GHC includes functions for converting between its internal AST and these types.
+This introduces a form of coupling between GHC internals and the interface of the ``template-haskell`` library.
+
+When using Template Haskell quotes, we must convert an arbitrary GHC AST into a Template Haskell syntax tree.
+And when using Template Haskell splices, we must convert an arbitrary Template Haskell syntax tree into a GHC AST.
+This puts pressure on the Template Haskell syntax trees to be able to express the full breadth and depth of Haskell syntax.
+
+Whenever a new syntactic construct is added to GHC, we also want to introduce a corresponding change to the Template Haskell syntax tree types.
+As we expect GHC's internal AST to regularly evolve with each major version of GHC, it is likely that each new major release of GHC will force a new major release of the ``template-haskell`` library.
+
+.. Note::
+   In ``template-haskell-2.18``, a new field was added to the ``ConP`` constructor of ``Pat`` to express the possibility of a list of type applications as part of a constructor pattern.
+   End-users then had to update their code to account for this change. ``yesod`` uses ``ConP`` in some code for generating typeclass instances.
+   The code had to be changed to pass an extra ``[]`` argument. See: `the PR to yesod <https://github.com/yesodweb/yesod/pull/1754/files#diff-b0e5dbc5d4ca2998772f987cc5f27c5fc761b34549bdecc93892bbe142d89d26R30>`_.
+
+When upgrading GHC, users are often also forced to upgrade to the new GHC bundled ``template-haskell`` library.
+
+.. _why strategy:
+Justifying our strategy
+^^^^^^^^^^^^^^^^^^^^^^^
+Our strategy is informed by the classes of usages of ``template-haskell`` found in the ecosystem. We can divide users as follows:
+
+* (A) Quote-and-splice clients: These users use only splices, quotes, ``DeriveLift`` or quasiquotes. These users might not even need to import the ``template-haskell`` library.
+* (B) Syntax-construction clients. These users construct Template Haskell syntax trees either directly through its constructors, or indirectly through the smart-constructors exported by ``Language.Haskell.TH.Lib``.
+* (C) Reification clients. These users, notably various forms of deriving, use reification to interrogate the program. Reification currently returns Template Haskell ASTs.
+* (D) Syntax-analysis clients. Some clients pattern match on Template Haskell syntax tree datatypes.
+
+These diverse usages of the library lead to diverse levels of breakage when a new major version of ``template-haskell`` comes out. We can rank them from (A) with the least breakage to (D) with the most.
+For instance, the ``uuid`` library, which just depends on ``template-haskell`` in order to provide a derived ``Lift`` instance (a type (A) client), in all likelyhood would only need to bump its upper-bound on the library.
+On the other-hand ``th-desugar``, which pattern matches on the entire syntax tree (a type (D) client), would have to make code changes on most releases of the library.
+
+Type (A) users are already using interfaces which are quite stable. Yet, they have to update their upper bounds whenever they want to be compatible with a new major version of GHC.
+The first concrete step in our strategy is to publish package that provide these stable APIs. We will return to the benefits of this in the next section.
+
+(B-D) do not currently use stable subsets of the ``template-haskell`` interface.
+In the future, we aim to continue this strategy, by identifying stable interfaces for these classes of users which aren't tightly coupled to the Template Haskell AST.
+The smart-constructors from the ``Language.Haskell.TH.Lib`` module are a good starting point for type (B) clients. Another idea is to use smart-constructors based on the Haskell2010 AST (See: `GHC#20828 <https://gitlab.haskell.org/ghc/ghc/-/issues/20828>`_).
+For type (C) clients, we can build on the existing `th-abstraction` library, and perhaps expose a refined AST that doesn't need to be as expressive as the surface language.
+Type (D) clients on the otherhand are likely to be difficult to accommodate, since they are inherently tightly coupled to the Template Haskell syntax trees.
+
+Our strategy of splitting out stable subsets of the API has the advantage that it allows users to opt-in to more stability.
+``template-haskell`` is used very widely in the ecosystem. This makes it important that any attempt to improve its stability doesn't force a change to all users.
+Users who wish to continue to use ``template-haskell`` may continue to do so, and the interfaces will continue to be exposed in both the new packages and the old.
+
+By focusing on smaller subsets of the API we also make it much easier to be compatible with multiple versions of GHC.
+This is an important property for any stable package as it allows a user to upgrade their dependencies independently of GHC.
+We plan to implement this by create compatibility shims using ``CPP`` or ``PatternSynonyms``.
+
+.. _advantages:
+Benefits of splitting out ``template-haskell-lift`` and ``template-haskell-quasiquote``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Publishing ``template-haskell-lift`` and ``template-haskell-quasiquote`` will be beneficial both for GHC and the ecosystem.
+
+The biggest benefit is that library authors who are just deriving or using ``Lift`` instances or just exposing ``Quasiquoter``s no longer need to depend on the entirety of ``template-haskell``.
+This can help avoid the sorts of dependency bounds propagation problems identified in the `GHC.X.Hackage proposal <https://github.com/bgamari/tech-proposals/blob/ghc-x-hackage/proposals/001-ghc-x-hackage.md>`_.
+
+There is a more subtle benefit for the ``template-haskell`` package. Currently the wide usage of ``Lift`` instances greatly limits the possible dependencies of ``template-haskell``.
+For instance, ``template-haskell`` cannot depend on ``containers`` or ``filepath``, since these libraries depend on ``template-haskell``.
+But if these packages switch to depending on our new packages, then ``template-haskell`` could depend on them.
+Currently ``template-haskell`` must vendor a small portion of ``filepath`` and ``containers``, and that would no longer be necessary.
+
+Many boot packages depend on ``template-haskell``, but all of them only depend on it for the parts of the interface exposed by ``template-haskell-lift`` and ``template-haskell-quasiquote``.
+If we can convince their maintainers to depend on these packages instead, then GHC would no longer (transitively) depend on ``template-haskell``.
+This makes it possible for packages to depend on the ``ghc`` library at the same time as a version of ``template-haskell`` different to the one bundled with that GHC.
+
+
+Proposed Change Specification
+-----------------------------
+No changes to the language or the compiler are required for this proposal.
+
+Proposed Library Change Specification
+-------------------------------------
+
+We propose to publish two new libraries: ``template-haskell-lift`` and ``template-haskell-quasiquote``.
+These will be shipped with GHC.
+They will also be buildable from Hackage.
+They will be buildable with at a *minimum* the last 3 versions of GHC.
+
+Their interfaces will be as follows:
+
+``template-haskell-lift``::
+
+   module TemplateHaskell.Lift
+    ( Q
+    , Code
+    , Quote
+    , Exp
+    , Lift(..)
+    , defaultLiftTyped -- a utility for writing `liftTyped` methods when an instance currently defines lift only
+    , liftAddrCompat -- a utility for creating an `Addr#` value, eg, for defining `Lift ByteString`
+    , liftIntCompat -- a utility for lifting an `Int` without causing issues when used with `OverloadedSyntax`
+    )
+
+``template-haskell-quasiquote``::
+
+   module TemplateHaskell.Quasiquoter
+    ( Q
+    , Exp
+    , Pat
+    , Type
+    , Dec
+    , QuasiQuoter (QuasiQuoter, quoteExp, quotePat, quoteType, quoteDec)
+    )
+
+Note that these modules are in the ``TemplateHaskell.`` namespace rather than the ``Language.Haskell.TH.`` namespace.
+The idea to use this less verbose namespace for the new stable interfaces is thanks to Adam Gundry.
+
+Effect and Interactions
+-----------------------
+This works towards removing the special case for ``template-haskell`` in (GR1), but on its own it doesn't achieve it.
+There should be no interactions with other proposals.
+
+
+Costs and Drawbacks
+-------------------
+This proposal requires the GHC team to maintain two packages for the conceivable future.
+This should be a relatively small cost as we expect these packages to be relatively stable.
+Teo Camarasu is happy to take on any maintainance work necessary for these packages for the conceivable future,
+but someone else would have to take over if they are no longer able to.
+
+
+Backward Compatibility
+----------------------
+As this proposal deals exclusively with creating new packages, there are no backwards compatibilty worries.
+
+
+Alternatives
+------------
+The design space for improving ``template-haskell`` stability is vast.
+TODO: finish off this section
+
+Unresolved Questions
+--------------------
+
+- Should the modules live in the ``TemplateHaskell.`` or the ``Language.Haskell.TH.`` namespace?
+- Should these packages live in the GHC repo, in another repository on Gitlab, or on GitHub?
+
+Implementation Plan
+-------------------
+Teo Camarasu has implemented a `MR <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13569>`_
+and is happy to take on the work of finishing it and submitting patches to boot libraries.
+
+Endorsements
+-------------

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -30,6 +30,7 @@ Each of these packages can be versioned independently and can more easily be mad
 We do not propose to remove from ``template-haskell`` these parts of the interface, rather a version of ``template-haskell`` will re-export the interfaces from the more refined packages.
 
 Concretely, we propose introducing the following two libraries:
+
 * ``template-haskell-lift``, exposes the ``Lift`` typeclass and compatibility functions. Users who make use of the ``DerivingLift`` language extension only need to depend on this package in order to derive instances of ``Lift`` or manually give instances using ``TemplateHaskellQuotes``.
 * ``template-haskell-quasiquote`` exposes the ``Quasiquoter`` datatype, which allows libraries to expose their own custom quasiquoters.
 
@@ -67,14 +68,14 @@ Justifying our strategy
 ^^^^^^^^^^^^^^^^^^^^^^^
 Our strategy is informed by the classes of usages of ``template-haskell`` found in the ecosystem. We can divide users as follows:
 
-* (A) Quote-and-splice clients: These users use only splices, quotes, ``DeriveLift`` or quasiquotes. These users might not even need to import the ``template-haskell`` library.
-* (B) Syntax-construction clients. These users construct Template Haskell syntax trees either directly through its constructors, or indirectly through the smart-constructors exported by ``Language.Haskell.TH.Lib``.
-* (C) Reification clients. These users, notably various forms of deriving, use reification to interrogate the program. Reification currently returns Template Haskell ASTs.
-* (D) Syntax-analysis clients. Some clients pattern match on Template Haskell syntax tree datatypes.
+* (\A) Quote-and-splice clients: These users use only splices, quotes, ``DeriveLift`` or quasiquotes. These users might not even need to import the ``template-haskell`` library.
+* (\B) Syntax-construction clients. These users construct Template Haskell syntax trees either directly through its constructors, or indirectly through the smart-constructors exported by ``Language.Haskell.TH.Lib``.
+* (\C) Reification clients. These users, notably various forms of deriving, use reification to interrogate the program. Reification currently returns Template Haskell ASTs.
+* (\D) Syntax-analysis clients. Some clients pattern match on Template Haskell syntax tree datatypes.
 
 These diverse usages of the library lead to diverse levels of breakage when a new major version of ``template-haskell`` comes out. We can rank them from (A) with the least breakage to (D) with the most.
 For instance, the ``uuid`` library, which just depends on ``template-haskell`` in order to provide a derived ``Lift`` instance (a type (A) client), in all likelyhood would only need to bump its upper-bound on the library.
-On the other-hand ``th-desugar``, which pattern matches on the entire syntax tree (a type (D) client), would have to make code changes on most releases of the library.
+On the other hand ``th-desugar``, which pattern matches on the entire syntax tree (a type (D) client), would have to make code changes on most releases of the library.
 
 Type (A) users are already using interfaces which are quite stable. Yet, they have to update their upper bounds whenever they want to be compatible with a new major version of GHC.
 The first concrete step in our strategy is to publish package that provide these stable APIs. We will return to the benefits of this in the next section.
@@ -83,7 +84,7 @@ The first concrete step in our strategy is to publish package that provide these
 In the future, we aim to continue this strategy, by identifying stable interfaces for these classes of users which aren't tightly coupled to the Template Haskell AST.
 The smart-constructors from the ``Language.Haskell.TH.Lib`` module are a good starting point for type (B) clients. Another idea is to use smart-constructors based on the Haskell2010 AST (See: `GHC#20828 <https://gitlab.haskell.org/ghc/ghc/-/issues/20828>`_).
 For type (C) clients, we can build on the existing `th-abstraction` library, and perhaps expose a refined AST that doesn't need to be as expressive as the surface language.
-Type (D) clients on the otherhand are likely to be difficult to accommodate, since they are inherently tightly coupled to the Template Haskell syntax trees.
+Type (D) clients on the other hand are likely to be difficult to accommodate, since they are inherently tightly coupled to the Template Haskell syntax trees.
 
 Our strategy of splitting out stable subsets of the API has the advantage that it allows users to opt-in to more stability.
 ``template-haskell`` is used very widely in the ecosystem. This makes it important that any attempt to improve its stability doesn't force a change to all users.
@@ -98,7 +99,7 @@ Benefits of splitting out ``template-haskell-lift`` and ``template-haskell-quasi
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Publishing ``template-haskell-lift`` and ``template-haskell-quasiquote`` will be beneficial both for GHC and the ecosystem.
 
-The biggest benefit is that library authors who are just deriving or using ``Lift`` instances or just exposing ``Quasiquoter``s no longer need to depend on the entirety of ``template-haskell``.
+The biggest benefit is that library authors who are just deriving or using ``Lift`` instances or just exposing ``Quasiquoter``\s no longer need to depend on the entirety of ``template-haskell``.
 This can help avoid the sorts of dependency bounds propagation problems identified in the `GHC.X.Hackage proposal <https://github.com/bgamari/tech-proposals/blob/ghc-x-hackage/proposals/001-ghc-x-hackage.md>`_.
 
 There is a more subtle benefit for the ``template-haskell`` package. Currently the wide usage of ``Lift`` instances greatly limits the possible dependencies of ``template-haskell``.

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -252,22 +252,19 @@ Whereas with the split packages, you only need to update your bounds if the inte
 Just one stable package
 ^^^^^^^^^^^^^^^^^^^^^^^
 This proposal splits out two interfaces from ``template-haskell`` into two packages.
-An alternative would be to split them into one new package, perhaps called ``template-haskell-stable``.
+An alternative would be to split them into one new package.
 
-This would be simpler as it would lead to fewer packages.
-Yet, it would reduce the benefits from this proposal, especially if we choose to continue with this strategy of splitting out interfaces from ``template-haskell`` in the future.
+Fundamentally, these two interfaces are conceptually and practically independent.
+They have evolved independently of each other in the past, and they are likely to continue to do so.
 
-`PVP <https://pvp.haskell.org/>`_ dictates that if any interface in a package changes in a breaking way, then the entire package needs to bump its major version.
-The most unstable interface in a package determines the package's overall stability.
-The more interfaces a package contains, the greater the risk of a frequent breaking changes.
-If we choose to continue splitting interfaces out of the ``template-haskell`` package, this risk will grow further if we choose to put them into ``template-haskell-stable``.
-Eventually ``template-haskell-stable`` might no longer be stable at all.
+The majority of the users of ``Lift`` do not depend on ``QuasiQuoter``, and they would suffer from unnecessary version bumps if the two interfaces were packaged together.
+The `PVP <https://pvp.haskell.org/>`_ dictates that if any interface in a package changes in a breaking way, then the entire package needs to bump its major version.
 
-This risk would be diminished if the majority of users used both the ``Lift`` and ``QuasiQuoter`` interfaces. In that case, users would need to update their bounds if either package had a major release,
-so it would be equivalent to updating the bounds for ``template-haskell-stable``. But, this is not the case. The vast majority of the packages that depend on this interface only use ``Lift``.
-Some use only ``QuasiQuoter``, and others use both.
+By keeping them apart, users can benefit from their independently versioned.
+A user could pick and choose which versions they depend on from each package.
+This allows us to minimise the breakage from backwards- and/or forwards-compatible changes.
 
-We should also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
+We also be sceptical of a ``template-haskell-stable`` package because stability is not an essential property of an interface.
 We can look back on the *past* stability of these interfaces, but we cannot know their *future* stability.
 Part of the motivation of this proposal is to make it easier to accommodate future changes to these interfaces.
 Our aim here isn't to split these interfaces out in order to fix them in stone, but to make it easier for end-users to cope with future changes,
@@ -278,6 +275,9 @@ If two interfaces are tightly coupled, it makes sense to group them into one pac
 
 These two interfaces are related in being parts of the overall Template Haskell feature set, but are otherwise conceptually independent.
 They could evolve independently. We could imagine the interface of ``Lift`` changing without impacting ``QuasiQuoter`` and vice versa.
+
+In light of the complexities surrounding ``Lift`` in the `Explicit Level Imports <./0682-explicit-level-imports.rts>` proposal,
+having a distinct ``template-haskell-lift`` package also helps document that a package is depending on this interface.
 
 Including ``DeriveLift`` as part of the interface of ``template-haskell-lift``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -165,7 +165,7 @@ Costs and Drawbacks
 -------------------
 This proposal requires the GHC team to maintain two packages for the conceivable future.
 This should be a relatively small cost as we expect these packages to be relatively stable.
-Teo Camarasu is happy to take on any maintainance work necessary for these packages for the forseeable future,
+Teo Camarasu is happy to take on any maintenance work necessary for these packages for the foreseeable future,
 but someone else would have to take over if they are no longer able to.
 
 

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -192,7 +192,7 @@ Their initial interfaces will be as follows:
 
 ``template-haskell-lift``::
 
-   module TemplateHaskell.Lift
+   module Language.Haskell.TH.Lift
     ( Q
     , Code
     , Quote
@@ -205,7 +205,7 @@ Their initial interfaces will be as follows:
 
 ``template-haskell-quasiquoter``::
 
-   module TemplateHaskell.QuasiQuoter
+   module Language.Haskell.TH.QuasiQuoter
     ( Q
     , Exp
     , Pat
@@ -213,9 +213,6 @@ Their initial interfaces will be as follows:
     , Dec
     , QuasiQuoter (QuasiQuoter, quoteExp, quotePat, quoteType, quoteDec)
     )
-
-Note that these modules are in the ``TemplateHaskell.`` namespace rather than the ``Language.Haskell.TH.`` namespace.
-The idea to use this less verbose namespace for the new stable interfaces is thanks to Adam Gundry.
 
 Effect and Interactions
 -----------------------

--- a/proposals/0000-splitting-out-stable-interfaces-from-th.rst
+++ b/proposals/0000-splitting-out-stable-interfaces-from-th.rst
@@ -157,7 +157,7 @@ The idea to use this less verbose namespace for the new stable interfaces is tha
 
 Effect and Interactions
 -----------------------
-This works towards removing the special case for ``template-haskell`` in (GR1) from `Principles for GHC <../principles.rst>`_, but on its own it doesn't achieve it.
+This works towards removing the special case for ``template-haskell`` in `(GR1) <https://github.com/ghc-proposals/ghc-proposals/blob/master/principles.rst#33stability-gr1>`_ from `Principles for GHC <../principles.rst>`_, but on its own it doesn't achieve it.
 There should be no interactions with other proposals.
 
 


### PR DESCRIPTION
This proposal introduces the  `template-haskell-lift` and `template-haskell-quasiquote` packages as stable subsets of the `template-haskell` API. This is the first step in a wider strategy to publish stable packages that cover uses of `template-haskell` reducing ecosystem breakage from this inherently unstable package.

[Rendered](https://github.com/TeofilC/ghc-proposals/blob/wip/th-lift-and-quasiquote/proposals/0000-splitting-out-stable-interfaces-from-th.rst)