### PR TITLE
581: Wildcard specification

### DIFF
--- a/proposals/0581-namespace-specified-imports.rst
+++ b/proposals/0581-namespace-specified-imports.rst
@@ -209,8 +209,18 @@ namespace.  It is an error to use a namespace specifier if the identifier is not
 in scope in the given namespace.
 
 Moreover, a namespace specifier may be followed by a ``..`` wildcard instead of
-a single name. This is equivalent to importing or exporting all the available
-names in the corresponding namespace.
+a single name. A wildcard item ``type ..`` or ``data ..`` expands to a set of
+names as follows:
+
+- If the wildcard is a subordinate import/export item: all associated child
+  names (data constructors, field selectors, class methods, associated types),
+  filtered by the namespace specifier.
+
+- If the wildcard is a top-level import item: all names exported by the
+  imported module, filtered by the namespace specifier.
+
+- If the wildcard is a top-level export item: all names defined in the
+  current module, filtered by the namespace specifier.
 
 More precisely, the existing grammar of import/export items accepted by GHC is
 essentially the following (after some minor simplifications): ::


### PR DESCRIPTION
Consider this example

```haskell
module M (type ..) where

import Data.Monoid

data T = MkT
data D = MkD
```

The question is:

* Should the `type ..` export re-export all type names from `Data.Monoid`, i.e. `All`, `Alt`, `Any`, `Ap`, `Dual`, `Endo`, `First`, `Last`, `Monoid`, `Product`, `Semigroup`, `Sum`? As well as all type names from `Prelude`?

* Or just the locally defined `T`, `D`?

I believe exporting only the locally defined type names makes more practical sense, and it is also the result you get if you write

```haskell
module M (module M) where

import Data.Monoid

data T = MkT
```

However, the proposal is currently uses the phrase "all the available names in the corresponding namespace", and it is not clear whether imported names are considered "available" for the purposes of a wildcard export.

This amendment offers a more detailed specification for wildcards, and uses the phrase "all names defined in the current module, filtered by the namespace specifier". In the above example, this means `type ..` exports `T` and `D` only.

cc @adamgundry as the lead author of the proposal.