### PR TITLE
QualifiedStrings updates

### DIFF
--- a/proposals/0723-qualified-strings.rst
+++ b/proposals/0723-qualified-strings.rst
@@ -176,13 +176,7 @@ Proposed Library Change Specification
 Template Haskell
 ~~~~~~~~~~~~~~~~
 
-We'll add the following constructors instead of modifying the existing ``StringL`` constructor, to maintain backwards compatibility:
-
-::
-
-  data Lit
-    = ...
-    | QualStringL ModName String
+We intentionally avoid adding a "qualified string" constructor to Template Haskell (at least for now), since it's simply syntax sugar that can be represented in Template Haskell as an explicit `appE (varE 'MyMod.fromString) (litE $ stringL "...")`. This is also consistent with MultilineStrings, which doesn't have a TH constructor.
 
 Examples
 --------


### PR DESCRIPTION
**The [proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0723-qualified-strings.rst) has been accepted; the following discussion is mostly of historic interest.**

Some updates after working on the implementation in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14975:
* Remove adding `QualStringL` constructor to TH
    * Qualified strings don't make sense as literals, since they don't have a static type. It's also unnecessary, as TH can just manually expand the `M.fromString "..."` expression.