### PR TITLE
Abstract Q

### DIFF
--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -70,7 +70,13 @@ This is a breaking change.
 
 The ``runQ :: Quasi m => Q a -> m a`` function would be moved from the top-level and become
 a method of ``Quasi``. This is a breaking change.
+
 Note that ``runQ/Quasi`` is to ``Q`` as ``liftIO/MonadIO`` is to ``IO``.
+
+If a user gives a definition of ``runQ`` then all other methods except for ``qRecover`` can be implemented by lifting the method from the ``Q`` instance.
+Therefore we would also make all methods of ``Quasi`` except for ``runQ`` and ``qRecover`` optional.
+This means that libraries that implement ``Quasi`` instances would likely not have to make any changes if a new method is added.
+
 
 The rest of the changes are internal to GHC and ``ghc-internal``.
 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -22,9 +22,14 @@ These typeclasses are both external interfaces used by users and internal interf
 This exposes implementation details to users, which makes it difficult or impossible to alter
 the internal interface while keeping the external interface the same.
 
-We propose adding a new ``MetaHandlers`` record type of actions as a purely internal interface, which is not exposed to users.
+We propose splitting the existing one interface into two, with clear separation between the internal and external interfaces.
+The internal interface would be part of GHC and versioned with it, while the external would be able to evolve independently and be implemented in terms of the internal interface.
+
+We propose adding a new ``MetaHandlers`` record type of actions as this purely internal interface.
 ``Q`` is to be changed into an abstract newtype over ``MetaHandlers -> IO a``. ``Quasi`` and ``Quote`` are to be implemented in terms of it.
-``runQ :: Quasi m => Q a -> m a`` would become a method of ``Quasi``.
+
+The existing interface of ``template-haskell`` exposes a top-level ``runQ :: Quasi m => Q a -> m a`` function.
+This would no longer be possible to implement with the new definition of ``Q``. So, we also propose adding a corresponding method to ``Quasi``.
 
 Motivation
 ----------
@@ -35,7 +40,8 @@ Suppose I wanted to add new effect that could be used in Template Haskell splice
 ``reifyCore :: Name -> Q Core``, which given the ``Name`` of a term would produce the Core representation of it.
 
 I would currently implement this by adding this as a method to ``Quasi`` and adding an implementation in GHC.
