### PR TITLE
Amend #669 to categorize more language extensions (under review)

### DIFF
--- a/proposals/0669-extension-categorization.md
+++ b/proposals/0669-extension-categorization.md
@@ -172,7 +172,7 @@ The following table contains the language extension, the proposed categorization
 | Arrows                 | Experimental   | Stable                  |
 | DuplicateRecordFields  | Experimental   | Stable                  |
 | ExtendedLiterals       | Experimental   | Stable                  |
-| FieldSelectors         | Experimental   | Stable                  |
+| FieldSelectors         | Stable         | Experimental            |
 | GHCForeignImportPrim   | Experimental   | Stable                  |
 | ImpredicativeTypes     | Experimental   | Stable                  |
 | JavaScriptFFI          | Experimental   | Stable                  |

--- a/proposals/0669-extension-categorization.md
+++ b/proposals/0669-extension-categorization.md
@@ -61,6 +61,7 @@ The following table contains the language extension, the proposed categorization
 | FlexibleInstances          | Stable         | Stable                  |
 | ForeignFunctionInterface   | Stable         | Stable                  |
 | GADTSyntax                 | Stable         | Stable                  |
+| GADTs                      | Stable         | Stable                  |
 | GeneralizedNewtypeDeriving | Stable         | Stable                  |
 | HexFloatLiterals           | Stable         | Stable                  |
 | ImplicitParams             | Stable         | Stable                  |
@@ -81,6 +82,8 @@ The following table contains the language extension, the proposed categorization
 | NumDecimals                | Stable         | Stable                  |
 | NumericUnderscores         | Stable         | Stable                  |
 | OverloadedLabels           | Stable         | Stable                  |
+| OverloadedRecordDot        | Stable         | Stable                  |
+| OverloadedStrings          | Stable         | Stable                  |
 | ParallelListComp           | Stable         | Stable                  |
 | PatternGuards              | Stable         | Stable                  |
 | PatternSynonyms            | Stable         | Stable                  |
@@ -95,12 +98,16 @@ The following table contains the language extension, the proposed categorization
 | StandaloneKindSignatures   | Stable         | Stable                  |
 | StrictData                 | Stable         | Stable                  |
 | TraditionalRecordSyntax    | Stable         | Stable                  |
+| TupleSections              | Stable         | Stable                  |
 | TypeApplications           | Stable         | Stable                  |
+| TypeData                   | Stable         | Stable                  |
 | TypeOperators              | Stable         | Stable                  |
 | TypeSynonymInstances       | Stable         | Stable                  |
 | UnboxedSums                | Stable         | Stable                  |
 | UnboxedTuples              | Stable         | Stable                  |
 | UnicodeSyntax              | Stable         | Stable                  |
+| UnliftedDatatypes          | Stable         | Stable                  |
+| UnliftedFFITypes           | Stable         | Stable                  |
 | UnliftedNewtypes           | Stable         | Stable                  |
 
 #### 2.1.2 Deprecated Extensions
@@ -111,13 +118,17 @@ The following are extensions that are to be categorized as `Deprecated` for both
 |-----------------------------------|----------------|-------------------------|
 | AlternativeLayoutRule             | Deprecated     | Deprecated              |
 | AlternativeLayoutRuleTransitional | Deprecated     | Deprecated              |
+| AutoDeriveTypeable                | Deprecated     | Deprecated              |
 | DoRec                             | Deprecated     | Deprecated              |
 | NullaryTypeClasses                | Deprecated     | Deprecated              |
 | OverlappingInstances              | Deprecated     | Deprecated              |
+| PackageImports                    | Deprecated     | Deprecated              |
 | ParallelArrays                    | Deprecated     | Deprecated              |
 | PolymorphicComponents             | Deprecated     | Deprecated              |
 | Rank2Types                        | Deprecated     | Deprecated              |
 | RecordPuns                        | Deprecated     | Deprecated              |
+| RelaxedLayout                     | Deprecated     | Deprecated              |
+| RelaxedPolyRec                    | Deprecated     | Deprecated              |
 | TypeInType                        | Deprecated     | Deprecated              |
 
 In particular it is the flag that is `Deprecated` in both cases for the extensions. The negation of all of these extensions are behaviors as if the positive flag had not been specified, and that behavior is not changed. So while for each extension, the `No*` flag is deprecated, we do not change the behavior of not specifying the positive flag.
@@ -130,7 +141,7 @@ Here we list extensions where the categorization is different based on if the ex
 
 #### 2.2.1 Legacy Extensions
 
