### PR TITLE
Fix: fix format at the table in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,8 @@ In brief all stages of the Reviewing process are shown in the table.
 |                              |                             | 1 week         | | Shepherd /         | Merge                     |                         |
 |                              |                             |                | | Secretary          |                           |                         |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
-| |st-implementation|          | |lbl-accepted| (PR closed)  | Indefinite     | Unspecified          | Implement the proposal    | *Implemented*           |
+| |st-implementation|          | | |lbl-accepted|            | Indefinite     | Unspecified          | Implement the proposal    | *Implemented*           |
+|                              | | (PR closed)               |                |                      |                           |                         |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
 | |st-implemented|_            | |lbl-implemented|           | (PR closed)    | ‒                    | ‒                         | ‒                       |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
@@ -392,7 +393,8 @@ in your branch. For instance,
     Types](http://research.microsoft.com/en-us/um/people/simonpj/papers/haskell-dynamic/index.htm)
     (Peyton Jones, _et al._ 2016).
 
-    [Rendered](https://github.com/bgamari/ghc-proposals/blob/typeable/proposals/0000-type-indexed-typeable.rst)
+    [Rendered\
+    ](https://github.com/bgamari/ghc-proposals/blob/typeable/proposals/0000-type-indexed-typeable.rst)
 
 
 How to amend an accepted proposal

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ In brief all stages of the Reviewing process are shown in the table.
 |                              |                             |                |                      +---------------------------+-------------------------+
 |                              |                             |                |                      | Close request             | *Withdrawn*             |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
-| |st-withdrawn|_              | ‒ (|lbl-withdrawn|)         | (PR closed)    | ‒                    | ‒                         | ‒                       |
+| |st-withdrawn|_              | ‒ (|lbl-withdrawn|)         | ‒              | (PR closed)          | ‒                         | ‒                       |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
 | |st-shepherd-appointment|    | ‒                           | 1 week         | Secretary            | Assign shepherd           | Shepherd review         |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
@@ -103,7 +103,7 @@ In brief all stages of the Reviewing process are shown in the table.
 |                              |                             |                |                      +---------------------------+-------------------------+
 |                              |                             |                |                      | Close request             | *Withdrawn*             |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
-| |st-rejected|_               | |lbl-rejected|              | (PR closed)    | ‒                    | ‒                         | ‒                       |
+| |st-rejected|_               | |lbl-rejected|              | ‒              | (PR closed)          | ‒                         | ‒                       |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
 | |st-accepted|                | |lbl-accepted-open|         | 2 weeks        | | Author &           | Do final corrections      | Implementation          |
 |                              |                             |                | | Shepherd           |                           |                         |
@@ -114,7 +114,7 @@ In brief all stages of the Reviewing process are shown in the table.
 | |st-implementation|          | | |lbl-accepted|            | Indefinite     | Unspecified          | Implement the proposal    | *Implemented*           |
 |                              | | (PR closed)               |                |                      |                           |                         |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
-| |st-implemented|_            | |lbl-implemented|           | (PR closed)    | ‒                    | ‒                         | ‒                       |
+| |st-implemented|_            | |lbl-implemented|           | ‒              | (PR closed)          | ‒                         | ‒                       |
 +------------------------------+-----------------------------+----------------+----------------------+---------------------------+-------------------------+
 
 .. _st-withdrawn: #withdrawn


### PR DESCRIPTION
Not a Proposal, but a style fixing.
It looks like the maximum width view of README file is different at 
- https://github.com/ghc-proposals/ghc-proposals
- https://github.com/ghc-proposals/ghc-proposals/blob/master/README.rst

This Pull Request fix splitting "(PR closed)" into 2 lines in the table at the main Repository page.

Also this PR removes horizontal scroll in md-comment example.