-This forces a breaking change on ``template-haskell``, since it exports ``Quasi``.
+This forces a breaking change on ``template-haskell``, since it re-exports ``Quasi``.
+
 We cannot hide this method for the sake of compatibility, since end users depend on the ability to write custom instances of ``Quasi`` for their own monads
 (eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>` provides instances for certain monad transformers).
 
@@ -47,6 +53,11 @@ By separating out the internal interface, we can avoid this tight coupling.
 Old versions of ``template-haskell`` would still be compatible with the new version of GHC, as they can simply ignore the new field.
 A new version of ``template-haskell`` can add the corresponding method to ``Quasi`` and use the field from ``MetaHandlers`` to implement it.
 
+``Q`` is wired-in to GHC. This fixes a single definition for each version of GHC. Since it is implemented in terms of ``Quasi``, it is also fixed.
+By breaking this tight coupling, we allow ``template-haskell``\'s interface to be compatible with a greater range of GHC versions and to evolve independently of it.
+
+Our new definition of ``Q`` is also easier to optimise for the compiler, since it uses a known ``Monad``. Though this is a minor benefit, since the runtime performance of splices is rarely an issue.
+
 Proposed Change Specification
 -----------------------------
 
@@ -56,27 +67,51 @@ Proposed Library Change Specification
 -------------------------------------
 
 This proposal requires making changes to the interface of ``template-haskell``.
+In this section we will purely focus on the changes to the interface.
+We will return to the implementation details in `Implementation plan <LINK!>`_
 
-The definition of ``Q`` would change from ::
+The interface of ``Language.Haskell.TH.Syntax`` (and ``Language.Haskell.TH``) will change from::
+
+ -- Note: these is defined in ghc-internalGHC.Internal.TH.Syntax
+ -- and only re-exported from template-haskell. They are wired-in defintions of GHC.
 
  newtype Q a = Q { unQ :: forall m. Quasi m => m a }
 
+ class (MonadIO m, MonadFail m) => Quasi m where
+  qNewName :: String -> m Name
+  qRecover :: m a -> m a -> m a
+  qReport  :: Bool -> String -> m ()
+  qReify   :: Name -> m Info
+  ... and so on
+
 to::
 
- newtype Q a = Q { unQ :: MetaHandlers -> IO a }
+ -- Note: Q is defined in ghc-internalGHC.Internal.TH.Syntax
+ -- and only re-exported from template-haskell.
+ newtype Q a -- Q is abstract or opaque
+
+ -- Note: Quasi is now defined in template-haskell. It is no longer wired-in.
+
+ class (MonadIO m, MonadFail m) => Quasi m where
+  qRun     :: Q a -> m a -- New method
+  qNewName :: String -> m Name
+  qRecover :: m a -> m a -> m a
+  qReport  :: Bool -> String -> m ()
+  qReify   :: Name -> m Info
+  ... and so on
+  {-# MINIMAL qRun qRecover #-}
 
 ``unQ`` and the ``Q`` constructor would no longer be exported from ``template-haskell``.
 This is a breaking change.
 
-The ``runQ :: Quasi m => Q a -> m a`` function would be moved from the top-level and become
-a method of ``Quasi``. This is a breaking change.
-
-Note that ``runQ/Quasi`` is to ``Q`` as ``liftIO/MonadIO`` is to ``IO``.
+A new ``qRun :: Quasi m => Q a -> m a`` method would be added to a ``Quasi``, so that the top-level ``runQ`` can still be implemented.
+This is a breaking change.
 
 If a user gives a definition of ``runQ`` then all other methods except for ``qRecover`` can be implemented by lifting the method from the ``Q`` instance.
-Therefore we would also make all methods of ``Quasi`` except for ``runQ`` and ``qRecover`` optional.
+Therefore we would also make all methods of ``Quasi`` except for ``qRun`` and ``qRecover`` optional.
 This means that libraries that implement ``Quasi`` instances would likely not have to make any changes if a new method is added.
 
+``qRecover`` cannot be implemented in terms of ``qRun`` as it includes a mention of the monad in negative position.
 
 The rest of the changes are internal to GHC and ``ghc-internal``.
 
@@ -106,14 +141,53 @@ Implementation Plan
 -------------------
 Teo Camarasu will implement this.
 
-We would create a new ``MetaHandlers`` record in ``ghc-internal``.
-This record would have a field for each method of ``Quasi``.
+This section is mostly here to clarify the internal changes required to implement the changes to the interface.
 
-We would have to refactor the code for running splices in the compiler to use use this new interface.
+We would make the following changes in ``GHC.Internal.TH.Syntax``::
 
-We would update ``template-haskell`` with the changes proposed here.
+  -- we create a new type
+  data MetaHandlers =
+    MetaHandlers
+    { mReify :: Name -> IO Info
+    , mNewName :: String -> IO Name
+    ... and so on
+    }
 
-We would submit patches to any packages on Hackage broken by these changes.
+  -- we change the definition of Q
+  newtype Q a = Q { unQ :: MetaHandlers -> IO a }
+
+  -- we move Quasi Language.Haskell.TH.Syntax
+  -- so the code is deleted from here
+
+We would make the following changes in ``Language.Haskell.TH.Syntax``::
+
+ class (MonadIO m, MonadFail m) => Quasi m where
+  qRun     :: Q a -> m a -- New method
+  qRecover :: m a -> m a -> m a
+  qNewName :: String -> m Name
+  qNewName nm = qRun $ \handlers -> mNewName nm -- we add default methods
+  qReport  :: Bool -> String -> m ()
+  qReport severity msg = qRun $ \handlers -> mReport severity msg -- we add default methods
+  qReify   :: Name -> m Info
+  qReify nm = qRun $ \handlers -> mReify nm -- we add default methods
+  ... and so on
+  {-# MINIMAL qRun qRecover #-}
+
+  instance Quasi Q where
+    qRun = id
+    qRecover r k = catch k (const $ r)
+    -- all other methods are just the default
+
+  runQ :: Quasi m => Q a -> m a
+  runQ = qRun
+
+We would also alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers``.
+
+An important note is that currently the error throwing and recovery logic (``qReport`` and ``qRecover``) for ``Q`` make use of the fact that
+``Q`` is lifted into a ``TcM`` value (GHC's type checking monad), and use utilities from that.
+
+TODO: figure out exactly what to do here.
+
 
 Endorsements
 -------------

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -1,0 +1,113 @@
+Abstract Q
+==============
+
+.. author:: Teo Camarasu
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first GHC version which
+                 implements the described feature.
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/700>`_.
+.. sectnum::
+.. contents::
+
+Template Haskell is GHC's metaprogramming facility. It allows users to write Haskell programs that can manipulate on Haskell syntax trees.
+These programs are run at compile-time, and their results are spliced into the syntax tree.
+They can be effectful and run ``IO`` actions or introspect into the compiler state in limited ways.
+These effects are exposed to users through the ``Quote`` and ``Quasi`` typeclasses and the ``Q`` monad.
+
+These typeclasses are both external interfaces used by users and internal interfaces of GHC.
+This exposes implementation details to users, which makes it difficult or impossible to alter
+the internal interface while keeping the external interface the same.
+
+We propose adding a new ``MetaHandlers`` record type of actions as a purely internal interface, which is not exposed to users.
+``Q`` is to be changed into an abstract newtype over ``MetaHandlers -> IO a``. ``Quasi`` and ``Quote`` are to be implemented in terms of it.
+``runQ :: Quasi m => Q a -> m a`` would become a method of ``Quasi``.
+
+Motivation
+----------
+
+Let's motivate this change with an example.
+
+Suppose I wanted to add new effect that could be used in Template Haskell splices:
+``reifyCore :: Name -> Q Core``, which given the ``Name`` of a term would produce the Core representation of it.
+
+I would currently implement this by adding this as a method to ``Quasi`` and adding an implementation in GHC.
+This forces a breaking change on ``template-haskell``, since it exports ``Quasi``.
+We cannot hide this method for the sake of compatibility, since end users depend on the ability to write custom instances of ``Quasi`` for their own monads
+(eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>` provides instances for certain monad transformers).
+
+We would run into the same issue if we wanted to remove a method from ``Quasi``  or change its type.
+The change in GHC would have to be reflected in the exposed interface of ``template-haskell``, forcing end-users to upgrade to a new major release if they want to use the new version of GHC.
+
+By separating out the internal interface, we can avoid this tight coupling.
+``reifyCore`` can be added as a field to ``MetaHandlers``. ``Quasi`` would then live purely in ``template-haskell``.
+Old versions of ``template-haskell`` would still be compatible with the new version of GHC, as they can simply ignore the new field.
+A new version of ``template-haskell`` can add the corresponding method to ``Quasi`` and use the field from ``MetaHandlers`` to implement it.
+
+Proposed Change Specification
+-----------------------------
+
+No changes are being proposed to the language.
+
+Proposed Library Change Specification
+-------------------------------------
+
+This proposal requires making changes to the interface of ``template-haskell``.
+
+The definition of ``Q`` would change from ::
+
+ newtype Q a = Q { unQ :: forall m. Quasi m => m a }
+
+to::
+
+ newtype Q a = Q { unQ :: MetaHandlers -> IO a }
+
+``unQ`` and the ``Q`` constructor would no longer be exported from ``template-haskell``.
+This is a breaking change.
+
+The ``runQ :: Quasi m => Q a -> m a`` function would be moved from the top-level and become
+a method of ``Quasi``. This is a breaking change.
+Note that ``runQ/Quasi`` is to ``Q`` as ``liftIO/MonadIO`` is to ``IO``.
+
+The rest of the changes are internal to GHC and ``ghc-internal``.
+
+Effect and Interactions
+-----------------------
+
+* The `Pure Template Haskell proposal <https://github.com/ghc-proposals/ghc-proposals/pull/655>`_ aims to
+  empower users to ban use of ``IO`` in Template Haskell splices.
+  This proposal opens up a lightweight implementation path for something along these lines.
+  One could implement a ``dropIO :: Q a -> Q a`` function that removes the ``runIO`` effect from the ``MetaHandlers`` record,
+  replacing it with an error call. This function could only be implemented by accessing ``ghc-internal``.
+
+
+Costs and Drawbacks
+-------------------
+
+The main cost of this proposal is that it entails a breaking change to the ``template-haskell`` interface.
+The implementation should be relatively simple and if anything it should simplify things as an existential is being replaced with a common-or-garden record.
+
+
+Backward Compatibility
+----------------------
+TODO: impact assessment but it's likely to be minor
+
+
+Implementation Plan
+-------------------
+Teo Camarasu will implement this.
+
+We would create a new ``MetaHandlers`` record in ``ghc-internal``.
+This record would have a field for each method of ``Quasi``.
+
+We would have to refactor the code for running splices in the compiler to use use this new interface.
+
+We would update ``template-haskell`` with the changes proposed here.
+
+We would submit patches to any packages on Hackage broken by these changes.
+
+Endorsements
+-------------

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -193,7 +193,7 @@ We would make the following changes in ``Language.Haskell.TH.Syntax``::
 
   instance Quasi Q where
     qRun = id
-    qRecover (Q r) (Q k) = Q $ \handlers -> mRecover handlers r k
+    qRecover (Q r) (Q k) = Q $ \handlers -> mRecover handlers (r handlers) (k handlers)
     -- all other methods are just the default
 
   runQ :: Quasi m => Q a -> m a

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -22,7 +22,7 @@ The list of primitive methods exposed from ``Q`` is defined by the ``Quasi m`` t
 Any change to the interface of ``Q`` / ``Quasi`` is a breaking change, which requires a new major release of ``template-haskell``,
 and this change cannot be made forwards or backwards compatible.
 
-The aim of this proposal is to allow modifying the implementation of this interface in a forwards and backwards compatible way.
+The aim of this proposal is to allow modifying the set of effects available in ``Q`` in a forwards and backwards compatible way, and to allow making such changes without requiring a new major version of ``template-haskell``.
 
 This will allow us to give greater stability guarantees for the very widely used ``template-haskell`` library, which has 13936 transitive reverse dependencies. Thus reducing the amount of upper bound updating required when a new version of GHC comes out is very valuable. Being able to change these interfaces more easily also opens the door to cleaning up historical issues in a non-breaking way.
 
@@ -276,7 +276,14 @@ How the implementation satisfies the motivation
 This new definition of ``Q`` achieves the goals we have set in
 `Motivation <#motivation>`_.
 
-If I wish to add a new method ``reifyCore :: Name -> Q Core`` that can be run in TemplateHaskell splices, then I need only make a change to the compiler. I add a new method to ``MetaHandlers`` in ``ghc-internal``, say ``mReifyCore :: Name -> IO Core`` and give a definition in the compiler. I can then release the compiler without requiring any change to ``template-haskell``. So ``GHC-2`` can be released which is compatible with ``template-haskell-0.1`` (re-using the version numbers from earlier). Then I can independently release ``template-haskell-0.2`` with the new method. Since these definitions are entirely internal to the compiler, I can also backport my patch without worrying about breaking previous versions of ``template-haskell``, so we could make the next minor release in the previous line, ``GHC-1.1`` compatible with the new major version of ``template-haskell``, ``template-haskell-0.2``.
+If I wish to add a new method ``reifyCore :: Name -> Q Core`` that can be run in TemplateHaskell splices, then I need only make a change to the compiler.
+I add a new method to ``MetaHandlers`` in ``ghc-internal``, say ``mReifyCore :: Name -> IO Core`` and give a definition in the compiler.
+I can then release the compiler without requiring any change to ``template-haskell``.
+So ``GHC-2`` can be released which is compatible with ``template-haskell-0.1`` (re-using the version numbers from earlier).
+Then I can independently release ``template-haskell-0.2`` with the new method.
+Since these definitions are entirely internal to the compiler, I can also backport my patch without worrying about breaking previous versions of ``template-haskell``, so we could make the next minor release in the previous line, ``GHC-1.1`` compatible with the new major version of ``template-haskell``, ``template-haskell-0.2``.
+
+Later on, I may wish to expose this new method from ``template-haskell``, I can then export a function ``reifyCore`` with only a minor version bump, as we no longer need to add the method to ``Quasi``. If a user wishes to lift the method into an arbitary instance of ``Quasi`` then they can simply use ``liftQ``.
 
 The same sorts of techniques can be used for removing methods from the interface of ``Q`` in ``template-haskell`` or for modifying methods (equivalent to adding and then removing methods).
 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -2,73 +2,93 @@ Abstract Q
 ==============
 
 .. author:: Teo Camarasu
-.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
-.. ticket-url:: Leave blank. This will eventually be filled with the
-                ticket URL which will track the progress of the
-                implementation of the feature.
-.. implemented:: Leave blank. This will be filled in with the first GHC version which
-                 implements the described feature.
+.. date-accepted::
+.. ticket-url::
+.. implemented::
 .. highlight:: haskell
 .. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/700>`_.
 .. sectnum::
 .. contents::
 
 Template Haskell is GHC's metaprogramming facility.
-It allows users to make use of Haskell programs at compile-time that can manipulate Haskell syntax trees.
-They can be effectful and run ``IO`` actions or introspect into the compiler state in certain limited ways.
-These effects are exposed to users through the ``Quote`` and ``Quasi`` typeclasses and the ``Q`` monad.
+It allows users to make use of Haskell programs at compile-time to manipulate Haskell syntax trees.
+These programs are written in the ``Q`` monad, which is analogous to the familiar ``IO`` monad of everyday Haskell programs.
 
-These typeclasses are both external interfaces used by users and internal interfaces of GHC.
-This exposes implementation details to users, which makes it difficult or impossible to alter
-the internal interface while keeping the external interface the same.
+They can be effectful and, for instance, run ``IO`` actions (via ``liftIO :: IO a -> Q a``) or introspect into the compiler state in certain limited ways.
+For instance, we can reify certain information about a name (``reify :: Name -> Q Info``), or store some state between different splice invocations in the same module ``putQ :: Typeable a => a -> Q ()``.
 
-We propose splitting the existing single interface into two, with a clear separation between the internal and external interfaces.
-The internal interface would be part of GHC and versioned with it. The external would be able to evolve independently and be implemented in terms of the internal interface.
+The list of primitive methods exposed from ``Q`` is defined by the ``Quasi m`` typeclass. This typeclass is exposed to users via ``template-haskell`` but is also used inside the compiler to define how computations in ``Q`` should be run.
 
-This will be implemented by adding a new ``MetaHandlers`` record type of actions as this purely internal interface.
-``Q`` is to be changed into an abstract newtype over ``MetaHandlers -> IO a``. ``Quasi`` and ``Quote`` are to be implemented in terms of it.
+Any change to the interface of ``Q`` / ``Quasi`` is a breaking change, which requires a new major release of ``template-haskell``,
+and this change cannot be made forwards or backwards compatible.
 
-The existing interface of ``template-haskell`` exposes a top-level ``runQ :: Quasi m => Q a -> m a`` function.
-This would no longer be possible to implement with the new definition of ``Q``. So, we also propose adding a corresponding method to ``Quasi``.
+The aim of this proposal is to allow modifying this interface in a forwards and backwards compatible way and to only require a minor release of ``template-haskell`` when such a change is made.
 
-In order to hide the implementation details, we propose hiding the ``Q`` (value) constructor and adding a backwards compatible ``unQ`` function.
+This will allow us to give greater stability guarantees for the very widely used ``template-haskell`` library, which has 13936 transitive reverse dependencies. Thus reducing the amount of upper bound updating required when a new version of GHC comes out is very valuable. Being able to change these interfaces more easily also opens the door to cleaning up historical issues in a non-breaking way.
 
-As such, the change from this proposal is very small. We alter the interface of ``Language.Haskell.TH.Syntax``:
+Our strategy is to hide the definition of the ``Q`` monad. At present, it is defined in terms of the ``Quasi`` typeclass, which is part of the public interface. We replace this implementation. We continue to export ``Quasi`` in order to preserve backwards compatibility, but it will no longer be a load bearing part of the interface.
 
-* remove ``Q`` constructor
+While this does lead to a breaking change to the interface, we try to keep the damage to a minimum.
+
+In short, we propose to:
+
+* no longer export ``Q`` constructor
 * add new ``qRunQ :: Quasi m => Q a -> m a`` method to the ``Quasi`` typeclass.
-
-The rest of this proposal is about the detailed explanation for why we want to do that and how the implementation details for these choices.
 
 
 Motivation
 ----------
 
-Let's motivate this change with an example.
+The definition of Q and Quasi 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Suppose I wanted to add new effect that could be used in Template Haskell splices:
-``reifyCore :: Name -> Q Core``, which given the ``Name`` of a term would produce the Core representation of it.
+The ``Q`` typeclass is defined as::
 
-I would currently implement this by adding this as a method to ``Quasi`` and adding an implementation in GHC.
-This forces a breaking change of ``template-haskell``, since it re-exports ``Quasi``.
+  newtype Q a = Q {unQ :: forall m. Quasi m => m a}
 
-We cannot hide this method for the sake of compatibility, since end users depend on the ability to write custom instances of ``Quasi`` for their own monads
-(eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers).
+This tells us that a value of ``Q a`` consists of a ``Quasi`` dictionary for some type ``m`` and a value of ``m a``.
+When constructing a value of ``Q a``, we do not know which concrete monad that computation will be executed in, but we do know that monad will be an instance of ``Quasi``.
+Thus we can only rely on ``Quasi`` and derived operations when constructing our value.
 
-We would run into the same issue if we wanted to remove a method from ``Quasi``  or change a method's type.
-The change in GHC would have to be reflected in the exposed interface of ``template-haskell``, forcing end-users to upgrade to a new major release of ``template-haskell`` if they want to use the new version of GHC.
+This roundabout definition exists to solve a problem. Users of ``template-haskell`` do not wish to depend on the ``ghc`` library, but that is where the definitions of the methods of ``Quasi``, which are run when splices are executed, can be found. This definition allows us the invert this dependency. Rather than ``template-haskell`` depending on ``ghc``, ``ghc`` actually depends on the location where ``Quasi`` and ``Q`` are defined, ``ghc-internal``.
 
-By separating out the internal interface, we can avoid this tight coupling.
-``reifyCore`` can be added as a field to ``MetaHandlers``. ``Quasi`` would then live purely in ``template-haskell``.
-Old versions of ``template-haskell`` would still be compatible with the new version of GHC, as they can simply ignore the new field.
-A new major version of ``template-haskell`` can add the corresponding method to ``Quasi`` and use the field from ``MetaHandlers`` to implement it.
+To allow running splices. GHC provides a ``Quasi`` instance for the typechecking monad, ``TcM``, and then uses ``unQ`` specialized to ``Q a -> Quasi TcM => TcMa``. 
 
-The definition of ``Q`` is fixed by GHC. A single definition of it for each version of GHC. Since it is implemented in terms of ``Quasi``, ``Quasi`` is also fixed.
-By breaking this tight coupling, we allow ``template-haskell``\'s interface to potentially be compatible with a greater range of GHC versions and to evolve independently of it.
+Both ``Quasi`` and ``Q`` are defined in ``ghc-internal`` and then used by ``ghc`` and also re-exported by ``template-haskell``.
 
-Our new definition of ``Q`` is also easier to optimise for the compiler, since it uses a known ``Monad``. Though this is a minor benefit, since the runtime performance of splices is rarely an issue.
 
-It also has potential to interface well with the ``bluefin``/``effectful`` family of effects libraries, which are implemented in terms of ``IO``, and could not express Template Haskell effects previously.
+Adding a new method to splices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Let's say we want to add ``reifyCore :: Name -> Q Core`` to the set of methods accessible from TemplateHaskell splices.
+We would modify the definition of ``Quasi`` in ``ghc-internal`` by adding a new ``qReifyCore :: Name -> m Core`` method.
+We would give a definition of that method for ``TcM`` in the compiler (and for the external interpreter).
+Finally, we would create a utility function ``reifyCore nm = Q $ qReifyCore nm`` in ``template-haskell`` to lift this into ``Q``.
+
+As we've added a new method to a typeclass exposed from ``template-haskell`` we need to release a new major version as per the `PVP <https://pvp.haskell.org/>`_.
+Suppose that the previous version of GHC was ``GHC-1`` and that it ships with ``template-haskell-0.1.0``.
+Then ``GHC-2`` will need to ship with ``template-haskell-0.2.0``.
+
+Note that ``Quasi`` lives in ``ghc-internal``, so it must be versioned with GHC.
+This means that ``template-haskell-0.1`` cannot be made compatible with ``GHC-2`` and 
+``template-haskell-0.2`` cannot be made compatible with ``GHC-1``.
+
+Any user of ``template-haskell`` is then forced to update their upper bound on ``template-haskell`` if they wish to upgrade to ``GHC-2``, and this must be done atomically.
+They could not update ``template-haskell`` first and ``GHC`` second or vice versa.
+
+Other instances of Quasi
+^^^^^^^^^^^^^^^^^^^^^^^^
+As we have exposed this ``Quasi`` typeclass, end users are free to give their own instances of it.
+For instance, the `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers.
+Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transsformer stacks and use ``MonadIO`` to lift ``IO`` operations into that.
+In practice, ``Quasi`` often functions equivalently to ``MonadIO`` for ``Q``.
+
+Concrete monad
+^^^^^^^^^^^^^^
+
+The use of an abstract ``Monad`` in the definition of ``Q`` means that the optimizer cannot inline the ``>>=``, which can be important for the performance of longer splices. Although for most users this is extremely unlikely to be an issue. Our design uses a concrete ``Monad`` to alleviate this.
+
+Our design also allows better interfacing with the  ``bluefin``/``effectful`` family of effects libraries, which are implemented in terms of ``IO``, and could not express Template Haskell effects previously.
 
 Proposed Change Specification
 -----------------------------
@@ -116,17 +136,22 @@ to::
   ... and so on
   {-# MINIMAL qRunQ qRecover #-}
 
-``unQ`` and the ``Q`` constructor would no longer be exported from ``template-haskell``.
+The ``Q`` constructor would no longer be exported from ``template-haskell``.
 This is a breaking change.
 
 A new ``qRunQ :: Quasi m => Q a -> m a`` method would be added to a ``Quasi``, so that the top-level ``runQ`` can still be implemented.
 This is a breaking change.
+
+Adding the ``qRunQ`` method is crucial to ensure that users can still give meaningful instances of ``Quasi`` even if it is no longer tightly coupled to the implementation of ``Q``.
+``qRunQ`` is analgous to ``liftIO`` but we have chosen to avoid the term, since a ``runQ`` function with the correct type already existed in the ``template-haskell`` interface, and out of a worry that ``liftQ :: Quasi m => Q a -> m a`` could be confused with ``lift :: Lift a => a -> Q Exp``.
 
 If a user gives a definition of ``runQ`` then all other methods except for ``qRecover`` can be implemented by lifting the method from the ``Q`` instance.
 Therefore we would also make all methods of ``Quasi`` except for ``qRunQ`` and ``qRecover`` optional.
 This means that libraries that implement ``Quasi`` instances would likely not have to make any changes if a new method is added.
 
 ``qRecover`` cannot be implemented in terms of ``qRunQ`` as it includes a mention of the monad in negative position.
+
+As ``Quasi`` is no longer part of the implementation of ``Q``, it technically could be removed from the interface of ``template-haskell``, but we have chosen to retain it for backwards compatibility and because it is useful for user's to use analogously to ``MonadIO``.
 
 The rest of the changes are internal to GHC and ``ghc-internal``.
 
@@ -172,6 +197,11 @@ Teo Camarasu will implement this.
 This section is purely here to clarify the internal changes required to implement the changes to the interface.
 The exact details of GHC's internals are out of scope of the proposal.
 
+Our implementation basically duplicates the ``Quasi`` typeclass as a record of handlers.
+We choose to go with a record rather than a typeclass purely for the sake of simplicity.
+
+As we always run ``Q`` computations in monads which are themselves reader monads on top of ``IO``, we can use ``IO`` as our concrete monad.
+
 We would make the following changes in ``GHC.Internal.TH.Monad``::
 
   -- we create a new type
@@ -205,15 +235,17 @@ We would make the following changes in ``Language.Haskell.TH.Syntax``::
 
   instance Quasi Q where
     qRunQ = id
-    qRecover r k = Q $ \runInIO handlers -> runInIO $ mRecover handlers r k 
+    qRecover r k = Q $ \handlers -> mRecover handlers r k 
     -- all other methods are just the default
 
   runQ :: Quasi m => Q a -> m a
   runQ = qRunQ
 
-Note that ``qRecover`` is a special case. It cannot use the default method like the other methods as we get a value of ``Q`` in a negative position.
+  -- backwards compatibility for removed unQ field selector
+  unQ :: Quasi m => Q a -> m a
+  unQ = runQ
 
-The new type of ``Q`` might seem somewhat complex, but a good way to think about it is that it is a computation running in ``IO`` along with a all the ``Quasi`` methods that run in ``env -> IO _`` and also a value of ``env``. The type is abstract since we don't want to make any assumptions about the monads defined in ``lib:ghc`` in ``ghc-internal``.
+Note that ``qRecover`` is a special case. It cannot use the default method like the other methods as we get a value of ``Q`` in a negative position. This is only relevant for user defined instances of ``Quasi``.
 
 We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers`` using the existing implementations.
 To do so we would defined something like this::

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -98,25 +98,25 @@ to::
  -- Note: Quasi is now defined in template-haskell. It is no longer known key.
 
  class (MonadIO m, MonadFail m) => Quasi m where
-  qRun     :: Q a -> m a -- New method
+  qRunQ     :: Q a -> m a -- New method
   qNewName :: String -> m Name
   qRecover :: m a -> m a -> m a
   qReport  :: Bool -> String -> m ()
   qReify   :: Name -> m Info
   ... and so on
-  {-# MINIMAL qRun qRecover #-}
+  {-# MINIMAL qRunQ qRecover #-}
 
 ``unQ`` and the ``Q`` constructor would no longer be exported from ``template-haskell``.
 This is a breaking change.
 
-A new ``qRun :: Quasi m => Q a -> m a`` method would be added to a ``Quasi``, so that the top-level ``runQ`` can still be implemented.
+A new ``qRunQ :: Quasi m => Q a -> m a`` method would be added to a ``Quasi``, so that the top-level ``runQ`` can still be implemented.
 This is a breaking change.
 
 If a user gives a definition of ``runQ`` then all other methods except for ``qRecover`` can be implemented by lifting the method from the ``Q`` instance.
-Therefore we would also make all methods of ``Quasi`` except for ``qRun`` and ``qRecover`` optional.
+Therefore we would also make all methods of ``Quasi`` except for ``qRunQ`` and ``qRecover`` optional.
 This means that libraries that implement ``Quasi`` instances would likely not have to make any changes if a new method is added.
 
-``qRecover`` cannot be implemented in terms of ``qRun`` as it includes a mention of the monad in negative position.
+``qRecover`` cannot be implemented in terms of ``qRunQ`` as it includes a mention of the monad in negative position.
 
 The rest of the changes are internal to GHC and ``ghc-internal``.
 
@@ -180,24 +180,24 @@ We would make the following changes in ``GHC.Internal.TH.Syntax``::
 We would make the following changes in ``Language.Haskell.TH.Syntax``::
 
  class (MonadIO m, MonadFail m) => Quasi m where
-  qRun     :: Q a -> m a -- New method
+  qRunQ     :: Q a -> m a -- New method
   qRecover :: m a -> m a -> m a
   qNewName :: String -> m Name
-  qNewName nm = qRun $ \handlers -> mNewName handlers nm -- we add default methods
+  qNewName nm = qRunQ $ \handlers -> mNewName handlers nm -- we add default methods
   qReport  :: Bool -> String -> m ()
-  qReport severity msg = qRun $ \handlers -> mReport handlers severity msg -- we add default methods
+  qReport severity msg = qRunQ $ \handlers -> mReport handlers severity msg -- we add default methods
   qReify   :: Name -> m Info
-  qReify nm = qRun $ \handlers -> mReify handlers nm -- we add default methods
+  qReify nm = qRunQ $ \handlers -> mReify handlers nm -- we add default methods
   ... and so on
-  {-# MINIMAL qRun qRecover #-}
+  {-# MINIMAL qRunQ qRecover #-}
 
   instance Quasi Q where
-    qRun = id
+    qRunQ = id
     qRecover (Q r) (Q k) = Q $ \handlers -> mRecover handlers (r handlers) (k handlers)
     -- all other methods are just the default
 
   runQ :: Quasi m => Q a -> m a
-  runQ = qRun
+  runQ = qRunQ
 
 We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers`` using the existing implementations.
 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -80,7 +80,7 @@ Other instances of Quasi
 ^^^^^^^^^^^^^^^^^^^^^^^^
 As we have exposed this ``Quasi`` typeclass, end users are free to give their own instances of it.
 For instance, the `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers.
-Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transsformer stacks and use ``MonadIO`` to lift ``IO`` operations into that.
+Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transformer stacks and use ``MonadIO`` to lift ``IO`` operations into that.
 In practice, ``Quasi`` often functions equivalently to ``MonadIO`` for ``Q``.
 
 Concrete monad
@@ -268,3 +268,19 @@ To do so we would defined something like this::
 You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> IO a`` rather than ``IO a -> IO a -> IO a``. This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers TcM``, but we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
 
 We also have to modify the definition of the external interpreter, which simply proxies messages to the compiler. 
+
+How the implementation satisfies the motivation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This new definition of ``Q`` achieves the goals we have set in
+`Motivation <#motivation>`_.
+
+If I wish to add a new method ``reifyCore :: Name -> Q Core`` that can be run in TemplateHaskell splices, then I need only make a change to the compiler. I add a new method to ``MetaHandlers`` in ``ghc-internal``, say ``mReifyCore :: Name -> IO Core`` and give a definition in the compiler. I can then release the compiler without requiring any change to ``template-haskell``. So ``GHC-2`` can be released which is compatible with ``template-haskell-0.1`` (re-using the version numbers from earlier). Then I can independently release ``template-haskell-0.2`` with the new method. Since these definitions are entirely internal to the compiler, I can also backport my patch without worrying about breaking previous versions of ``template-haskell``, so we could make the next minor release in the previous line, ``GHC-1.1`` compatible with the new major version of ``template-haskell``, ``template-haskell-0.2``.
+
+The same sorts of techniques can be used for removing methods from the interface of ``Q`` in ``template-haskell`` or for modifying methods (equivalent to adding and then removing methods).
+
+Our definition still allows end-users to give their own instances of ``Quasi`` and in fact greatly reduces the boilerplate involved as they only need to define ``qRunQ`` and ``qRecover``, the other methods can be derived from these two. They can also stilll run ``Q`` in ``IO`` by using ``runQ``.
+
+Our definition of ``Q`` is now given in terms of a concrete monad, which opens up opportunities for easier optimization. And our choice of a reader over ``IO`` allows us to nicely fit in to the ``bluefin`` / ``effectful`` ecosystem.
+
+

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -43,7 +43,7 @@ I would currently implement this by adding this as a method to ``Quasi`` and add
 This forces a breaking change of ``template-haskell``, since it re-exports ``Quasi``.
 
 We cannot hide this method for the sake of compatibility, since end users depend on the ability to write custom instances of ``Quasi`` for their own monads
-(eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>` provides instances for certain monad transformers).
+(eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers).
 
 We would run into the same issue if we wanted to remove a method from ``Quasi``  or change a method's type.
 The change in GHC would have to be reflected in the exposed interface of ``template-haskell``, forcing end-users to upgrade to a new major release of ``template-haskell`` if they want to use the new version of GHC.
@@ -145,13 +145,14 @@ While this is a breaking change to ``template-haskell``, this interface breaks r
 Despite this, we've tried to maximise backwards compatibility by adding an ``unQ`` pattern synonym to the interface.
 
 The following packages on Hackage will be impacted as they give custom instances of ``Quasi``:
-- ``RepLib``
-- ``aeson-schema``
-- ``large-records``
-- ``geniplate``
-- ``th-test-utils``
-- ``nyan-interpolation-core``
-- ``th-traced``
+
+* ``RepLib``
+* ``aeson-schema``
+* ``large-records``
+* ``geniplate``
+* ``th-test-utils``
+* ``nyan-interpolation-core``
+* ``th-traced``
 
 
 Implementation Plan

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -92,7 +92,7 @@ to::
  -- and only re-exported from template-haskell.
  -- It is still known key.
  newtype Q a -- Q is abstract or opaque
- -- bundlend pattern synonym for backwards compatibility
+ -- bundled pattern synonym for backwards compatibility
  pattern unQ :: Q a -> forall m. Quasi m => m a
 
  -- Note: Quasi is now defined in template-haskell. It is no longer known key.
@@ -159,21 +159,22 @@ Implementation Plan
 -------------------
 Teo Camarasu will implement this.
 
-This section is mostly here to clarify the internal changes required to implement the changes to the interface.
+This section is purely here to clarify the internal changes required to implement the changes to the interface.
+The exact details of GHC's internals are out of scope of the proposal.
 
-We would make the following changes in ``GHC.Internal.TH.Syntax``::
+We would make the following changes in ``GHC.Internal.TH.Monad``::
 
   -- we create a new type
-  data MetaHandlers =
+  data MetaHandlers m =
     MetaHandlers
-    { mReify :: Name -> IO Info
-    , mNewName :: String -> IO Name
-    , mRecover :: forall a. IO a -> IO a -> IO a
+    { mReify :: Name -> m Info
+    , mNewName :: String -> m Name
+    , mRecover :: forall a. Q a -> Q a -> m a
     ... and so on
     }
 
   -- we change the definition of Q
-  newtype Q a = Q { unQ :: MetaHandlers -> IO a }
+  newtype Q a = Q { unQ :: forall m. (forall x. m x -> IO x) -> MetaHandlers m -> IO a }
 
   -- we move Quasi Language.Haskell.TH.Syntax
   -- so the code is deleted from here
@@ -184,25 +185,44 @@ We would make the following changes in ``Language.Haskell.TH.Syntax``::
   qRunQ     :: Q a -> m a -- New method
   qRecover :: m a -> m a -> m a
   qNewName :: String -> m Name
-  qNewName nm = qRunQ $ \handlers -> mNewName handlers nm -- we add default methods
+  qNewName nm = qRunQ $ \handlers -> runInIO $ mNewName handlers nm -- we add default methods
   qReport  :: Bool -> String -> m ()
-  qReport severity msg = qRunQ $ \handlers -> mReport handlers severity msg -- we add default methods
+  qReport severity msg = qRunQ $ \runInIO handlers -> runInIO $ mReport handlers severity msg -- we add default methods
   qReify   :: Name -> m Info
-  qReify nm = qRunQ $ \handlers -> mReify handlers nm -- we add default methods
+  qReify nm = qRunQ $ \runInIO handlers -> runInIO $ mReify handlers nm -- we add default methods
   ... and so on
   {-# MINIMAL qRunQ qRecover #-}
 
   instance Quasi Q where
     qRunQ = id
-    qRecover (Q r) (Q k) = Q $ \handlers -> mRecover handlers (r handlers) (k handlers)
+    qRecover r k = Q $ \runInIO handlers -> runInIO $ mRecover handlers r k 
     -- all other methods are just the default
 
   runQ :: Quasi m => Q a -> m a
   runQ = qRunQ
 
-We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers`` using the existing implementations.
+Note that ``qRecover`` is a special case. It cannot use the default method like the other methods as we get a value of ``Q`` in a negative position.
 
-When defining ``Quasi Q``, note that we can't provide a default method for ``qRecover`` as the monad appears in negative position.
+The new type of ``Q`` might seem somewhat complex, but a good way to think about it is that it is a computation running in ``IO`` along with a all the ``Quasi`` methods that run in ``env -> IO _`` and also a value of ``env``. The type is abstract since we don't want to make any assumptions about the monads defined in ``lib:ghc`` in ``ghc-internal``.
 
-Endorsements
--------------
+We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers TcM`` using the existing implementations.
+To do so we would defined something like this::
+
+  -- this replaces: runQuasi :: Quasi m => m a -> TcM a
+  runQinTcM :: Q a -> TcM a
+  runQInTcM (Q m) = IOEnv $ \env -> 
+    let
+      runInIO :: forall x. TcM x -> IO x
+      runInIO (IOEnv n) = n env
+    in m runInIO metaHandlersTcM
+
+  metaHandlersTcM :: MetaHandlers TcM
+  metaHandlersTcM = MetaHandlers
+    { mFail = \str -> fail str
+    , mRecover = \r k -> tryTcDiscardingErrs (runQinTcM r) (runQinTcM k)
+    ...
+    }
+
+You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> m a`` rather than ``m a -> m a -> m a``. This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers TcM``, but we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
+
+We also have to modify the definition of the external interpreter, which simply proxies messages to the compiler. 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -32,7 +32,7 @@ While this does lead to a breaking change to the interface, we try to keep the d
 
 In short, we propose to:
 
-* no longer export ``Q`` constructor
+* no longer export the ``Q`` constructor
 * add new ``qRunQ :: Quasi m => Q a -> m a`` method to the ``Quasi`` typeclass.
 
 
@@ -78,11 +78,11 @@ They could not update ``template-haskell`` first and ``GHC`` second or vice vers
 Other instances of Quasi
 ^^^^^^^^^^^^^^^^^^^^^^^^
 As we have exposed the ``Quasi`` typeclass, end users are free to give their own instances of it.
-For instance, the `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers.
-Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transformer stacks and use ``MonadIO`` to lift ``IO`` operations into that.
+For instance, the `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ package provides instances for certain monad transformers.
+Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transformer stacks and use ``MonadIO`` to lift ``IO`` operations.
 In practice, ``Quasi`` often functions equivalently to ``MonadIO`` for ``Q``.
 
-Concrete monad
+Concrete Monad
 ^^^^^^^^^^^^^^
 
 The use of an abstract ``Monad`` in the definition of ``Q`` means that the optimizer cannot inline the ``>>=``, which can be important for the performance of longer splices. Although for most users this is extremely unlikely to be an issue. Our design uses a concrete ``Monad`` to alleviate this.
@@ -104,7 +104,7 @@ We will return to the implementation details in `Implementation plan <#7implemen
 The interface of ``Language.Haskell.TH.Syntax`` (and ``Language.Haskell.TH``) will change from::
 
  -- Note: these is defined in ghc-internal:GHC.Internal.TH.Syntax
- -- and only re-exported from template-haskell. These are known key definitions for GHC.
+ -- and only re-exported from template-haskell. Q is a known key definition for GHC.
 
  newtype Q a = Q { unQ :: forall m. Quasi m => m a }
 
@@ -124,7 +124,7 @@ to::
  -- backwards compatibility function to shim over the removed record selector
  unQ :: Q a -> forall m. Quasi m => m a
 
- -- Note: Quasi is now defined in template-haskell. It is no longer known key.
+ -- Note: Quasi is now defined in template-haskell. It is no longer (transitively) known key.
 
  class (MonadIO m, MonadFail m) => Quasi m where
   qRunQ     :: Q a -> m a -- New method

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -144,6 +144,15 @@ While this is a breaking change to ``template-haskell``, this interface breaks r
 
 Despite this, we've tried to maximise backwards compatibility by adding an ``unQ`` pattern synonym to the interface.
 
+The following packages on Hackage will be impacted as they give custom instances of ``Quasi``:
+- ``RepLib``
+- ``aeson-schema``
+- ``large-records``
+- ``geniplate``
+- ``th-test-utils``
+- ``nyan-interpolation-core``
+- ``th-traced``
+
 
 Implementation Plan
 -------------------

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -13,17 +13,17 @@ Abstract Q
 .. sectnum::
 .. contents::
 
-Template Haskell is GHC's metaprogramming facility. It allows users to write Haskell programs can manipulate Haskell syntax trees.
-These programs are run at compile-time, and their results are spliced into the syntax tree.
-They can be effectful and run ``IO`` actions or introspect into the compiler state in limited ways.
+Template Haskell is GHC's metaprogramming facility.
+It allows users to make use of Haskell programs at compile-time that can manipulate Haskell syntax trees.
+They can be effectful and run ``IO`` actions or introspect into the compiler state in certain limited ways.
 These effects are exposed to users through the ``Quote`` and ``Quasi`` typeclasses and the ``Q`` monad.
 
 These typeclasses are both external interfaces used by users and internal interfaces of GHC.
 This exposes implementation details to users, which makes it difficult or impossible to alter
 the internal interface while keeping the external interface the same.
 
-We propose splitting the existing one interface into two, with clear separation between the internal and external interfaces.
-The internal interface would be part of GHC and versioned with it, while the external would be able to evolve independently and be implemented in terms of the internal interface.
+We propose splitting the existing single interface into two, with a clear separation between the internal and external interfaces.
+The internal interface would be part of GHC and versioned with it. The external would be able to evolve independently and be implemented in terms of the internal interface.
 
 We propose adding a new ``MetaHandlers`` record type of actions as this purely internal interface.
 ``Q`` is to be changed into an abstract newtype over ``MetaHandlers -> IO a``. ``Quasi`` and ``Quote`` are to be implemented in terms of it.
@@ -46,17 +46,19 @@ We cannot hide this method for the sake of compatibility, since end users depend
 (eg, `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>` provides instances for certain monad transformers).
 
 We would run into the same issue if we wanted to remove a method from ``Quasi``  or change a method's type.
-The change in GHC would have to be reflected in the exposed interface of ``template-haskell``, forcing end-users to upgrade to a new major release if they want to use the new version of GHC.
+The change in GHC would have to be reflected in the exposed interface of ``template-haskell``, forcing end-users to upgrade to a new major release of ``template-haskell`` if they want to use the new version of GHC.
 
 By separating out the internal interface, we can avoid this tight coupling.
 ``reifyCore`` can be added as a field to ``MetaHandlers``. ``Quasi`` would then live purely in ``template-haskell``.
 Old versions of ``template-haskell`` would still be compatible with the new version of GHC, as they can simply ignore the new field.
-A new version of ``template-haskell`` can add the corresponding method to ``Quasi`` and use the field from ``MetaHandlers`` to implement it.
+A new major version of ``template-haskell`` can add the corresponding method to ``Quasi`` and use the field from ``MetaHandlers`` to implement it.
 
-``Q`` is wired-in to GHC. This fixes a single definition of it for each version of GHC. Since it is implemented in terms of ``Quasi``, it is also fixed.
+The definition of ``Q`` is fixed by GHC. A single definition of it for each version of GHC. Since it is implemented in terms of ``Quasi``, ``Quasi`` is also fixed.
 By breaking this tight coupling, we allow ``template-haskell``\'s interface to potentially be compatible with a greater range of GHC versions and to evolve independently of it.
 
-Our new definition of ``Q`` is also easier to optimise for the compiler, since it uses a known ``Monad``. Though this is a minor benefit, since the runtime performance of splices is rarely an issue. It also has potential to interface well with the ``bluefin``/``effectful`` family of effects libraries, which are implemented in terms of ``IO``, and could not express Template Haskell effects previously.
+Our new definition of ``Q`` is also easier to optimise for the compiler, since it uses a known ``Monad``. Though this is a minor benefit, since the runtime performance of splices is rarely an issue.
+
+It also has potential to interface well with the ``bluefin``/``effectful`` family of effects libraries, which are implemented in terms of ``IO``, and could not express Template Haskell effects previously.
 
 Proposed Change Specification
 -----------------------------
@@ -73,7 +75,7 @@ We will return to the implementation details in `Implementation plan <#7implemen
 The interface of ``Language.Haskell.TH.Syntax`` (and ``Language.Haskell.TH``) will change from::
 
  -- Note: these is defined in ghc-internal:GHC.Internal.TH.Syntax
- -- and only re-exported from template-haskell. These are wired-in definitions of GHC.
+ -- and only re-exported from template-haskell. These are known key definitions for GHC.
 
  newtype Q a = Q { unQ :: forall m. Quasi m => m a }
 
@@ -88,10 +90,10 @@ to::
 
  -- Note: Q is defined in ghc-internal:GHC.Internal.TH.Syntax
  -- and only re-exported from template-haskell.
- -- It is wired-in.
+ -- It is still known key.
  newtype Q a -- Q is abstract or opaque
 
- -- Note: Quasi is now defined in template-haskell. It is no longer wired-in.
+ -- Note: Quasi is now defined in template-haskell. It is no longer known key.
 
  class (MonadIO m, MonadFail m) => Quasi m where
   qRun     :: Q a -> m a -- New method
@@ -135,7 +137,8 @@ The implementation should be relatively simple and if anything it should simplif
 
 Backward Compatibility
 ----------------------
-TODO: impact assessment but it's likely to be minor
+
+While this is a breaking change to ``template-haskell``, this interface breaks regularly anyway. For instance, GHC-10 will include a new method in the ``Quasi`` typeclass, which would have a similar level of breakage. Implementing this change will protect users from future frequent breakages.
 
 
 Implementation Plan

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -175,16 +175,16 @@ The exact details of GHC's internals are out of scope of the proposal.
 We would make the following changes in ``GHC.Internal.TH.Monad``::
 
   -- we create a new type
-  data MetaHandlers m =
+  data MetaHandlers =
     MetaHandlers
-    { mReify :: Name -> m Info
-    , mNewName :: String -> m Name
-    , mRecover :: forall a. Q a -> Q a -> m a
+    { mReify :: Name -> IO Info
+    , mNewName :: String -> IO Name
+    , mRecover :: forall a. Q a -> Q a -> IO a
     ... and so on
     }
 
   -- we change the definition of Q
-  newtype Q a = Q { unQ :: forall m. (forall x. m x -> IO x) -> MetaHandlers m -> IO a }
+  newtype Q a = Q { unQ :: MetaHandlers -> IO a }
 
   -- we move Quasi Language.Haskell.TH.Syntax
   -- so the code is deleted from here
@@ -215,7 +215,7 @@ Note that ``qRecover`` is a special case. It cannot use the default method like 
 
 The new type of ``Q`` might seem somewhat complex, but a good way to think about it is that it is a computation running in ``IO`` along with a all the ``Quasi`` methods that run in ``env -> IO _`` and also a value of ``env``. The type is abstract since we don't want to make any assumptions about the monads defined in ``lib:ghc`` in ``ghc-internal``.
 
-We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers TcM`` using the existing implementations.
+We would alter the code for running splices in ``GHC.Tc.Gen.Splice`` and would construct a value of type ``MetaHandlers`` using the existing implementations.
 To do so we would defined something like this::
 
   -- this replaces: runQuasi :: Quasi m => m a -> TcM a
@@ -226,13 +226,13 @@ To do so we would defined something like this::
       runInIO (IOEnv n) = n env
     in m runInIO metaHandlersTcM
 
-  metaHandlersTcM :: MetaHandlers TcM
-  metaHandlersTcM = MetaHandlers
-    { mFail = \str -> fail str
-    , mRecover = \r k -> tryTcDiscardingErrs (runQinTcM r) (runQinTcM k)
+  metaHandlersTcM :: (forall a. TcM a -> IO a) -> MetaHandlers
+  metaHandlersTcM runInIO = MetaHandlers
+    { mFail = \str -> runInIO $ fail str
+    , mRecover = \r k -> runInIO $ tryTcDiscardingErrs (runQinTcM r) (runQinTcM k)
     ...
     }
 
-You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> m a`` rather than ``m a -> m a -> m a``. This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers TcM``, but we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
+You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> IO a`` rather than ``IO a -> IO a -> IO a``. This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers TcM``, but we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
 
 We also have to modify the definition of the external interpreter, which simply proxies messages to the compiler. 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -22,7 +22,7 @@ The list of primitive methods exposed from ``Q`` is defined by the ``Quasi m`` t
 Any change to the interface of ``Q`` / ``Quasi`` is a breaking change, which requires a new major release of ``template-haskell``,
 and this change cannot be made forwards or backwards compatible.
 
-The aim of this proposal is to allow modifying this interface in a forwards and backwards compatible way and to only require a minor release of ``template-haskell`` when such a change is made.
+The aim of this proposal is to allow modifying the implementation of this interface in a forwards and backwards compatible way.
 
 This will allow us to give greater stability guarantees for the very widely used ``template-haskell`` library, which has 13936 transitive reverse dependencies. Thus reducing the amount of upper bound updating required when a new version of GHC comes out is very valuable. Being able to change these interfaces more easily also opens the door to cleaning up historical issues in a non-breaking way.
 
@@ -52,7 +52,7 @@ Thus we can only rely on ``Quasi`` and derived operations when constructing our 
 
 This roundabout definition exists to solve a problem. Users of ``template-haskell`` do not wish to depend on the ``ghc`` library, but that is where the definitions of the methods of ``Quasi``, which are run when splices are executed, can be found. This definition allows us the invert this dependency. Rather than ``template-haskell`` depending on ``ghc``, ``ghc`` actually depends on the location where ``Quasi`` and ``Q`` are defined, ``ghc-internal``.
 
-To allow running splices. GHC provides a ``Quasi`` instance for the typechecking monad, ``TcM``, and then uses ``unQ`` specialized to ``Q a -> Quasi TcM => TcMa``. 
+To allow running splices. GHC provides a ``Quasi`` instance for the typechecking monad, ``TcM``, and then uses ``unQ`` specialized to ``Q a -> Quasi TcM => TcM a``. 
 
 Both ``Quasi`` and ``Q`` are defined in ``ghc-internal`` and then used by ``ghc`` and also re-exported by ``template-haskell``.
 
@@ -61,24 +61,23 @@ Adding a new method to splices
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's say we want to add ``reifyCore :: Name -> Q Core`` to the set of methods accessible from TemplateHaskell splices.
-We would modify the definition of ``Quasi`` in ``ghc-internal`` by adding a new ``qReifyCore :: Name -> m Core`` method.
-We would give a definition of that method for ``TcM`` in the compiler (and for the external interpreter).
+
+We add new ``qReifyCore :: Name -> m Core`` method to ``Quasi`` interface in ``ghc-internal``.
+Then we would implmement that method for ``TcM`` in the compiler (and for the external interpreter).
 Finally, we would create a utility function ``reifyCore nm = Q $ qReifyCore nm`` in ``template-haskell`` to lift this into ``Q``.
 
-As we've added a new method to a typeclass exposed from ``template-haskell`` we need to release a new major version as per the `PVP <https://pvp.haskell.org/>`_.
-Suppose that the previous version of GHC was ``GHC-1`` and that it ships with ``template-haskell-0.1.0``.
-Then ``GHC-2`` will need to ship with ``template-haskell-0.2.0``.
+Suppose that the previous version of GHC was ``GHC-1`` and that it ships with ``ghc-internal-1`` and that ``template-haskell-0.1.0`` requires exactly that version of ``ghc-internal``.
 
-Note that ``Quasi`` lives in ``ghc-internal``, so it must be versioned with GHC.
-This means that ``template-haskell-0.1`` cannot be made compatible with ``GHC-2`` and 
-``template-haskell-0.2`` cannot be made compatible with ``GHC-1``.
+As we've added a new method to an exposed typeclass, we need to release ``template-haskell-0.2.0``, a new major version, as per the `PVP <https://pvp.haskell.org/>`_.
+Then ``GHC-2`` will need to ship with ``ghc-internal-2`` and a new major version of ``template-haskell-0.2.0`` will only be compatible with ``ghc-internal-2``, as it re-exports the ``Quasi`` interface from ``ghc-internal``.
+So, ``template-haskell-0.1`` cannot be made compatible with ``ghc-internal-2`` and ``template-haskell-0.2`` cannot be made compatible with ``ghc-internal-1``.
 
 Any user of ``template-haskell`` is then forced to update their upper bound on ``template-haskell`` if they wish to upgrade to ``GHC-2``, and this must be done atomically.
 They could not update ``template-haskell`` first and ``GHC`` second or vice versa.
 
 Other instances of Quasi
 ^^^^^^^^^^^^^^^^^^^^^^^^
-As we have exposed this ``Quasi`` typeclass, end users are free to give their own instances of it.
+As we have exposed the ``Quasi`` typeclass, end users are free to give their own instances of it.
 For instance, the `th-orphans <https://hackage.haskell.org/package/th-orphans-0.13.16/docs/Language-Haskell-TH-Instances.html>`_ provides instances for certain monad transformers.
 Such instances are never used when running splices in the compiler, but they are useful in similar ways to how it is useful to place ``IO`` in monad transformer stacks and use ``MonadIO`` to lift ``IO`` operations into that.
 In practice, ``Quasi`` often functions equivalently to ``MonadIO`` for ``Q``.
@@ -143,7 +142,7 @@ A new ``qRunQ :: Quasi m => Q a -> m a`` method would be added to a ``Quasi``, s
 This is a breaking change.
 
 Adding the ``qRunQ`` method is crucial to ensure that users can still give meaningful instances of ``Quasi`` even if it is no longer tightly coupled to the implementation of ``Q``.
-``qRunQ`` is analgous to ``liftIO`` but we have chosen to avoid the term, since a ``runQ`` function with the correct type already existed in the ``template-haskell`` interface, and out of a worry that ``liftQ :: Quasi m => Q a -> m a`` could be confused with ``lift :: Lift a => a -> Q Exp``.
+``qRunQ`` is analgous to ``liftIO`` but we have chosen to avoid the term ``liftQ``, since a ``runQ`` function with the correct type already existed in the ``template-haskell`` interface, and out of a worry that ``liftQ :: Quasi m => Q a -> m a`` could be confused with ``lift :: Lift a => a -> Q Exp``.
 
 If a user gives a definition of ``runQ`` then all other methods except for ``qRecover`` can be implemented by lifting the method from the ``Q`` instance.
 Therefore we would also make all methods of ``Quasi`` except for ``qRunQ`` and ``qRecover`` optional.
@@ -227,9 +226,9 @@ We would make the following changes in ``Language.Haskell.TH.Syntax``::
   qNewName :: String -> m Name
   qNewName nm = qRunQ $ \handlers -> runInIO $ mNewName handlers nm -- we add default methods
   qReport  :: Bool -> String -> m ()
-  qReport severity msg = qRunQ $ \runInIO handlers -> runInIO $ mReport handlers severity msg -- we add default methods
+  qReport severity msg = qRunQ $ \handlers -> mReport handlers severity msg -- we add default methods
   qReify   :: Name -> m Info
-  qReify nm = qRunQ $ \runInIO handlers -> runInIO $ mReify handlers nm -- we add default methods
+  qReify nm = qRunQ $ \handlers -> mReify handlers nm -- we add default methods
   ... and so on
   {-# MINIMAL qRunQ qRecover #-}
 
@@ -256,7 +255,7 @@ To do so we would defined something like this::
     let
       runInIO :: forall x. TcM x -> IO x
       runInIO (IOEnv n) = n env
-    in m runInIO metaHandlersTcM
+    in m (metaHandlersTcM runInIO)
 
   metaHandlersTcM :: (forall a. TcM a -> IO a) -> MetaHandlers
   metaHandlersTcM runInIO = MetaHandlers
@@ -265,7 +264,9 @@ To do so we would defined something like this::
     ...
     }
 
-You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> IO a`` rather than ``IO a -> IO a -> IO a``. This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers TcM``, but we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
+You might have noticed above that ``mRecover`` has type ``Q a -> Q a -> IO a`` rather than the simpler ``IO a -> IO a -> IO a``.
+This is because we have access to ``Q a -> TcM a`` when defining ``MetaHandlers`` in the ``lib:ghc``.
+But we do not have access to ``TcM a -> Q a`` when defining the ``qRecover`` instance for ``Quasi`` in ``template-haskell``, since we are not allowed to depend on ``lib:ghc`` there.
 
 We also have to modify the definition of the external interpreter, which simply proxies messages to the compiler. 
 

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -167,9 +167,12 @@ Effect and Interactions
 Costs and Drawbacks
 -------------------
 
-The main cost of this proposal is that it entails a breaking change to the ``template-haskell`` interface.
+* The main cost of this proposal is that it entails a breaking change to the ``template-haskell`` interface.
 The implementation should be relatively simple and if anything it should simplify things as an existential is being replaced with a common-or-garden record.
 
+* At present, ``Quasi`` fully enumerates the interface of ``Q``. This allows an end-user to give a full instance of ``Quasi`` for their own concrete monad, ``TestQ``, and use it for mocking their code that uses ``Q`` via ``runQ``. If this proposal is implemented, this workflow becomes more difficult. A user would then need to import ``MetaHandlers`` and the constructor for ``Q``, which are explicitly unstable interfaces. Note that in both cases a full implementation would require being able to run ``IO`` actions in ``TestQ`` as ``MonadIO`` is a superclass of ``Quasi``, and the new definition of ``Q`` contains ``IO``. This cost is fundamental to proposal as it is about moving the details of the implementation of ``Q`` out of the ``template-haskell`` interface.
+
+* We do not propose a wide ranging overhaul of the ``Q`` interface in this proposal. Although this proposal does make a complete redesign less painful and easier to do incrementally and with minimal breakge. It is our hope to work on this in the near future.
 
 Backward Compatibility
 ----------------------

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -25,11 +25,21 @@ the internal interface while keeping the external interface the same.
 We propose splitting the existing single interface into two, with a clear separation between the internal and external interfaces.
 The internal interface would be part of GHC and versioned with it. The external would be able to evolve independently and be implemented in terms of the internal interface.
 
-We propose adding a new ``MetaHandlers`` record type of actions as this purely internal interface.
+This will be implemented by adding a new ``MetaHandlers`` record type of actions as this purely internal interface.
 ``Q`` is to be changed into an abstract newtype over ``MetaHandlers -> IO a``. ``Quasi`` and ``Quote`` are to be implemented in terms of it.
 
 The existing interface of ``template-haskell`` exposes a top-level ``runQ :: Quasi m => Q a -> m a`` function.
 This would no longer be possible to implement with the new definition of ``Q``. So, we also propose adding a corresponding method to ``Quasi``.
+
+In order to hide the implementation details, we propose hiding the ``Q`` (value) constructor and adding a backwards compatible ``unQ`` pattern synonym.
+
+As such, the change from this proposal is very small. We alter the interface of ``Language.Haskell.TH.Syntax``:
+
+* remove ``Q`` constructor
+* add new ``qRunQ :: Quasi m => Q a -> m a`` method to the ``Quasi`` typeclass.
+
+The rest of this proposal is about the detailed explanation for why we want to do that and how the implementation details for these choices.
+
 
 Motivation
 ----------

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -92,6 +92,8 @@ to::
  -- and only re-exported from template-haskell.
  -- It is still known key.
  newtype Q a -- Q is abstract or opaque
+ -- bundlend pattern synonym for backwards compatibility
+ pattern unQ :: Q a -> forall m. Quasi m => m a
 
  -- Note: Quasi is now defined in template-haskell. It is no longer known key.
 
@@ -139,6 +141,8 @@ Backward Compatibility
 ----------------------
 
 While this is a breaking change to ``template-haskell``, this interface breaks regularly anyway. For instance, GHC-10 will include a new method in the ``Quasi`` typeclass, which would have a similar level of breakage. Implementing this change will protect users from future frequent breakages.
+
+Despite this, we've tried to maximise backwards compatibility by adding an ``unQ`` pattern synonym to the interface.
 
 
 Implementation Plan

--- a/proposals/0000-abstract-q.rst
+++ b/proposals/0000-abstract-q.rst
@@ -31,7 +31,7 @@ This will be implemented by adding a new ``MetaHandlers`` record type of actions
 The existing interface of ``template-haskell`` exposes a top-level ``runQ :: Quasi m => Q a -> m a`` function.
 This would no longer be possible to implement with the new definition of ``Q``. So, we also propose adding a corresponding method to ``Quasi``.
 
-In order to hide the implementation details, we propose hiding the ``Q`` (value) constructor and adding a backwards compatible ``unQ`` pattern synonym.
+In order to hide the implementation details, we propose hiding the ``Q`` (value) constructor and adding a backwards compatible ``unQ`` function.
 
 As such, the change from this proposal is very small. We alter the interface of ``Language.Haskell.TH.Syntax``:
 
@@ -102,8 +102,8 @@ to::
  -- and only re-exported from template-haskell.
  -- It is still known key.
  newtype Q a -- Q is abstract or opaque
- -- bundled pattern synonym for backwards compatibility
- pattern unQ :: Q a -> forall m. Quasi m => m a
+ -- backwards compatibility function to shim over the removed record selector
+ unQ :: Q a -> forall m. Quasi m => m a
 
  -- Note: Quasi is now defined in template-haskell. It is no longer known key.
 
@@ -152,7 +152,7 @@ Backward Compatibility
 
 While this is a breaking change to ``template-haskell``, this interface breaks regularly anyway. For instance, GHC-10 will include a new method in the ``Quasi`` typeclass, which would have a similar level of breakage. Implementing this change will protect users from future frequent breakages.
 
-Despite this, we've tried to maximise backwards compatibility by adding an ``unQ`` pattern synonym to the interface.
+Despite this, we've tried to maximise backwards compatibility by adding an ``unQ`` function to the interface.
 
 The following packages on Hackage will be impacted as they give custom instances of ``Quasi``:
 


### PR DESCRIPTION
The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0700-abstract-q.rst) has been accepted; the following discussion is mostly of historic interest.

---

We propose hiding the implementation of the `Q` monad. This allows an internal only interface to be split out of `Quasi`. This enables the internal interface to evolve independently of `Quasi`, the external interface.