-The following are all extensions that are to be categorized as `Legacy` when enabled, and for the `No` version are categorized as `Stable`. As a reminder, the [categorizations](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0601-extension-lifecycle-framework.md#21-categories) state that `Legacy` extensions are not recommended for new code but are expected to be supported indefinitely.
+The following are all extensions that are to be categorized as `Legacy`  when enabled with the `Negative` categorized as `Stable` or when enabled to be categorized as `Stable` and the `Negative` categorized as `Legacy`. As a reminder, the [categorizations](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0601-extension-lifecycle-framework.md#21-categories) state that `Legacy` extensions are not recommended for new code but are expected to be supported indefinitely.
 
 The following table contains the language extension, the proposed categorization for the extension being turned on, and the proposed categorization for the extension being turned off.
 
@@ -139,8 +150,14 @@ The following table contains the language extension, the proposed categorization
 | CUSKs                    | Legacy         | Stable                  |
 | DatatypeContexts         | Legacy         | Stable                  |
 | DeepSubsumption          | Legacy         | Stable                  |
+| DoAndIfThenElse          | Stable         | Legacy                  |
+| IncoherentInstances      | Legacy         | Stable                  |
+| MonoLocalBinds           | Stable         | Legacy                  |
 | NondecreasingIndentation | Legacy         | Stable                  |
 | NPlusKPatterns           | Legacy         | Stable                  |
+| OverloadedLists          | Legacy         | Stable                  |
+| StarIsType               | Legacy         | Stable                  |
+| TransformListComp        | Legacy         | Stable                  |
 
 #### 2.2.2 Experimental Extensions
 
@@ -150,13 +167,25 @@ The following table contains the language extension, the proposed categorization
 
 | Extension              | Categorization | Negative Categorization |
 |------------------------|----------------|-------------------------|
-| GHCForeignImportPrim   | Experimental   | Stable                  |
+| AllowAmbiguousTypes    | Experimental   | Stable                  |
+| ApplicativeDo          | Experimental   | Stable                  |
+| Arrows                 | Experimental   | Stable                  |
+| DuplicateRecordFields  | Experimental   | Stable                  |
 | ExtendedLiterals       | Experimental   | Stable                  |
+| FieldSelectors         | Experimental   | Stable                  |
+| GHCForeignImportPrim   | Experimental   | Stable                  |
 | ImpredicativeTypes     | Experimental   | Stable                  |
 | JavaScriptFFI          | Experimental   | Stable                  |
 | LinearTypes            | Experimental   | Stable                  |
+| ListTuplePuns          | Experimental   | Stable                  |
+| MultilineStrings       | Experimental   | Stable                  |
+| OrPatterns             | Experimental   | Stable                  |
 | OverloadedRecordUpdate | Experimental   | Stable                  |
+| PatternSignatures      | Experimental   | Stable                  |
+| QuantifiedConstraints  | Experimental   | Stable                  |
 | RequiredTypeArguments  | Experimental   | Stable                  |
+| StaticPointers         | Experimental   | Stable                  |
+| Strict                 | Experimental   | Stable                  |
 | TypeAbstractions       | Experimental   | Stable                  |
 
 ### 2.3 Uncategorized Extensions
@@ -165,49 +194,22 @@ The following are the extensions that are uncategorized as of this proposal. The
 
 | Extension               |
 |-------------------------|
-| AllowAmbiguousTypes     |
-| ApplicativeDo           |
-| Arrows                  |
-| AutoDeriveTypeable      |
-| DoAndIfThenElse         |
-| DuplicateRecordFields   |
 | ExplicitNamespaces      |
-| FieldSelectors          |
 | FunctionalDependencies  |
-| GADTs                   |
-| IncoherentInstances     |
 | LexicalNegation         |
-| ListTuplePuns           |
-| MonoLocalBinds          |
 | NegativeLiterals        |
-| OverloadedLists         |
-| OverloadedRecordDot     |
-| OverloadedStrings       |
-| PackageImports          |
 | PartialTypeSignatures   |
-| PatternSignatures       |
-| QuantifiedConstraints   |
 | QuasiQuotes             |
 | RebindableSyntax        |
-| RelaxedLayout           |
-| RelaxedPolyRec          |
 | Safe                    |
 | ScopedTypeVariables     |
-| StarIsType              |
-| StaticPointers          |
-| Strict                  |
 | TemplateHaskell         |
 | TemplateHaskellQuotes   |
-| TransformListComp       |
 | Trustworthy             |
-| TupleSections           |
-| TypeData                |
 | TypeFamilies            |
 | TypeFamilyDependencies  |
 | UndecidableInstances    |
 | UndecidableSuperClasses |
-| UnliftedDatatypes       |
-| UnliftedFFITypes        |
 | Unsafe                  |
 | ViewPatterns            |
 

--- a/proposals/0669-extension-categorization.md
+++ b/proposals/0669-extension-categorization.md
@@ -151,7 +151,6 @@ The following table contains the language extension, the proposed categorization
 | DatatypeContexts         | Legacy         | Stable                  |
 | DeepSubsumption          | Legacy         | Stable                  |
 | DoAndIfThenElse          | Stable         | Legacy                  |
-| IncoherentInstances      | Legacy         | Stable                  |
 | MonoLocalBinds           | Stable         | Legacy                  |
 | NondecreasingIndentation | Legacy         | Stable                  |
 | NPlusKPatterns           | Legacy         | Stable                  |
@@ -175,6 +174,7 @@ The following table contains the language extension, the proposed categorization
 | FieldSelectors         | Stable         | Experimental            |
 | GHCForeignImportPrim   | Experimental   | Stable                  |
 | ImpredicativeTypes     | Experimental   | Stable                  |
+| IncoherentInstances    | Experimental   | Stable                  |
 | JavaScriptFFI          | Experimental   | Stable                  |
 | LinearTypes            | Experimental   | Stable                  |
 | ListTuplePuns          | Experimental   | Stable                  |

--- a/proposals/0669-extension-categorization.md
+++ b/proposals/0669-extension-categorization.md
@@ -98,6 +98,7 @@ The following table contains the language extension, the proposed categorization
 | StandaloneKindSignatures   | Stable         | Stable                  |
 | StrictData                 | Stable         | Stable                  |
 | TraditionalRecordSyntax    | Stable         | Stable                  |
+| TransformListComp          | Stable         | Stable                  |
 | TupleSections              | Stable         | Stable                  |
 | TypeApplications           | Stable         | Stable                  |
 | TypeData                   | Stable         | Stable                  |
@@ -124,6 +125,7 @@ The following are extensions that are to be categorized as `Deprecated` for both
 | OverlappingInstances              | Deprecated     | Deprecated              |
 | PackageImports                    | Deprecated     | Deprecated              |
 | ParallelArrays                    | Deprecated     | Deprecated              |
+| PatternSignatures                 | Deprecated     | Deprecated              |
 | PolymorphicComponents             | Deprecated     | Deprecated              |
 | Rank2Types                        | Deprecated     | Deprecated              |
 | RecordPuns                        | Deprecated     | Deprecated              |
@@ -156,7 +158,7 @@ The following table contains the language extension, the proposed categorization
 | NPlusKPatterns           | Legacy         | Stable                  |
 | OverloadedLists          | Legacy         | Stable                  |
 | StarIsType               | Legacy         | Stable                  |
-| TransformListComp        | Legacy         | Stable                  |
+
 
 #### 2.2.2 Experimental Extensions
 
@@ -177,11 +179,10 @@ The following table contains the language extension, the proposed categorization
 | IncoherentInstances    | Experimental   | Stable                  |
 | JavaScriptFFI          | Experimental   | Stable                  |
 | LinearTypes            | Experimental   | Stable                  |
-| ListTuplePuns          | Experimental   | Stable                  |
+| ListTuplePuns          | Stable         | Experimental            |
 | MultilineStrings       | Experimental   | Stable                  |
 | OrPatterns             | Experimental   | Stable                  |
 | OverloadedRecordUpdate | Experimental   | Stable                  |
-| PatternSignatures      | Experimental   | Stable                  |
 | QuantifiedConstraints  | Experimental   | Stable                  |
 | RequiredTypeArguments  | Experimental   | Stable                  |
 | StaticPointers         | Experimental   | Stable                  |


### PR DESCRIPTION
This is an amendment to proposal #669. Many more language extensions are categorized. In an effort
to not muddy the existing categorization document, I have included below sections for the extensions
including a short reason for them. There are a few large "buckets" of reasons that most, but not all, fit into:

1. There is an accepted proposal, not marked as implemented yet, that includes changes to the
   extension.
2. @adamgundry categorized it as such in his previous [pass](https://docs.google.com/spreadsheets/d/1sRIcNKdflX2ogrx2EF3vKOn0vmv-UEOdladBqtYXdaw/edit?pli=1&gid=0#gid=0)
   These are all marked with "Per categorization by Adam" in the tables below.
3. Direct conversations with a GHC developer, at Zurihac 2025, part of Stability Working Group,
   pre-review on this proposal or elsewhere, suggested it.
   These are all marked with "Recommended in direct conversations" in the tables below.
4. The extension is still "young" which is measured by having less than 3 major Stackage LTS
   releases where it is available. That is a very rough proxy for seeing how much of broader,
   potentially much slower moving parts of the community have had any time to be impacted. As of
   this writing this means that anything introduced after GHC 9.6 is "young".
5. The extension is always on and cannot be disabled.

# Additions

N.B. Negative Categorization is for categorizing the 'No' prefix version. For example, we want to say `DoAndIfThenElse` is `Stable` and `NoAndIfThenElse` is `Legacy`.

## Additions to Stable

| Extension           | Categorization | Negative Categorization |
|---------------------|----------------|-------------------------|
| GADTs               | Stable         | Stable                  | 
| OverloadedRecordDot | Stable         | Stable                  |
| OverloadedStrings   | Stable         | Stable                  | 
| TransformListComp   | Stable         | Stable                  | 
| TupleSections       | Stable         | Stable                  | 
| TypeData            | Stable         | Stable                  | 
| UnliftedDatatypes   | Stable         | Stable                  | 
| UnliftedFFITypes    | Stable         | Stable                  | 

## Additions to Deprecated

| Extension          | Categorization | Negative Categorization | Reason                                                                                           |
|--------------------|----------------|-------------------------|--------------------------------------------------------------------------------------------------|
| AutoDeriveTypeable | Deprecated     | Deprecated              | Always on, cannot turn off                                                                       |
| PackageImports     | Deprecated     | Deprecated              | See [ghc issue](https://gitlab.haskell.org/ghc/ghc/-/issues/24227#note_572977)                                                              |
| PatternSignatures     | Deprecated   | Deprecated                  | GHC already reports as deprecated for `ScopedTypeVariables` |
| RelaxedLayout      | Deprecated     | Deprecated              | [Consideration](https://gitlab.haskell.org/ghc/ghc/-/issues/11359) has existed for >10 years on removal |
| RelaxedPolyRec     | Deprecated     | Deprecated              | Always on, cannot turn off                                                                       |

## Additions to Legacy

| Extension           | Categorization | Negative Categorization | Reason                                                           |
|---------------------|----------------|-------------------------|------------------------------------------------------------------|
| DoAndIfThenElse     | Stable         | Legacy                  | Part of Haskell2010+                                              |
| MonoLocalBinds      | Stable         | Legacy                  | Type Inference becomes less predictable when turned off and other Stable extensions, like GADTs are used.                                      |
| OverloadedLists     | Legacy         | Stable                  | Discussions on the PR                              |
| StarIsType          | Legacy         | Stable                  | Scheduled for deprecation in proposal #143 but part of Haskell98 so still needed |

## Additions to Experimental

As a reminder, this is the closest we have to a "default" state for language
extensions. Particularly moving from `experimental` to `stable` is a rather high bar precisely to
provide as much assurance for those marked as `stable` as is realistic. Thus an extension being
`experimental` is not a judgement, rather a recognition of the current state of the extension both
in isolation _and_ in combination with _all_ `stable` extensions.

| Extension             | Categorization | Negative Categorization |
|-----------------------|----------------|-------------------------|
| AllowAmbiguousTypes   | Experimental   | Stable                  |
| ApplicativeDo         | Experimental   | Stable                  | 
| Arrows                | Experimental   | Stable                  |
| DuplicateRecordFields | Experimental   | Stable                  | 
| FieldSelectors        | Stable         | Experimental            | 
| IncoherentInstances   | Experimental   | Stable                  |
| ListTuplePuns         | Stable         | Experimental            |
| MultilineStrings      | Experimental   | Stable                  |
| OrPatterns            | Experimental   | Stable                  |
| QuantifiedConstraints | Experimental   | Stable                  | 
| StaticPointers        | Experimental   | Stable                  | 
| Strict                | Experimental   | Stable                  | 

# Remaining

While the above categorizations are numerous, there remain several extensions that are left to
future discussion. This is done to keep ourselves moving forward by limiting scope, with no principled basis for the remaining set. I expect to have
at least a couple more amendments that follow this one to handle the remaining extensions in keeping
with the idea to limit scope and make forward progress.

| Remaining Uncategorized |
|-------------------------|
| ExplicitNamespaces      |
| FunctionalDependencies  |
| LexicalNegation         |
| NegativeLiterals        |
| PartialTypeSignatures   |
| QuasiQuotes             |
| RebindableSyntax        |
| Safe                    |
| ScopedTypeVariables     |
| TemplateHaskell         |
| TemplateHaskellQuotes   |
| Trustworthy             |
| TypeFamilies            |
| TypeFamilyDependencies  |
| UndecidableInstances    |
| UndecidableSuperClasses |
| Unsafe                  |
| ViewPatterns            |

