### PR TITLE
Comma Tuples

### DIFF
--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -1,0 +1,328 @@
+Redundant commas in Comma Qualified lists and tuples
+======================================================
+
+.. author:: Viktor WW
+.. date-accepted::
+.. ticket-url::
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/749>`_.
+.. sectnum::
+.. contents::
+
+This proposal suggests extending the Haskell syntax by adding alternative syntax for lists, tuples and constraint tuples with build support of trailing and leading commas.
+
+This change aims to improve code readability and maintainability by allowing more flexibility in formatting lists, tuples and constraint tuples. 
+
+First of all, particularly important in scenarios involving version control, code reviews, and automated code generation.
+
+
+Motivation
+----------
+
+In many programming languages, including JavaScript, Python, and Rust, trailing commas in lists
+(and other collection types) are a common feature.
+
+This feature provides several benefits:
+
+1. **Improved Diff Quality**: When adding or removing items in a list, having a trailing comma means only the relevant lines are changed in version control systems, 
+reducing the noise in diffs and making reviews easier.
+
+.. code-block:: diff
+
+  --- example.hs	2024-06-10 12:00:00 +0000
+  +++ example.hs	2024-06-10 12:01:00 +0000
+  @@ -2,5 +2,5 @@
+      "apple",
+      "banana",
+  -   "cherry"
+  +   "cherry",
+  +   "peach"
+      ]
+      
+.. code-block:: diff
+
+  --- example.hs	2024-06-10 12:00:00 +0000
+  +++ example.hs	2024-06-10 12:01:00 +0000
+  @@ -2,5 +2,5 @@
+      "apple",
+      "banana",
+      "cherry",
+  +   "peach",
+      ]
+      
+2. **Ease of Code Modification**: Developers can add new elements to the end of a list without having to modify the previous last line, which reduces the likelihood of syntax errors.
+
+3. **Consistency in Formatting**: When generating code automatically or formatting lists in a specific way, leading and trailing commas can simplify the process.
+
+
+History
+~~~~~~~~~~~~
+
+Adding trailing commas (and more rarely leading commas) is a frequently asked feature to add in Haskell.
+
+But this task is highly divisive in the Haskell community.
+
+Original Proposal #87 `ExtraCommas (was: Trailing and leading commas in sub-export lists) <https://github.com/ghc-proposals/ghc-proposals/pull/87>`__ 
+was discussed for several years, and that discussion was so controversial 
+that the author withdrew their own proposal just before the final Acceptation was received (with minor changes).
+
+Unfortunately, redundant commas contradict with ``TupleSection`` (and presumably/conceivable ``ListSections``) extension's notation. This is inconstancy.
+
+This proposal is an attempt to allow redundant commas more universally and consistently.
+
+
+Proposed Change Specification
+-----------------------------
+
+Main idea is: 
+
+1. To forbid redundant commas for existing order-matter structures (lists and tuples, list comprehensions, constraint tuples)
+
+2. To create an alternating/qualified syntax for order-matter structures (lists, tuples, and constraint tuples) that has built support
+for trailing and leading commas.
+
+This proposal introduces the following syntactical changes to Haskell:
+
+1. Add language extension ``CommaQualifiedStructures``
+
+2. **Comma Qualified tuples**: Allow to write ``qualified`` keyword after tuple close bracket `)` in tuples, 
+unboxed-tuples and constraint tuples at terms and types.
+The only difference between qualified and non-qualified lists is:
+
+   - non-qualified tuples don't allow redundant commas, but allow ``TupletSections`` (or presumably allow for constraint tuples)
+   - qualified tuples allow redundant commas, but ignore ``TupletSections``
+
+  ::
+  
+      myTuple1 :: (Int, String, Char)
+      myTuple1 = (1, "2abc", 'd') qualified
+
+      unlftTuple1 = (# 1#, 'x'#, 3.2## #) qualified
+
+3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``qualified`` keyword ::
+
+      mySoloTuple :: (Int) qualified
+	  mySoloTuple  = (5) qualified
+
+4. **Comma Qualified lists**: Allow to write ``qualified`` keyword after list close bracket `]` in lists at terms and types.
+   The only difference between qualified and non-qualified lists is:
+   
+   - non-qualified lists don't allow redundant commas, but allow presumably/conceivable ``ListSections`` extension
+   - qualified lists allow redundant commas, but ignore presumably/conceivable ``ListSections`` extension
+
+   ::
+     
+      myList1 = [1, 2, 3, 4, 5, 6, 7, 8] qualified
+
+5. **Qualified Trailing Commas**: Allow a comma after the last element in qualified lists (expanded, non-enumerations) and tuples/constraint tuples. ::
+
+      myList2 :: [Int]
+      myList2 = [
+                    1, 
+                    2, 
+                    3, 
+                    4, 
+                    5, 
+                    6, 
+                    7, 
+                    8,
+                ] qualified
+
+      instance (GSerialize a, GSerialize b,) qualified => GSerialize (a :+: b) where
+
+      myfun1 :: forall a s. (
+                    C1 a,
+                    C2 a s,
+                    C3 s,
+                ) qualified. =>
+                     (# 
+                       SuperLongType a,
+                       SuperPuperLongType a s,
+                       MegaPuperLongType (Maybe a),
+                     #) qualified
+                     -> Int#
+                     -> Int#
+                     -> Int#
+      myfun1 = ....
+      
+
+6. **Qualified Leading Commas**: Allow a comma after the last element in qualified lists (expanded, non-enumerations) and tuples/constraint tuples. ::
+
+      myTuple2 :: (,Int, String, Char,) qualified
+      myTuple2 = (,1, "2abc", 'd') qualified
+
+      myList3 :: [Int]
+      myList3 = [
+                    , 1
+                    , 2 
+                    , 3 
+                    , 4 
+                    , 5 
+                    , 6 
+                    , 7 
+                    , 8
+                ] qualified
+      
+
+Syntax
+~~~~~~~~~~~~
+	  
+The formal grammar changes for ``CommaQualifiedStructures``:
+
+:: 
+
+    atype := gtycon
+        |    tyvar
+        |    ( ,? type1 , ... , typek ,? ) qualified    (tuple type, k>=1)     -- new
+        |    ( type1 , ... , typek )    (tuple type, k>=2)
+        |    (# ,? type1 , ... , typek ,? #) qualified    (tuple type, k>=1)   -- new
+        |    (# type1 , ... , typek #)    (tuple type, k>=2)
+        |    '[' [,] type1 , ... , typek [,] ']' qualified    (type, k>=1)     -- new
+        |    '[' type ']'	(list type)
+        | ......
+
+    gtycon := qtycon
+        |    () qualified     --(unit type)            -- new
+        |    ()    --(unit type)
+        |    (##) qualified   --(unlifted unit type)   -- new
+        |    (##)    --(unlifted unit type)
+        |    [] qualified     --(list constructor)     -- new
+        |    []    --(list constructor)
+        | ......
+
+
+Proposed Library Change Specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is a fully backwards-compatible syntax extension, so no changes to user libraries are required.
+
+Libraries from the GHC ecosystem may need to be updated to handle the new syntax.
+
+Examples
+--------
+
+1. **Trailing Commas**
+
+   ::
+      numbers = [
+        1,
+        2,
+        3,
+      ] qualified
+   This would be equivalent to:
+
+   ::
+   
+      numbers = [1, 2, 3]
+      
+2. **Leading Commas**
+
+   ::
+      fruits = [
+        , "apple"
+        , "banana"
+        , "cherry"
+      ] qualified
+      
+   This would be equivalent to: ::
+
+      fruits = ["apple", "banana", "cherry"]
+      
+3. **Combined Leading and Trailing Commas**
+
+   ::
+      mixed = [
+        , 1, 2
+        , 3, 4, -- 5
+      ] qualified
+      
+   This would be equivalent to:  ::
+
+      mixed = [1, 2, 3, 4]
+
+Effect and Interactions
+-----------------------
+
+We choose the **postfix variant** ``[x,y,z] qualified`` over **prefix variant** ``qualified [x,y,z]`` to avoid injections 
+for ``Bang Patterns``, ``As Pattern``, ``StrictPattern``,  ``Irrefutable Patterns``, ``Specified(Qualified) Literals`` ::
+
+    -- Bang Patterns
+    let !(,p,q,) qualified = e in body
+    
+    let (!x, ![y,] qualified) = e in body
+
+    -- As Pattern
+    foo1 :: (a, b) -> a
+    foo1 t@(,p,q,) qualified = t
+
+    -- Specified(Qualified) Literals
+    bar2 a b  = M.[a, b,] qualified
+    
+    -- StrictPattern
+    data T = MkT ~(Int, Int, Int,) qualified
+    
+    -- Irrefutable Patterns
+    let ~[a,b,] qualified = expr in e0 a b
+
+Tuple Section
+~~~~~~~~~~~~~~~~~~
+
+Both ``TupleSection`` extension and presumable/conceivable ``ListSection`` extension
+are fully consistent and compatible with ``CommaQualifiedStructures``
+
+
+Costs and Drawbacks
+-------------------
+
+We expect the implementation and maintenance costs of ``CommaQualifiedStructures`` has medium difficulty.
+
+
+Backward Compatibility
+---------------------------------
+
+This change is backward compatible with existing Haskell code,
+as it introduces new syntactical permissiveness without altering the existing valid syntax.
+All current Haskell programs will remain valid and unchanged in their behavior.
+
+Alternatives
+------------
+
+The primary alternative is "status quo".
+
+Alternative Syntax
+~~~~~~~~~~~~~~~~~~
+
+Alternative to ``(x, y, z) qualified`` and ``[x, y, z] qualified`` syntax we could choose alternative syntax,
+like ``q(x, y, z)`` and ``q[x, y, z]`` or ``%(x, y, z)`` and ``%[x, y, z]``.
+
+
+Unresolved Questions
+--------------------
+
+Since the length of the ``qualified`` keyword is long it is better to have some Unicode ``Char`` equivalent in ``UnicodeSyntax``.
+
+But is unclear what to choose.
+
+
+Implementation Plan
+-------------------
+
+It is unclear.
+
+
+Acknowledgments
+----------------
+
+Thanks to all contributors of `ExtraCommas (was: Trailing and leading commas in sub-export lists) 
+<https://github.com/ghc-proposals/ghc-proposals/pull/87>`__.
+
+Thanks to all contributors of `Add Support for Trailing and Leading Commas in Lists 
+<https://github.com/ghc-proposals/ghc-proposals/pull/658>`__.
+
+Thanks to all contributors of `Allow Trailing Comma in List Constructor Syntaxs 
+<https://github.com/ghc-proposals/ghc-proposals/issues/653>`__.
+
+
+Endorsements
+-------------

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -26,7 +26,7 @@ In many programming languages, including JavaScript, Python, and Rust, trailing 
 This feature provides several benefits:
 
 1. **Improved Diff Quality**: When adding or removing items in a list, having a trailing comma means only the relevant lines are changed in version control systems, 
-reducing the noise in diffs and making reviews easier.
+   reducing the noise in diffs and making reviews easier.
 
 .. code-block:: diff
 
@@ -80,30 +80,30 @@ Main idea is:
 1. To forbid redundant commas for existing order-matter structures (lists and tuples, list comprehensions, constraint tuples)
 
 2. To create an alternating/qualified syntax for order-matter structures (lists, tuples, and constraint tuples) that has built support
-for trailing and leading commas.
+   for trailing and leading commas.
 
 This proposal introduces the following syntactical changes to Haskell:
 
 1. Add language extension ``CommaQualifiedStructures``
 
 2. **Comma Qualified tuples**: Allow to write ``qualified`` keyword after tuple close bracket `)` in tuples, 
-unboxed-tuples and constraint tuples at terms and types.
-The only difference between qualified and non-qualified lists is:
+   unboxed-tuples and constraint tuples at terms and types.
+
+   The only difference between qualified and non-qualified lists is:
 
    - non-qualified tuples don't allow redundant commas, but allow ``TupletSections`` (or presumably allow for constraint tuples)
    - qualified tuples allow redundant commas, but ignore ``TupletSections``
-
-  ::
+     ::
   
-      myTuple1 :: (Int, String, Char)
-      myTuple1 = (1, "2abc", 'd') qualified
+       myTuple1 :: (Int, String, Char)
+       myTuple1 = (1, "2abc", 'd') qualified
 
-      unlftTuple1 = (# 1#, 'x'#, 3.2## #) qualified
+       unlftTuple1 = (# 1#, 'x'#, 3.2## #) qualified
 
 3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``qualified`` keyword ::
 
-      mySoloTuple :: (Int) qualified
-	  mySoloTuple  = (5) qualified
+       mySoloTuple :: (Int) qualified
+       mySoloTuple  = (5) qualified
 
 4. **Comma Qualified lists**: Allow to write ``qualified`` keyword after list close bracket `]` in lists at terms and types.
    The only difference between qualified and non-qualified lists is:
@@ -174,21 +174,21 @@ The formal grammar changes for ``CommaQualifiedStructures``:
 
     atype := gtycon
         |    tyvar
-        |    ( ,? type1 , ... , typek ,? ) qualified    (tuple type, k>=1)     -- new
-        |    ( type1 , ... , typek )    (tuple type, k>=2)
-        |    (# ,? type1 , ... , typek ,? #) qualified    (tuple type, k>=1)   -- new
-        |    (# type1 , ... , typek #)    (tuple type, k>=2)
-        |    '[' [,] type1 , ... , typek [,] ']' qualified    (type, k>=1)     -- new
-        |    '[' type ']'	(list type)
+        |    ( ,? type1 , ... , typek ,? ) qualified    (tuple type, k>=1)    -- new
+        |    ( type1 , ... , typek )                    (tuple type, k>=2)
+        |    (# ,? type1 , ... , typek ,? #) qualified  (tuple type, k>=1)    -- new
+        |    (# type1 , ... , typek #)                  (tuple type, k>=2)
+        |    '[' [,] type1 , ... , typek [,] ']' qualified   (type, k>=1)     -- new
+        |    '[' type ']'	                                 (list type)
         | ......
 
     gtycon := qtycon
         |    () qualified     --(unit type)            -- new
-        |    ()    --(unit type)
+        |    ()               --(unit type)
         |    (##) qualified   --(unlifted unit type)   -- new
-        |    (##)    --(unlifted unit type)
+        |    (##)             --(unlifted unit type)
         |    [] qualified     --(list constructor)     -- new
-        |    []    --(list constructor)
+        |    []               --(list constructor)
         | ......
 
 
@@ -204,12 +204,14 @@ Examples
 
 1. **Trailing Commas**
 
-   ::
+   List with trailing comma::
+
       numbers = [
         1,
         2,
         3,
       ] qualified
+
    This would be equivalent to:
 
    ::
@@ -218,7 +220,8 @@ Examples
       
 2. **Leading Commas**
 
-   ::
+   List with leading comma::
+
       fruits = [
         , "apple"
         , "banana"
@@ -231,7 +234,8 @@ Examples
       
 3. **Combined Leading and Trailing Commas**
 
-   ::
+   List with mix of leading and trailing commas::
+
       mixed = [
         , 1, 2
         , 3, 4, -- 5
@@ -245,7 +249,7 @@ Effect and Interactions
 -----------------------
 
 We choose the **postfix variant** ``[x,y,z] qualified`` over **prefix variant** ``qualified [x,y,z]`` to avoid injections 
-for ``Bang Patterns``, ``As Pattern``, ``StrictPattern``,  ``Irrefutable Patterns``, ``Specified(Qualified) Literals`` ::
+for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns``, ``Specified(Qualified)Literals`` ::
 
     -- Bang Patterns
     let !(,p,q,) qualified = e in body
@@ -269,7 +273,7 @@ Tuple Section
 ~~~~~~~~~~~~~~~~~~
 
 Both ``TupleSection`` extension and presumable/conceivable ``ListSection`` extension
-are fully consistent and compatible with ``CommaQualifiedStructures``
+are fully consistent and compatible with ``CommaQualifiedStructures``.
 
 
 Costs and Drawbacks
@@ -283,6 +287,7 @@ Backward Compatibility
 
 This change is backward compatible with existing Haskell code,
 as it introduces new syntactical permissiveness without altering the existing valid syntax.
+
 All current Haskell programs will remain valid and unchanged in their behavior.
 
 Alternatives

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -1,4 +1,4 @@
-Data Tuples
+Comma Tuples
 ============
 
 .. author:: Viktor WW
@@ -14,7 +14,7 @@ This proposal suggests extending the Haskell syntax by adding alternative syntax
 for tuple-like structures with build support of trailing and leading commas.
 
 This change aims to improve code readability and maintainability by allowing more flexibility 
-in formatting boxed and unboxed tuples, constraint tuples and class context. 
+in formatting boxed and unboxed tuples, constraint tuples and class context simplified and not. 
 
 First of all, particularly important in scenarios involving version control, code reviews, and automated code generation.
 
@@ -77,18 +77,23 @@ that has built support for trailing and leading commas and are not affected by `
 
 This proposal introduces the following syntactical changes to Haskell:
 
-1. Add language extension ``DataTuples``
+1. Add language extension ``CommaTuples``
 
-2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = DataTuples + ExtraNonTupleCommas``
+2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = CommaTuples + ExtraNonTupleCommas``
 
-3. **Comma Qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
+3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
    unboxed-tuples, constraint tuples and class context at terms and types.
 
-   The only difference between ``data``-qualified and ordinary tuples is:
-
-   - ordinary tuples don't allow extra commas, but allow tupling constructors and ``TupletSections`` (if values are not Constraint kind)
+   Comma qualified tuples by meaning are indistinguishable from ordinary tuples, but they are different in syntax.
    
-   - ``data``-qualified tuples allow extra commas, but ignore ``TupletSections``
+   Tuple ``(a, b, c)`` is the same as ``(, a, b, c,) data`` in types or class context;
+   and ``(x, y, z)`` is the same as ``(, x, y, z,) data`` in terms. 
+
+   The only difference between comma-qualified and ordinary tuples is:
+
+   - ordinary tuples don't allow extra commas, but allow curried tupling constructors and ``TupletSections`` (if values are not Constraint kind)
+   
+   - comma-qualified tuples allow extra commas, but ignore ``TupletSections``
    
      - Allow a comma before the first element after opening bracket ``(`` or ``(#``
 	
@@ -116,7 +121,7 @@ This proposal introduces the following syntactical changes to Haskell:
 Syntax
 ~~~~~~~~~~~~
 	  
-The formal grammar changes for ``DataTuples``:
+The formal grammar changes for ``CommaTuples``:
 
 Syntax for tuples, unboxed tuples, constraint tuples:
 
@@ -174,7 +179,7 @@ Syntax for class content and class simplified content:
     simpletype  := tycon tyvar1 … tyvark                         (k ≥ 0)
 
 
-These changes allow extra commas in the all tuple-like structures:
+These changes allow extra commas in the all comma-tuple-like structures:
 
 - tuples
 - unboxed tuples
@@ -183,6 +188,22 @@ These changes allow extra commas in the all tuple-like structures:
 - class simplified content
 
 This proposal does not cover multi-tupling constructors for obvious reasons.
+
+
+Proposed Library Change Specification
+-------------------------------------
+
+The core library ``base`` must be changed.
+
+First of all must be updated ``Read a`` instances 
+for supporting reading comma qualified tuples.
+
+Second, we update ``Data.Tuple`` to:
+::
+
+    data Solo a = (a) data
+	
+    pattern MkSolo a = (a) data
 
 
 Examples
@@ -203,7 +224,7 @@ Examples
 
 
       
-2. Mix of data-tuples
+2. Mix of comma-tuples and ordinary tuples
 
    Unboxed tupleles, class context ::
 
@@ -230,7 +251,7 @@ Examples
 Effect and Interactions
 -----------------------
 
-We choose the **postfix variant** ``(x,y,z) data`` over **prefix variant** ``data [x,y,z]`` to avoid injections 
+We choose the **postfix variant** ``(x,y,z) data`` over **prefix variant** ``data (x,y,z)`` to avoid injections 
 for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns``, data declaration ::
 
     -- Bang Patterns
@@ -243,24 +264,24 @@ for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns`
     foo1 t@(,p,q,) data = t
    
     -- StrictPattern
-    data T = MkT ~(Int, Int, Int,) data
+    data T = MkT ~(,Int, Int, Int,) data
     
     -- Irrefutable Patterns
     let ~(a,b,) data = expr in e0 a b
 
     -- Data declaration	vs function declaration
-	(a1, b1) data `op` (a2, b2) data = expr
+	(a1, b1,) data `op` (a2, b2,) data = expr
 
 Tuple Section
 ~~~~~~~~~~~~~~~~~~
 
-``TupleSection`` extension do not interact with alternative syntax of data tuples.
+``TupleSection`` extension do not interact with alternative syntax of comma-tuples.
 
 
 Costs and Drawbacks
 -------------------
 
-We expect the implementation and maintenance costs of ``DataTuples`` has medium difficulty.
+We expect the implementation and maintenance costs of ``CommaTuples`` has medium difficulty.
 
 
 Backward Compatibility
@@ -304,9 +325,9 @@ Or alternative keywords could be chosen insted of ``data``, like ``qualified``.
 Alternative Rule for Commas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This proposal has synchronized rules with 748 Proposal:
+This proposal has synchronized rules with ``ExtraNonTupleCommas`` extension:
 
-  We allow Leading Comma AND Trailing Comma (in single Structure) but WITHOUT Repetitive Commas.
+  We allow Leading Comma AND Trailing Comma (in single Structure) but WITHOUT Adjacent Commas.
 
 Alternative to this are different rules, which are different from described one.
 

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -86,7 +86,7 @@ This proposal introduces the following syntactical changes to Haskell:
 
    The only difference between ``data``-qualified and ordinary tuples is:
 
-   - ordinary tuples don't allow extra commas, but allow tupling constructors and ``TupletSections`` (if values are not Constraint king)
+   - ordinary tuples don't allow extra commas, but allow tupling constructors and ``TupletSections`` (if values are not Constraint kind)
    
    - ``data``-qualified tuples allow extra commas, but ignore ``TupletSections``
    
@@ -140,9 +140,9 @@ Syntax for class content and class simplified content:
 .. code:: abnf
 
     topdecl := 'type' simpletype '=' type
-        | 'data' [context '=>'] simpletype ['=' constrs] [deriving]
-        | 'newtype' [context '=>'] simpletype '=' newconstr [deriving]
-        | 'class' [scontext '=>'] tycls tyvar ['where' cdecls]
+        | 'data'     [context '=>'] simpletype ['=' constrs] [deriving]
+        | 'newtype'  [context '=>'] simpletype '=' newconstr [deriving]
+        | 'class'    [scontext '=>'] tycls tyvar ['where' cdecls]
         | 'instance' [scontext '=>'] qtycls inst ['where' idecls]
         | ……
 

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -105,6 +105,26 @@ This proposal introduces the following syntactical changes to Haskell:
 
        unlftTuple1 = (# 1#, 'x'#, 3.2## #) data
 
+       instance (GSerialize a, GSerialize b,) data => GSerialize (a :+: b) where
+
+       myfun1 :: forall a s. (
+                    C1 a,
+                    C2 a s,
+                    C3 s,
+                ) data. =>
+                     (# 
+                       SuperLongType a,
+                       SuperPuperLongType a s,
+                       MegaPuperLongType (Maybe a),
+                     #) data
+                     -> Int#
+                     -> Int#
+                     -> Int#
+       myfun1 = ....
+
+       myTuple3 :: (,Int, String, Char,) data
+       myTuple3 = (,1, "2abc", 'd') data
+
 3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``data`` keyword ::
 
        mySoloTuple :: (Int) data
@@ -132,26 +152,6 @@ This proposal introduces the following syntactical changes to Haskell:
                     8,
                 ] data
 
-      instance (GSerialize a, GSerialize b,) data => GSerialize (a :+: b) where
-
-      myfun1 :: forall a s. (
-                    C1 a,
-                    C2 a s,
-                    C3 s,
-                ) data. =>
-                     (# 
-                       SuperLongType a,
-                       SuperPuperLongType a s,
-                       MegaPuperLongType (Maybe a),
-                     #) data
-                     -> Int#
-                     -> Int#
-                     -> Int#
-      myfun1 = ....
-
-      myTuple3 :: (,Int, String, Char,) data
-      myTuple3 = (,1, "2abc", 'd') data
-
       myList3 :: [Int]
       myList3 = [
                     , 1
@@ -163,8 +163,23 @@ This proposal introduces the following syntactical changes to Haskell:
                     , 7 
                     , 8
                 ] data
-      
-5. **Qualified trailing & leading commas**: 
+
+5. **Comma Qualified records**: Allow to write ``data`` keyword after record close bracket `}` in lists at terms and types.
+   The only difference between qualified and non-qualified lists is:
+   
+   - non-qualified records don't allow extra commas, but allow presumably/conceivable ``RecordSections`` extension
+   - qualified lists allow exra commas, but ignore presumably/conceivable ``RrecordtSections`` extension
+
+   ::
+
+      data instance URec (Ptr ()) p = UAddr   { uAddr#   :: Addr#,    } data
+
+      data instance URec Char     p = UChar   { uChar#   :: Char#,   uInt# :: Int#, } data
+
+      data instance URec Double   p = UDouble { uDouble# :: Double#, uInt# :: Int#, uFloat#  :: Float#, } data
+
+
+6. **Qualified trailing & leading commas**: 
 
    - Allow a comma before the first element in qualified 
      records, lists (expanded, non-enumerations) and tuples/constraint tuples/s-context.
@@ -208,6 +223,12 @@ The formal grammar changes for ``ExtraDataCommas``:
         | ……
         | qcon { [,] fpat1 , … , fpatk [,] } [data]      (labeled pattern, k ≥ 0)   ;-- upd
 
+These changes allow extra commas in the all unordered structures:
+
+- tuples, constraint tuples, s-content
+- list-comprehensions and literal list (expressions and patterns)
+- records in terms and types (declarations, patterns, constructions)
+- nested multi-name signatures in records
 
 Proposed Library Change Specification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,7 +311,7 @@ for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns`
 Tuple Section
 ~~~~~~~~~~~~~~~~~~
 
-Both ``TupleSection`` extension and presumable/conceivable ``ListSection`` extension
+Both ``TupleSection`` extension and presumable/conceivable ``ListSection``, ``RecordSection`` extensions
 are fully consistent and compatible with ``ExtraDataCommas``.
 
 
@@ -319,19 +340,26 @@ Alternative Syntax
 Alternative to ``(x, y, z) data`` and ``[x, y, z] data`` syntax we could choose alternative syntax,
 like ``q(x, y, z)`` and ``q[x, y, z]`` or ``%(x, y, z)`` and ``%[x, y, z]``. Or alternative keywords could be chosen, like ``qualified``.
 
+Alternative Rule for Commas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This proposal has synchronized rules with 748 Proposal:
+
+  We allow Leading Comma AND Trailing Comma (in single Structure) but WITHOUT Repetitive Commas.
+
+Alternative to this are different rules, which are different from described one.
+
 
 Unresolved Questions
 --------------------
 
-Since the length of the ``qualified`` keyword is long it is better to have some Unicode ``Char`` equivalent in ``UnicodeSyntax``.
-
-But is unclear what to choose.
+None.
 
 
 Implementation Plan
 -------------------
 
-It is unclear.
+Unclear. The author cannot implement this proposal.
 
 
 Acknowledgments
@@ -346,6 +374,8 @@ Thanks to all contributors of `Add Support for Trailing and Leading Commas in Li
 Thanks to all contributors of `Allow Trailing Comma in List Constructor Syntaxs 
 <https://github.com/ghc-proposals/ghc-proposals/issues/653>`__.
 
+Thanks to all contributors of `Extra NonTuple Commas 
+<https://github.com/ghc-proposals/ghc-proposals/issues/748>`__.
 
 Endorsements
 -------------

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -1,5 +1,5 @@
-Extra Data Commas
-=====================
+Data Tuples
+============
 
 .. author:: Viktor WW
 .. date-accepted::
@@ -11,10 +11,10 @@ Extra Data Commas
 .. contents::
 
 This proposal suggests extending the Haskell syntax by adding alternative syntax 
-for lists, records, tuples and constraint tuples with build support of trailing and leading commas.
+for tuple-like structures with build support of trailing and leading commas.
 
 This change aims to improve code readability and maintainability by allowing more flexibility 
-in formatting lists, records, tuples and constraint tuples. 
+in formatting boxed and unboxed tuples, constraint tuples and class context. 
 
 First of all, particularly important in scenarios involving version control, code reviews, and automated code generation.
 
@@ -27,8 +27,21 @@ In many programming languages, including JavaScript, Python, and Rust, trailing 
 
 This feature provides several benefits:
 
-1. **Improved Diff Quality**: When adding or removing items in a list, having a trailing comma means only the relevant lines are changed in version control systems, 
-   reducing the noise in diffs and making reviews easier.
+1. **Improved Diff Quality**: When adding or removing items in a tuple structure, having a trailing or leading comma means only
+   the relevant lines are changed, reducing the noise in diffs and making reviews easier.
+  
+2. **Ease of Code Modification**: Developers can add new elements to the end / beginning of a structure without having 
+   to modify the previous last / first line, which reduces the likelihood of syntax errors.
+
+3. **Consistency in Formatting**: When generating code automatically or formatting structures in a specific way, 
+   leading and trailing commas can simplify the process.
+
+4. **Use a different style of coding**: Extra commas allow for different styles to write code.
+
+5. **Simplicity of conditional meta-programming**: Extra commas allow to write much simpler code when conditional meta-programming is used.
+
+
+Now git-diffs often looks like this:
 
 .. code-block:: diff
 
@@ -40,8 +53,10 @@ This feature provides several benefits:
   -   "cherry"
   +   "cherry",
   +   "peach"
-      ]
-      
+      )
+
+but we wish to write insted:
+
 .. code-block:: diff
 
   --- example.hs	2024-06-10 12:00:00 +0000
@@ -51,67 +66,152 @@ This feature provides several benefits:
       "banana",
       "cherry",
   +   "peach",
-      ]
+      ) data
       
-2. **Ease of Code Modification**: Developers can add new elements to the end of a list without having to modify the previous last line, which reduces the likelihood of syntax errors.
-
-3. **Consistency in Formatting**: When generating code automatically or formatting lists in a specific way, leading and trailing commas can simplify the process.
-
-
-History
-~~~~~~~~~~~~
-
-Adding trailing commas (and more rarely leading commas) is a frequently asked feature to add in Haskell.
-
-But this task is highly divisive in the Haskell community.
-
-Original Proposal #87 `ExtraCommas (was: Trailing and leading commas in sub-export lists) <https://github.com/ghc-proposals/ghc-proposals/pull/87>`__ 
-was discussed for several years, and that discussion was so controversial 
-that the author withdrew their own proposal just before the final Acceptation was received (with minor changes).
-
-Unfortunately, redundant commas contradict with ``TupleSection`` (and presumably/conceivable ``ListSections``) extension's notation. This is inconstancy.
-
-This proposal is an attempt to allow redundant commas more universally and consistently.
-
 
 Proposed Change Specification
 -----------------------------
 
-Main idea is: 
-
-1. To forbid redundant commas for existing data structures (records, lists and tuples, list comprehensions, constraint tuples)
-
-2. To create an alternating syntax for data structures (records, lists, tuples, and constraint tuples) that has built support
-   for trailing and leading commas.
+Main idea is:  To create an alternating syntax for tuple-like structures 
+that has built support for trailing and leading commas and are not affected by ``TupleSection`` extension.
 
 This proposal introduces the following syntactical changes to Haskell:
 
-1. Add language extension ``ExtraDataCommas``
+1. Add language extension ``DataTuples``
 
-2. **Comma Qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
-   unboxed-tuples and constraint tuples at terms and types.
+2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = DataTuples + ExtraNonTupleCommas``
 
-   The only difference between qualified and non-qualified lists is:
+3. **Comma Qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
+   unboxed-tuples, constraint tuples and class context at terms and types.
 
-   - non-qualified tuples don't allow extra commas, but allow ``TupletSections`` (or presumably allow for constraint tuples)
-   - qualified tuples allow extra commas, but ignore ``TupletSections``
-     ::
+   The only difference between ``data``-qualified and ordinary tuples is:
+
+   - ordinary tuples don't allow extra commas, but allow tupling constructors and ``TupletSections`` (if values are not Constraint king)
+   
+   - ``data``-qualified tuples allow extra commas, but ignore ``TupletSections``
+   
+     - Allow a comma before the first element after opening bracket ``(`` or ``(#``
+	
+     - Allow a comma after the last element before closing bracket ``)``  or ``#)``
+	
+     - Allow both trailing & leading commas in same structure
+   
+       ::
   
-       myTuple1 :: (Int, String, Char)
-       myTuple1 = (1, "2abc", 'd') data
+         myTuple1 :: (Int, String, Char)
+         myTuple1 = (1, "2abc", 'd') data
 
-       myTuple2 :: (Int, Int, String, Char) data
-       myTuple2 = (42, 43, "xyz", 'w') data
+         myTuple2 :: (, Int, Int, String, Char) data
+         myTuple2 = (42, 43, "xyz", 'w',) data
+
+         myTuple3 :: (,Int, String, Char,) data
+         myTuple3 = (,1, "2abc", 'd') data
+
+4. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``data`` keyword ::
+
+       mySoloTuple :: (Int) data
+       mySoloTuple  = (5) data
+
+
+Syntax
+~~~~~~~~~~~~
+	  
+The formal grammar changes for ``DataTuples``:
+
+.. code:: abnf
+
+    ;-- tuples, unboxed tuples, constraint tuples
+    
+    atype := gtycon
+        | tyvar                                                 ;-- kmax = if 'data' then 1 else 2
+        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']       (tuple type, k>=kmax)  ;-- upd
+        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']  (unboxed tuple type, k>=1)  ;-- upd
+        | ……
+
+    gtycon := qtycon
+        | '(' ')' ['data']        (unit type)           ;-- upd
+        | '(#' '#)' ['data']      (unlifted unit type)  ;-- upd
+        | ……
+
+.. code:: abnf
+
+    ;-- class content
+
+    topdecl := 'type' simpletype '=' type
+        | 'data' [context '=>'] simpletype ['=' constrs] [deriving]
+        | 'newtype' [context '=>'] simpletype '=' newconstr [deriving]
+        | 'class' [scontext '=>'] tycls tyvar ['where' cdecls]
+        | 'instance' [scontext '=>'] qtycls inst ['where' idecls]
+        | ……
+
+    gendecl := vars '::' [context '=>'] type      (type signature)
+        | fixity [integer] ops                (fixity declaration)
+        |                                      (empty declaration)
+
+    exp := infixexp '::' [context '=>'] type   (expression type signature)
+        | infixexp
+
+    context := class
+        | '(' ',' cntclasses [','] ')' 'data'                   ;-- upd
+        | '(' cntclasses ((')' ['data']) | (',' ')' 'data'))    ;-- upd
+
+
+    scontext := simpleclass
+        | '(' ',' scntclasses [','] ')' 'data'                   ;-- upd
+        | '(' scntclasses ((')' ['data']) | (',' ')' 'data'))    ;-- upd
+		
+    cntclasses := class1 ',' … ',' classn               (n ≥ 0)  ;-- upd
+
+    class := qtycls tyvar
+        | qtycls '(' tyvar atype1 … atypen ')'          (n ≥ 1)
+
+    scntclasses := simpleclass1 ',' … ',' simpleclassn  (n ≥ 0)  ;-- upd
+
+    simpleclass := qtycls tyvar
+ 
+    simpletype  := tycon tyvar1 … tyvark                (k ≥ 0)
+
+
+These changes allow extra commas in the all tuple-like structures:
+
+- tuples
+- unboxed tuples
+- constraint tuples
+- class content
+
+This proposal does not cover tupling constructors for obvious reasons.
+
+
+Examples
+--------
+
+1. **Trailing Commas**
+
+   Instance with content with trailing comma::
+
+       instance ( 
+                  GSerialize a, 
+                  GSerialize b,
+                ) data 
+            => 
+                GSerialize (a :+: b) 
+            where
+               ...
+
+
+      
+2. Mix of data-tuples
+
+   Unboxed tupleles, class context ::
 
        unlftTuple1 = (# 1#, 'x'#, 3.2## #) data
 
-       instance (GSerialize a, GSerialize b,) data => GSerialize (a :+: b) where
 
        myfun1 :: forall a s. (
                     C1 a,
                     C2 a s,
                     C3 s,
-                ) data. =>
+                ) data =>
                      (# 
                        SuperLongType a,
                        SuperPuperLongType a s,
@@ -122,203 +222,42 @@ This proposal introduces the following syntactical changes to Haskell:
                      -> Int#
        myfun1 = ....
 
-       myTuple3 :: (,Int, String, Char,) data
-       myTuple3 = (,1, "2abc", 'd') data
-
-3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``data`` keyword ::
-
-       mySoloTuple :: (Int) data
-       mySoloTuple  = (5) data
-
-4. **Comma Qualified lists**: Allow to write ``data`` keyword after list close bracket `]` in lists at terms and types.
-   The only difference between qualified and non-qualified lists is:
-   
-   - non-qualified lists don't allow extra commas, but allow presumably/conceivable ``ListSections`` extension
-   - qualified lists allow exra commas, but ignore presumably/conceivable ``ListSections`` extension
-
-   ::
-     
-      myList1 = [1, 2, 3, 4, 5, 6, 7, 8] data
-
-      myList2 :: [Int]
-      myList2 = [
-                    1, 
-                    2, 
-                    3, 
-                    4, 
-                    5, 
-                    6, 
-                    7, 
-                    8,
-                ] data
-
-      myList3 :: [Int]
-      myList3 = [
-                    , 1
-                    , 2 
-                    , 3 
-                    , 4 
-                    , 5 
-                    , 6 
-                    , 7 
-                    , 8
-                ] data
-
-5. **Comma Qualified records**: Allow to write ``data`` keyword after record close bracket `}` in lists at terms and types.
-   The only difference between qualified and non-qualified lists is:
-   
-   - non-qualified records don't allow extra commas, but allow presumably/conceivable ``RecordSections`` extension
-   - qualified lists allow exra commas, but ignore presumably/conceivable ``RrecordtSections`` extension
-
-   ::
-
-      data instance URec (Ptr ()) p = UAddr   { uAddr#   :: Addr#,    } data
-
-      data instance URec Char     p = UChar   { uChar#   :: Char#,   uInt# :: Int#, } data
-
-      data instance URec Double   p = UDouble { uDouble# :: Double#, uInt# :: Int#, uFloat#  :: Float#, } data
-
-
-6. **Qualified trailing & leading commas**: 
-
-   - Allow a comma before the first element in qualified 
-     records, lists (expanded, non-enumerations) and tuples/constraint tuples/s-context.
-
-   - Allow a comma after the last element in qualified 
-     records, lists (expanded, non-enumerations) and tuples/constraint tuples/s-context.
-
-   - Allow both trailing & leading commas in  same qualified structure
-
-
-Syntax
-~~~~~~~~~~~~
-	  
-The formal grammar changes for ``ExtraDataCommas``:
-
-.. code:: abnf
-
-    atype := gtycon
-        | tyvar
-        | ( [,] type1 , … , typek [,] ) [data]       (tuple type, k>=1)    --; upd
-        | (# [,] type1 , … , typek [,] #) [data]     (tuple type, k>=1)    --; upd
-        | '[' [,] type1 , … , typek [,] ']' [data]         (type, k>=1)    --; upd
-        | '[' type ']'	                                    (list type)
-        | qcon { [,] fbind1 , … , fbindn [,] } [data]         (labeled construction, n ≥ 0)   ;-- upd
-        | aexp_(qcon) { [,] fbind1 , … , fbindn [,] } [data]  (labeled update, n  ≥  1)       ;-- upd
-        | ……
-
-    gtycon := qtycon
-        | () [data]        (unit type)            --; upd
-        | (##) [data]      (unlifted unit type)   --; upd
-        | '[]' [data]      (list constructor)     --; upd
-        | ……
-
-    constr ::= con [!] atype1 … [!] atypek                  (arity con = k, k>=0)
-        | con { [,] fielddecl1 , … , fielddecln [,] } [data]       (records n>=0)   ;-- upd
-        | ……
-
-    apat ::= var [ @ apat]	                                         (as pattern)
-        | ……
-        | '[' [,] pat1 , … , patk [,] ']' [data]            (list pattern, k ≥ 1)   ;-- upd
-        | ……
-        | qcon { [,] fpat1 , … , fpatk [,] } [data]      (labeled pattern, k ≥ 0)   ;-- upd
-
-These changes allow extra commas in the all unordered structures:
-
-- tuples, constraint tuples, s-content
-- list-comprehensions and literal list (expressions and patterns)
-- records in terms and types (declarations, patterns, constructions)
-- nested multi-name signatures in records
-
-Proposed Library Change Specification
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is a fully backwards-compatible syntax extension, so no changes to user libraries are required.
-
-Libraries from the GHC ecosystem may need to be updated to handle the new syntax.
-
-Examples
---------
-
-1. **Trailing Commas**
-
-   List with trailing comma::
-
-      numbers = [
-        1,
-        2,
-        3,
-      ] data
-
-   This would be equivalent to:
-
-   ::
-   
-      numbers = [1, 2, 3]
-      
-2. **Leading Commas**
-
-   List with leading comma::
-
-      fruits = [
-        , "apple"
-        , "banana"
-        , "cherry"
-      ] data
-      
-   This would be equivalent to: ::
-
-      fruits = ["apple", "banana", "cherry"]
-      
-3. **Combined Leading and Trailing Commas**
-
-   List with mix of leading and trailing commas::
-
-      mixed = [
-        , 1, 2
-        , 3, 4, -- 5
-      ] data
-      
-   This would be equivalent to:  ::
-
-      mixed = [1, 2, 3, 4]
 
 
 Effect and Interactions
 -----------------------
 
-We choose the **postfix variant** ``[x,y,z] qualified`` over **prefix variant** ``qualified [x,y,z]`` to avoid injections 
-for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns``, ``Specified(Qualified)Literals`` ::
+We choose the **postfix variant** ``(x,y,z) data`` over **prefix variant** ``data [x,y,z]`` to avoid injections 
+for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns``, data declaration ::
 
     -- Bang Patterns
     let !(,p,q,) data = e in body
     
-    let (!x, ![y,] data) = e in body
+    let (!x, !(y,) data) = e in body
 
     -- As Pattern
     foo1 :: (a, b) -> a
     foo1 t@(,p,q,) data = t
-
-    -- Specified(Qualified) Literals
-    bar2 a b  = M.[a, b,] data
-    
+   
     -- StrictPattern
     data T = MkT ~(Int, Int, Int,) data
     
     -- Irrefutable Patterns
-    let ~[a,b,] data = expr in e0 a b
+    let ~(a,b,) data = expr in e0 a b
+
+    -- Data declaration	vs function declaration
+	(a1, b1) data `op` (a2, b2) data = expr
 
 Tuple Section
 ~~~~~~~~~~~~~~~~~~
 
-Both ``TupleSection`` extension and presumable/conceivable ``ListSection``, ``RecordSection`` extensions
-are fully consistent and compatible with ``ExtraDataCommas``.
+``TupleSection`` extension do not interact with alternative syntax of data tuples.
 
 
 Costs and Drawbacks
 -------------------
 
-We expect the implementation and maintenance costs of ``ExtraDataCommas`` has medium difficulty.
+We expect the implementation and maintenance costs of ``DataTuples`` has medium difficulty.
 
 
 Backward Compatibility
@@ -334,11 +273,30 @@ Alternatives
 
 The primary alternative is "status quo".
 
+History
+~~~~~~~~~~~~
+
+Adding trailing commas (and more rarely leading commas) is a frequently asked feature to add in Haskell.
+
+But this task is highly divisive in the Haskell community.
+
+Original Proposal #87 `ExtraCommas (was: Trailing and leading commas in sub-export lists) <https://github.com/ghc-proposals/ghc-proposals/pull/87>`__ 
+was discussed for several years, and that discussion was so controversial 
+that the author withdrew their own proposal just before the final Acceptation was received (with minor changes).
+
+Unfortunately, redundant commas contradict with ``TupleSection`` 
+(and presumably/conceivable ``ListSections``) extension's notation. 
+This is inconstancy.
+
+This proposal is an attempt to allow redundant commas more universally and consistently.
+
 Alternative Syntax
 ~~~~~~~~~~~~~~~~~~
 
-Alternative to ``(x, y, z) data`` and ``[x, y, z] data`` syntax we could choose alternative syntax,
-like ``q(x, y, z)`` and ``q[x, y, z]`` or ``%(x, y, z)`` and ``%[x, y, z]``. Or alternative keywords could be chosen, like ``qualified``.
+Alternative to ``(x, y, z) data`` syntax we could choose alternative syntax,
+like ``q(x, y, z)`` or ``(x, y, z)q`` or ``%(x, y, z)`` and ``(x, y, z)%``. 
+
+Or alternative keywords could be chosen insted of ``data``, like ``qualified``.
 
 Alternative Rule for Commas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -124,8 +124,8 @@ The formal grammar changes for ``DataTuples``:
     
     atype := gtycon
         | tyvar                                                 ;-- kmax = if 'data' then 1 else 2
-        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']       (tuple type, k>=kmax)  ;-- upd
-        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']  (unboxed tuple type, k>=1)  ;-- upd
+        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']       (tuple type, k ≥ kmax)  ;-- upd
+        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']  (unboxed tuple type, k ≥ 1)  ;-- upd
         | ……
 
     gtycon := qtycon

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -1,5 +1,5 @@
-Redundant commas in Comma Qualified lists and tuples
-======================================================
+Extra Data Commas
+=====================
 
 .. author:: Viktor WW
 .. date-accepted::
@@ -10,9 +10,11 @@ Redundant commas in Comma Qualified lists and tuples
 .. sectnum::
 .. contents::
 
-This proposal suggests extending the Haskell syntax by adding alternative syntax for lists, tuples and constraint tuples with build support of trailing and leading commas.
+This proposal suggests extending the Haskell syntax by adding alternative syntax 
+for lists, records, tuples and constraint tuples with build support of trailing and leading commas.
 
-This change aims to improve code readability and maintainability by allowing more flexibility in formatting lists, tuples and constraint tuples. 
+This change aims to improve code readability and maintainability by allowing more flexibility 
+in formatting lists, records, tuples and constraint tuples. 
 
 First of all, particularly important in scenarios involving version control, code reviews, and automated code generation.
 
@@ -77,45 +79,46 @@ Proposed Change Specification
 
 Main idea is: 
 
-1. To forbid redundant commas for existing order-matter structures (lists and tuples, list comprehensions, constraint tuples)
+1. To forbid redundant commas for existing data structures (records, lists and tuples, list comprehensions, constraint tuples)
 
-2. To create an alternating/qualified syntax for order-matter structures (lists, tuples, and constraint tuples) that has built support
+2. To create an alternating syntax for data structures (records, lists, tuples, and constraint tuples) that has built support
    for trailing and leading commas.
 
 This proposal introduces the following syntactical changes to Haskell:
 
-1. Add language extension ``CommaQualifiedStructures``
+1. Add language extension ``ExtraDataCommas``
 
-2. **Comma Qualified tuples**: Allow to write ``qualified`` keyword after tuple close bracket `)` in tuples, 
+2. **Comma Qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
    unboxed-tuples and constraint tuples at terms and types.
 
    The only difference between qualified and non-qualified lists is:
 
-   - non-qualified tuples don't allow redundant commas, but allow ``TupletSections`` (or presumably allow for constraint tuples)
-   - qualified tuples allow redundant commas, but ignore ``TupletSections``
+   - non-qualified tuples don't allow extra commas, but allow ``TupletSections`` (or presumably allow for constraint tuples)
+   - qualified tuples allow extra commas, but ignore ``TupletSections``
      ::
   
        myTuple1 :: (Int, String, Char)
-       myTuple1 = (1, "2abc", 'd') qualified
+       myTuple1 = (1, "2abc", 'd') data
 
-       unlftTuple1 = (# 1#, 'x'#, 3.2## #) qualified
+       myTuple2 :: (Int, Int, String, Char) data
+       myTuple2 = (42, 43, "xyz", 'w') data
 
-3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``qualified`` keyword ::
+       unlftTuple1 = (# 1#, 'x'#, 3.2## #) data
 
-       mySoloTuple :: (Int) qualified
-       mySoloTuple  = (5) qualified
+3. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``data`` keyword ::
 
-4. **Comma Qualified lists**: Allow to write ``qualified`` keyword after list close bracket `]` in lists at terms and types.
+       mySoloTuple :: (Int) data
+       mySoloTuple  = (5) data
+
+4. **Comma Qualified lists**: Allow to write ``data`` keyword after list close bracket `]` in lists at terms and types.
    The only difference between qualified and non-qualified lists is:
    
-   - non-qualified lists don't allow redundant commas, but allow presumably/conceivable ``ListSections`` extension
-   - qualified lists allow redundant commas, but ignore presumably/conceivable ``ListSections`` extension
+   - non-qualified lists don't allow extra commas, but allow presumably/conceivable ``ListSections`` extension
+   - qualified lists allow exra commas, but ignore presumably/conceivable ``ListSections`` extension
 
    ::
      
-      myList1 = [1, 2, 3, 4, 5, 6, 7, 8] qualified
-
-5. **Qualified Trailing Commas**: Allow a comma after the last element in qualified lists (expanded, non-enumerations) and tuples/constraint tuples. ::
+      myList1 = [1, 2, 3, 4, 5, 6, 7, 8] data
 
       myList2 :: [Int]
       myList2 = [
@@ -127,30 +130,27 @@ This proposal introduces the following syntactical changes to Haskell:
                     6, 
                     7, 
                     8,
-                ] qualified
+                ] data
 
-      instance (GSerialize a, GSerialize b,) qualified => GSerialize (a :+: b) where
+      instance (GSerialize a, GSerialize b,) data => GSerialize (a :+: b) where
 
       myfun1 :: forall a s. (
                     C1 a,
                     C2 a s,
                     C3 s,
-                ) qualified. =>
+                ) data. =>
                      (# 
                        SuperLongType a,
                        SuperPuperLongType a s,
                        MegaPuperLongType (Maybe a),
-                     #) qualified
+                     #) data
                      -> Int#
                      -> Int#
                      -> Int#
       myfun1 = ....
-      
 
-6. **Qualified Leading Commas**: Allow a comma after the last element in qualified lists (expanded, non-enumerations) and tuples/constraint tuples. ::
-
-      myTuple2 :: (,Int, String, Char,) qualified
-      myTuple2 = (,1, "2abc", 'd') qualified
+      myTuple3 :: (,Int, String, Char,) data
+      myTuple3 = (,1, "2abc", 'd') data
 
       myList3 :: [Int]
       myList3 = [
@@ -162,34 +162,51 @@ This proposal introduces the following syntactical changes to Haskell:
                     , 6 
                     , 7 
                     , 8
-                ] qualified
+                ] data
       
+5. **Qualified trailing & leading commas**: 
+
+   - Allow a comma before the first element in qualified 
+     records, lists (expanded, non-enumerations) and tuples/constraint tuples/s-context.
+
+   - Allow a comma after the last element in qualified 
+     records, lists (expanded, non-enumerations) and tuples/constraint tuples/s-context.
+
+   - Allow both trailing & leading commas in  same qualified structure
+
 
 Syntax
 ~~~~~~~~~~~~
 	  
-The formal grammar changes for ``CommaQualifiedStructures``:
+The formal grammar changes for ``ExtraDataCommas``:
 
-:: 
+.. code:: abnf
 
     atype := gtycon
-        |    tyvar
-        |    ( ,? type1 , ... , typek ,? ) qualified    (tuple type, k>=1)    -- new
-        |    ( type1 , ... , typek )                    (tuple type, k>=2)
-        |    (# ,? type1 , ... , typek ,? #) qualified  (tuple type, k>=1)    -- new
-        |    (# type1 , ... , typek #)                  (tuple type, k>=2)
-        |    '[' [,] type1 , ... , typek [,] ']' qualified   (type, k>=1)     -- new
-        |    '[' type ']'	                                 (list type)
-        | ......
+        | tyvar
+        | ( [,] type1 , … , typek [,] ) [data]       (tuple type, k>=1)    --; upd
+        | (# [,] type1 , … , typek [,] #) [data]     (tuple type, k>=1)    --; upd
+        | '[' [,] type1 , … , typek [,] ']' [data]         (type, k>=1)    --; upd
+        | '[' type ']'	                                    (list type)
+        | qcon { [,] fbind1 , … , fbindn [,] } [data]         (labeled construction, n ≥ 0)   ;-- upd
+        | aexp_(qcon) { [,] fbind1 , … , fbindn [,] } [data]  (labeled update, n  ≥  1)       ;-- upd
+        | ……
 
     gtycon := qtycon
-        |    () qualified     --(unit type)            -- new
-        |    ()               --(unit type)
-        |    (##) qualified   --(unlifted unit type)   -- new
-        |    (##)             --(unlifted unit type)
-        |    [] qualified     --(list constructor)     -- new
-        |    []               --(list constructor)
-        | ......
+        | () [data]        (unit type)            --; upd
+        | (##) [data]      (unlifted unit type)   --; upd
+        | '[]' [data]      (list constructor)     --; upd
+        | ……
+
+    constr ::= con [!] atype1 … [!] atypek                  (arity con = k, k>=0)
+        | con { [,] fielddecl1 , … , fielddecln [,] } [data]       (records n>=0)   ;-- upd
+        | ……
+
+    apat ::= var [ @ apat]	                                         (as pattern)
+        | ……
+        | '[' [,] pat1 , … , patk [,] ']' [data]            (list pattern, k ≥ 1)   ;-- upd
+        | ……
+        | qcon { [,] fpat1 , … , fpatk [,] } [data]      (labeled pattern, k ≥ 0)   ;-- upd
 
 
 Proposed Library Change Specification
@@ -210,7 +227,7 @@ Examples
         1,
         2,
         3,
-      ] qualified
+      ] data
 
    This would be equivalent to:
 
@@ -226,7 +243,7 @@ Examples
         , "apple"
         , "banana"
         , "cherry"
-      ] qualified
+      ] data
       
    This would be equivalent to: ::
 
@@ -239,11 +256,12 @@ Examples
       mixed = [
         , 1, 2
         , 3, 4, -- 5
-      ] qualified
+      ] data
       
    This would be equivalent to:  ::
 
       mixed = [1, 2, 3, 4]
+
 
 Effect and Interactions
 -----------------------
@@ -252,34 +270,34 @@ We choose the **postfix variant** ``[x,y,z] qualified`` over **prefix variant** 
 for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns``, ``Specified(Qualified)Literals`` ::
 
     -- Bang Patterns
-    let !(,p,q,) qualified = e in body
+    let !(,p,q,) data = e in body
     
-    let (!x, ![y,] qualified) = e in body
+    let (!x, ![y,] data) = e in body
 
     -- As Pattern
     foo1 :: (a, b) -> a
-    foo1 t@(,p,q,) qualified = t
+    foo1 t@(,p,q,) data = t
 
     -- Specified(Qualified) Literals
-    bar2 a b  = M.[a, b,] qualified
+    bar2 a b  = M.[a, b,] data
     
     -- StrictPattern
-    data T = MkT ~(Int, Int, Int,) qualified
+    data T = MkT ~(Int, Int, Int,) data
     
     -- Irrefutable Patterns
-    let ~[a,b,] qualified = expr in e0 a b
+    let ~[a,b,] data = expr in e0 a b
 
 Tuple Section
 ~~~~~~~~~~~~~~~~~~
 
 Both ``TupleSection`` extension and presumable/conceivable ``ListSection`` extension
-are fully consistent and compatible with ``CommaQualifiedStructures``.
+are fully consistent and compatible with ``ExtraDataCommas``.
 
 
 Costs and Drawbacks
 -------------------
 
-We expect the implementation and maintenance costs of ``CommaQualifiedStructures`` has medium difficulty.
+We expect the implementation and maintenance costs of ``ExtraDataCommas`` has medium difficulty.
 
 
 Backward Compatibility
@@ -298,8 +316,8 @@ The primary alternative is "status quo".
 Alternative Syntax
 ~~~~~~~~~~~~~~~~~~
 
-Alternative to ``(x, y, z) qualified`` and ``[x, y, z] qualified`` syntax we could choose alternative syntax,
-like ``q(x, y, z)`` and ``q[x, y, z]`` or ``%(x, y, z)`` and ``%[x, y, z]``.
+Alternative to ``(x, y, z) data`` and ``[x, y, z] data`` syntax we could choose alternative syntax,
+like ``q(x, y, z)`` and ``q[x, y, z]`` or ``%(x, y, z)`` and ``%[x, y, z]``. Or alternative keywords could be chosen, like ``qualified``.
 
 
 Unresolved Questions

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -118,24 +118,26 @@ Syntax
 	  
 The formal grammar changes for ``DataTuples``:
 
-.. code:: abnf
+Syntax for tuples, unboxed tuples, constraint tuples:
 
-    ;-- tuples, unboxed tuples, constraint tuples
+.. code:: abnf
     
     atype := gtycon
-        | tyvar                                                 ;-- kmax = if 'data' then 1 else 2
-        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']       (tuple type, k ≥ kmax)  ;-- upd
-        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']  (unboxed tuple type, k ≥ 1)  ;-- upd
+        | tyvar                                                  ;-- kmax = if 'data' then 1 else 2
+        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']   (tuple type, k ≥ kmax)              ;-- upd
+        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']   (unboxed tuple type, k ≥ 1)         ;-- upd
         | ……
 
     gtycon := qtycon
-        | '(' ')' ['data']        (unit type)           ;-- upd
-        | '(#' '#)' ['data']      (unlifted unit type)  ;-- upd
-        | ……
+        | '('   ')' ['data']             (unit type)             ;-- upd
+        | '(#' '#)' ['data']             (unlifted unit type)    ;-- upd
+        | '[' ']'                        (list constructor)
+        | '(' '->' ')'                   (function constructor)
+        | '(' ',' {','} ')'              (tupling constructors)
+
+Syntax for class content and class simplified content:
 
 .. code:: abnf
-
-    ;-- class content
 
     topdecl := 'type' simpletype '=' type
         | 'data' [context '=>'] simpletype ['=' constrs] [deriving]
@@ -144,32 +146,32 @@ The formal grammar changes for ``DataTuples``:
         | 'instance' [scontext '=>'] qtycls inst ['where' idecls]
         | ……
 
-    gendecl := vars '::' [context '=>'] type      (type signature)
-        | fixity [integer] ops                (fixity declaration)
-        |                                      (empty declaration)
+    gendecl := vars '::' [context '=>'] type                    (type signature)
+        | fixity [integer] ops                                  (fixity declaration)
+        |                                                       (empty declaration)
 
-    exp := infixexp '::' [context '=>'] type   (expression type signature)
+    exp := infixexp '::' [context '=>'] type                    (expression type signature)
         | infixexp
 
     context := class
-        | '(' ',' cntclasses [','] ')' 'data'                   ;-- upd
-        | '(' cntclasses ((')' ['data']) | (',' ')' 'data'))    ;-- upd
+        | '(' ',' cntclasses [','] ')' 'data'                             ;-- upd
+        | '(' cntclasses ((')' ['data']) | (',' ')' 'data'))              ;-- upd
 
 
     scontext := simpleclass
-        | '(' ',' scntclasses [','] ')' 'data'                   ;-- upd
-        | '(' scntclasses ((')' ['data']) | (',' ')' 'data'))    ;-- upd
+        | '(' ',' scntclasses [','] ')' 'data'                            ;-- upd
+        | '(' scntclasses ((')' ['data']) | (',' ')' 'data'))             ;-- upd
 		
-    cntclasses := class1 ',' … ',' classn               (n ≥ 0)  ;-- upd
+    cntclasses := class1 ',' … ',' classn                        (n ≥ 0)  ;-- upd
 
     class := qtycls tyvar
-        | qtycls '(' tyvar atype1 … atypen ')'          (n ≥ 1)
+        | qtycls '(' tyvar atype1 … atypen ')'                   (n ≥ 1)
 
-    scntclasses := simpleclass1 ',' … ',' simpleclassn  (n ≥ 0)  ;-- upd
+    scntclasses := simpleclass1 ',' … ',' simpleclassn           (n ≥ 0)  ;-- upd
 
     simpleclass := qtycls tyvar
  
-    simpletype  := tycon tyvar1 … tyvark                (k ≥ 0)
+    simpletype  := tycon tyvar1 … tyvark                         (k ≥ 0)
 
 
 These changes allow extra commas in the all tuple-like structures:
@@ -178,8 +180,9 @@ These changes allow extra commas in the all tuple-like structures:
 - unboxed tuples
 - constraint tuples
 - class content
+- class simplified content
 
-This proposal does not cover tupling constructors for obvious reasons.
+This proposal does not cover multi-tupling constructors for obvious reasons.
 
 
 Examples
@@ -334,6 +337,7 @@ Thanks to all contributors of `Allow Trailing Comma in List Constructor Syntaxs
 
 Thanks to all contributors of `Extra NonTuple Commas 
 <https://github.com/ghc-proposals/ghc-proposals/issues/748>`__.
+
 
 Endorsements
 -------------

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -81,18 +81,19 @@ This proposal introduces the following syntactical changes to Haskell:
 
 2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = CommaTuples + ExtraNonTupleCommas``
 
-3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple 
-   (and tuple-like strucures) close bracket `)` in tuples, 
+3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
    unboxed-tuples, constraint tuples and class context at terms and types.
 
-   Comma qualified tuples by meaning are indistinguishable from ordinary tuples, but they are different in syntax.
+   Comma qualified tuples (and tuple-like strucures) by meaning are indistinguishable 
+   from ordinary tuples, but they are different in syntax.
    
    Tuple ``(a, b, c)`` is the same as ``(, a, b, c,) data`` in types or class context;
    and ``(x, y, z)`` is the same as ``(, x, y, z,) data`` in terms. 
 
-   The only difference between comma-qualified and ordinary tuples is:
+   The only difference between comma-qualified and ordinary tuples (and tuple-like strucures) is:
 
-   - ordinary tuples don't allow extra commas, but allow curried tupling constructors and ``TupletSections`` (if values are not Constraint kind)
+   - ordinary tuples don't allow extra commas, but allow curried tupling constructors 
+     and ``TupletSections`` (if values are not Constraint kind)
    
    - comma-qualified tuples allow extra commas, but ignore ``TupletSections``
    
@@ -119,11 +120,14 @@ This proposal introduces the following syntactical changes to Haskell:
        mySoloTuple :: (Int) data
        mySoloTuple  = (5,) data
 
-5. **Comma Qualified unit-tuples**: Allow to write unit-tuples 
-   (and tuple-like strucures) with ``data`` keyword and just 1 extra comma::
+5. **Comma Qualified unit-tuples**: It is allowed to write unit-tuples 
+   (and tuple-like strucures), but not in constructors 
+   with ``data`` keyword, but without any extra comma::
 
-       myUnitTuple :: (,) data
-       myUnitTuple  = (,) data
+       myUnitTuple  :: () data
+       myUnitTuple   = () data
+
+       myUnitTuple2  = (,) data   -- forbidden
 
 
 Syntax
@@ -138,21 +142,21 @@ Syntax for tuples, unboxed tuples, constraint tuples:
     ;-- kmax = if 'data' then 1 else 2
 
     atype ::= gtycon
-        | '(' [','] ')'   'data'                                                  (comma empty tuple type)           ;-- new
+        | '(' ')'     'data'                                                      (comma empty tuple type)           ;-- new
         | '('  ',' type1 ',' … ',' typek [',']  ')'  'data'                       (comma tuple type, k ≥ 1)          ;-- upd
         | '('      type1 ',' … ',' typek (( ',' ')'  'data' )|( ')' ['data'] ))   (tuple type, k ≥ kmax)             ;-- new
-        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple type)   ;-- new
+        | '(#' '#)'   'data'                                                      (comma empty unboxed tuple type)   ;-- new
         | '(#'  ',' type1 ',' … ',' typek [',']  '#)' 'data'                      (unboxed comma-tuple type, k ≥ 1)  ;-- upd
         | '(#'      type1 ',' … ',' typek (( ',' '#)' 'data' )|( '#)' ['data'] )) (unboxed tuple type, k ≥ 1)        ;-- new
         | ……
 
-    aexp ::= qvar                                                                  (variable)
+    aexp ::= qvar                                                                 (variable)
         | ……
         | '(' exp ')'                                                             (parenthesized expression)
-        | '(' [','] ')'   'data'                                                  (comma empty tuple)                ;-- new
+        | '(' ')'    'data'                                                       (comma empty tuple)                ;-- new
         | '('  ',' exp1 ',' … ',' expk [',']  ')'  'data'                         (comma tuple, k ≥ 1)               ;-- upd
         | '('      exp1 ',' … ',' expk (( ',' ')'  'data' )|( ')' ['data'] ))     (tuple, k ≥ kmax)                  ;-- new
-        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple)        ;-- new
+        | '(#' '#)'  'data'                                                       (comma empty unboxed tuple)        ;-- new
         | '(#'  ',' exp1 ',' … ',' expk [',']  '#)' 'data'                        (unboxed comma-tuple, k ≥ kmax)    ;-- upd
         | '(#'      exp1 ',' … ',' expk (( ',' '#)' 'data' )|( '#)' ['data'] ))   (unboxed tuple, k ≥ 1)             ;-- new
         | '(' infixexp qop ')'                                                    (left section)
@@ -161,10 +165,10 @@ Syntax for tuples, unboxed tuples, constraint tuples:
     apat ::= var [ @ apat]                                                        (as pattern)
         | ……
         | '(' pat ')'                                                             (parenthesized pattern)
-        | '(' [','] ')'   'data'                                                  (comma empty tuple pattern)             ;-- new
+        | '(' ')'     'data'                                                      (comma empty tuple pattern)             ;-- new
         | '('  ',' pat1 ',' … ',' patk [',']  ')'  'data'                         (comma tuple pattern, k ≥ 1)            ;-- upd
         | '('      pat1 ',' … ',' expk (( ',' ')'  'data' )|( ')' ['data'] ))     (tuple pattern, k ≥ kmax)               ;-- new
-        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple pattern)     ;-- new
+        | '(#' '#)'   'data'                                                      (comma empty unboxed tuple pattern)     ;-- new
         | '(#'  ',' pat1 ',' … ',' patk [',']  '#)' 'data'                        (unboxed comma-tuple, k ≥ kmax pattern) ;-- upd
         | '(#'      pat1 ',' … ',' patk (( ',' '#)' 'data' )|( '#)' ['data'] ))   (unboxed tuple pattern, k ≥ 1)          ;-- new
 
@@ -188,20 +192,22 @@ Syntax for class content and class simplified content:
         | infixexp
 
     context ::= class
+        | '(' ')'  ['data']                                               ;-- upd
         | '(' ',' cntclasses [','] ')' 'data'                             ;-- upd
         | '(' cntclasses ((')' ['data']) | (',' ')' 'data'))              ;-- upd
 
 
     scontext ::= simpleclass
+        | '(' ')'  ['data']                                               ;-- upd
         | '(' ',' scntclasses [','] ')' 'data'                            ;-- upd
         | '(' scntclasses ((')' ['data']) | (',' ')' 'data'))             ;-- upd
 		
-    cntclasses ::= class1 ',' … ',' classn                       (n ≥ 0)  ;-- upd
+    cntclasses ::= class1 ',' … ',' classn                       (n ≥ 1)  ;-- upd
 
     class ::= qtycls tyvar
         | qtycls '(' tyvar atype1 … atypen ')'                   (n ≥ 1)
 
-    scntclasses ::= simpleclass1 ',' … ',' simpleclassn          (n ≥ 0)  ;-- upd
+    scntclasses ::= simpleclass1 ',' … ',' simpleclassn          (n ≥ 1)  ;-- upd
 
     simpleclass ::= qtycls tyvar
  

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -134,61 +134,78 @@ The formal grammar changes for ``CommaTuples``:
 Syntax for tuples, unboxed tuples, constraint tuples:
 
 .. code:: abnf
-    
-    atype := gtycon
-        | tyvar                                                                  ;-- kmax = if 'data' then 1 else 2
-        | '('  ',' type1 ',' … ',' typek [',']  ')'  'data'                      (comma tuple type, k ≥ 1)          ;-- upd
-        | '('      type1 ',' … ',' typek (( ',' ')'  'data' )|( ')' ['data'] ))  (tuple type, k ≥ kmax)             ;-- new
-        | '(#' ',' type1 ',' … ',' typek [',']  '#)' 'data'                      (unboxed comma-tuple type, k ≥ 1)  ;-- upd
-        | '(#'     type1 ',' … ',' typek (( ',' '#)' 'data' )|( '#)' ['data'] )) (unboxed tuple type, k ≥ 1)        ;-- new
+
+    ;-- kmax = if 'data' then 1 else 2
+
+    atype ::= gtycon
+        | '(' [','] ')'   'data'                                                  (comma empty tuple type)           ;-- new
+        | '('  ',' type1 ',' … ',' typek [',']  ')'  'data'                       (comma tuple type, k ≥ 1)          ;-- upd
+        | '('      type1 ',' … ',' typek (( ',' ')'  'data' )|( ')' ['data'] ))   (tuple type, k ≥ kmax)             ;-- new
+        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple type)   ;-- new
+        | '(#'  ',' type1 ',' … ',' typek [',']  '#)' 'data'                      (unboxed comma-tuple type, k ≥ 1)  ;-- upd
+        | '(#'      type1 ',' … ',' typek (( ',' '#)' 'data' )|( '#)' ['data'] )) (unboxed tuple type, k ≥ 1)        ;-- new
         | ……
 
-    gtycon := qtycon
-        | '('   ')'    ['data']                    (unit type)                   ;-- upd
-        | '(' ',' ')'   'data'                     (unit type)                   ;-- new
-        | '(#' '#)'    ['data']                    (unlifted unit type)          ;-- upd
-        | '(#' ',' '#)' 'data'                     (unlifted unit type)          ;-- new
-        | '[' ']'                                  (list constructor)
-        | '(' '->' ')'                             (function constructor)
-        | '(' ',' {','} ')'                        (tupling constructors)
+    aexp ::= qvar                                                                  (variable)
+        | ……
+        | '(' exp ')'                                                             (parenthesized expression)
+        | '(' [','] ')'   'data'                                                  (comma empty tuple)                ;-- new
+        | '('  ',' exp1 ',' … ',' expk [',']  ')'  'data'                         (comma tuple, k ≥ 1)               ;-- upd
+        | '('      exp1 ',' … ',' expk (( ',' ')'  'data' )|( ')' ['data'] ))     (tuple, k ≥ kmax)                  ;-- new
+        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple)        ;-- new
+        | '(#'  ',' exp1 ',' … ',' expk [',']  '#)' 'data'                        (unboxed comma-tuple, k ≥ kmax)    ;-- upd
+        | '(#'      exp1 ',' … ',' expk (( ',' '#)' 'data' )|( '#)' ['data'] ))   (unboxed tuple, k ≥ 1)             ;-- new
+        | '(' infixexp qop ')'                                                    (left section)
+        | '(' qop⟨-⟩ infixexp ')'                                                  (right section)
+
+    apat ::= var [ @ apat]                                                        (as pattern)
+        | ……
+        | '(' pat ')'                                                             (parenthesized pattern)
+        | '(' [','] ')'   'data'                                                  (comma empty tuple pattern)             ;-- new
+        | '('  ',' pat1 ',' … ',' patk [',']  ')'  'data'                         (comma tuple pattern, k ≥ 1)            ;-- upd
+        | '('      pat1 ',' … ',' expk (( ',' ')'  'data' )|( ')' ['data'] ))     (tuple pattern, k ≥ kmax)               ;-- new
+        | '(#' [','] '#)'   'data'                                                (comma empty unboxed tuple pattern)     ;-- new
+        | '(#'  ',' pat1 ',' … ',' patk [',']  '#)' 'data'                        (unboxed comma-tuple, k ≥ kmax pattern) ;-- upd
+        | '(#'      pat1 ',' … ',' patk (( ',' '#)' 'data' )|( '#)' ['data'] ))   (unboxed tuple pattern, k ≥ 1)          ;-- new
+
 
 Syntax for class content and class simplified content:
 
 .. code:: abnf
 
-    topdecl := 'type' simpletype '=' type
+    topdecl ::= 'type' simpletype '=' type
         | 'data'     [context '=>']  simpletype  ['=' constrs] [deriving]
         | 'newtype'  [context '=>']  simpletype  '=' newconstr [deriving]
         | 'class'    [scontext '=>'] tycls tyvar ['where' cdecls]
         | 'instance' [scontext '=>'] qtycls inst ['where' idecls]
         | ……
 
-    gendecl := vars '::' [context '=>'] type                    (type signature)
+    gendecl ::= vars '::' [context '=>'] type                   (type signature)
         | fixity [integer] ops                                  (fixity declaration)
         |                                                       (empty declaration)
 
-    exp := infixexp '::' [context '=>'] type                    (expression type signature)
+    exp ::= infixexp '::' [context '=>'] type                   (expression type signature)
         | infixexp
 
-    context := class
+    context ::= class
         | '(' ',' cntclasses [','] ')' 'data'                             ;-- upd
         | '(' cntclasses ((')' ['data']) | (',' ')' 'data'))              ;-- upd
 
 
-    scontext := simpleclass
+    scontext ::= simpleclass
         | '(' ',' scntclasses [','] ')' 'data'                            ;-- upd
         | '(' scntclasses ((')' ['data']) | (',' ')' 'data'))             ;-- upd
 		
-    cntclasses := class1 ',' … ',' classn                        (n ≥ 0)  ;-- upd
+    cntclasses ::= class1 ',' … ',' classn                       (n ≥ 0)  ;-- upd
 
-    class := qtycls tyvar
+    class ::= qtycls tyvar
         | qtycls '(' tyvar atype1 … atypen ')'                   (n ≥ 1)
 
-    scntclasses := simpleclass1 ',' … ',' simpleclassn           (n ≥ 0)  ;-- upd
+    scntclasses ::= simpleclass1 ',' … ',' simpleclassn          (n ≥ 0)  ;-- upd
 
-    simpleclass := qtycls tyvar
+    simpleclass ::= qtycls tyvar
  
-    simpletype  := tycon tyvar1 … tyvark                         (k ≥ 0)
+    simpletype  ::= tycon tyvar1 … tyvark                        (k ≥ 0)
 
 
 These changes allow extra commas in the all comma-tuple-like structures:
@@ -199,7 +216,7 @@ These changes allow extra commas in the all comma-tuple-like structures:
 - class content
 - class simplified content
 
-This proposal does not cover multi-tupling constructors for obvious reasons.
+This proposal does not cover constructors for obvious reasons.
 
 
 Proposed Library Change Specification

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -79,9 +79,7 @@ This proposal introduces the following syntactical changes to Haskell:
 
 1. Add language extension ``CommaTuples``
 
-2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = CommaTuples + ExtraNonTupleCommas``
-
-3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
+2. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
    unboxed-tuples, constraint tuples and class context at terms and types.
 
    Comma qualified tuples (and tuple-like strucures) by meaning are indistinguishable 
@@ -106,21 +104,21 @@ This proposal introduces the following syntactical changes to Haskell:
        ::
   
          myTuple1 :: (Int, String, Char)
-         myTuple1 = (1, "2abc", 'd') data
+         myTuple1 =  (1, "2abc", 'd') data
 
          myTuple2 :: (, Int, Int, String, Char) data
-         myTuple2 = (42, 43, "xyz", 'w',) data
+         myTuple2 =  (42, 43, "xyz", 'w',) data
 
          myTuple3 :: (,Int, String, Char,) data
-         myTuple3 = (,1, "2abc", 'd') data
+         myTuple3 =  (,1, "2abc", 'd') data
 
-4. **Comma Qualified solo-tuples**: Allow to write solo-tuples 
+3. **Comma Qualified solo-tuples**: Allow to write solo-tuples 
    (and tuple-like strucures) with ``data`` keyword ::
 
        mySoloTuple :: (Int) data
        mySoloTuple  = (5,) data
 
-5. **Comma Qualified unit-tuples**: It is allowed to write unit-tuples 
+4. **Comma Qualified unit-tuples**: It is allowed to write unit-tuples 
    (and tuple-like strucures), but not in constructors 
    with ``data`` keyword, but without any extra comma::
 
@@ -142,7 +140,7 @@ Syntax for tuples, unboxed tuples, constraint tuples:
     ;-- kmax = if 'data' then 1 else 2
 
     atype ::= gtycon
-        | '(' ')'     'data'                                                      (comma empty tuple type)           ;-- new
+        | '(' ')' 'data'                                                          (comma empty tuple type)           ;-- new
         | '('  ',' type1 ',' … ',' typek [',']  ')'  'data'                       (comma tuple type, k ≥ 1)          ;-- upd
         | '('      type1 ',' … ',' typek (( ',' ')'  'data' )|( ')' ['data'] ))   (tuple type, k ≥ kmax)             ;-- new
         | '(#' '#)'   'data'                                                      (comma empty unboxed tuple type)   ;-- new
@@ -236,7 +234,7 @@ for supporting reading comma qualified tuples.
 Second, we update ``Data.Tuple`` to:
 ::
 
-    data Solo a = (a) data
+    pattern Solo a = (a) data
 	
     pattern MkSolo a = (a) data
 
@@ -360,7 +358,7 @@ Or alternative keywords could be chosen insted of ``data``, like ``qualified``.
 Alternative Rule for Commas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This proposal has synchronized rules with ``ExtraNonTupleCommas`` extension:
+This proposal has synchronized rules with ``ExtraCommas`` extension:
 
   We allow Leading Comma AND Trailing Comma (in single Structure) but WITHOUT Adjacent Commas.
 
@@ -391,7 +389,7 @@ Thanks to all contributors of `Add Support for Trailing and Leading Commas in Li
 Thanks to all contributors of `Allow Trailing Comma in List Constructor Syntaxs 
 <https://github.com/ghc-proposals/ghc-proposals/issues/653>`__.
 
-Thanks to all contributors of `Extra NonTuple Commas 
+Thanks to all contributors of `Extra Commas 
 <https://github.com/ghc-proposals/ghc-proposals/issues/748>`__.
 
 

--- a/proposals/0000-comma_qualified_structures.rst
+++ b/proposals/0000-comma_qualified_structures.rst
@@ -81,7 +81,8 @@ This proposal introduces the following syntactical changes to Haskell:
 
 2. Add language extension ``ExtraCommas`` which is just unification of 2 extensions: ``ExtraCommas = CommaTuples + ExtraNonTupleCommas``
 
-3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple close bracket `)` in tuples, 
+3. **Comma qualified tuples**: Allow to write ``data`` keyword after tuple 
+   (and tuple-like strucures) close bracket `)` in tuples, 
    unboxed-tuples, constraint tuples and class context at terms and types.
 
    Comma qualified tuples by meaning are indistinguishable from ordinary tuples, but they are different in syntax.
@@ -112,10 +113,17 @@ This proposal introduces the following syntactical changes to Haskell:
          myTuple3 :: (,Int, String, Char,) data
          myTuple3 = (,1, "2abc", 'd') data
 
-4. **Comma Qualified solo-tuples**: Allow to write solo-tuples with ``data`` keyword ::
+4. **Comma Qualified solo-tuples**: Allow to write solo-tuples 
+   (and tuple-like strucures) with ``data`` keyword ::
 
        mySoloTuple :: (Int) data
-       mySoloTuple  = (5) data
+       mySoloTuple  = (5,) data
+
+5. **Comma Qualified unit-tuples**: Allow to write unit-tuples 
+   (and tuple-like strucures) with ``data`` keyword and just 1 extra comma::
+
+       myUnitTuple :: (,) data
+       myUnitTuple  = (,) data
 
 
 Syntax
@@ -128,25 +136,29 @@ Syntax for tuples, unboxed tuples, constraint tuples:
 .. code:: abnf
     
     atype := gtycon
-        | tyvar                                                  ;-- kmax = if 'data' then 1 else 2
-        | '('  [','] type1 ',' … ',' typek [','] ')'  ['data']   (tuple type, k ≥ kmax)              ;-- upd
-        | '(#' [','] type1 ',' … ',' typek [','] '#)' ['data']   (unboxed tuple type, k ≥ 1)         ;-- upd
+        | tyvar                                                                  ;-- kmax = if 'data' then 1 else 2
+        | '('  ',' type1 ',' … ',' typek [',']  ')'  'data'                      (comma tuple type, k ≥ 1)          ;-- upd
+        | '('      type1 ',' … ',' typek (( ',' ')'  'data' )|( ')' ['data'] ))  (tuple type, k ≥ kmax)             ;-- new
+        | '(#' ',' type1 ',' … ',' typek [',']  '#)' 'data'                      (unboxed comma-tuple type, k ≥ 1)  ;-- upd
+        | '(#'     type1 ',' … ',' typek (( ',' '#)' 'data' )|( '#)' ['data'] )) (unboxed tuple type, k ≥ 1)        ;-- new
         | ……
 
     gtycon := qtycon
-        | '('   ')' ['data']             (unit type)             ;-- upd
-        | '(#' '#)' ['data']             (unlifted unit type)    ;-- upd
-        | '[' ']'                        (list constructor)
-        | '(' '->' ')'                   (function constructor)
-        | '(' ',' {','} ')'              (tupling constructors)
+        | '('   ')'    ['data']                    (unit type)                   ;-- upd
+        | '(' ',' ')'   'data'                     (unit type)                   ;-- new
+        | '(#' '#)'    ['data']                    (unlifted unit type)          ;-- upd
+        | '(#' ',' '#)' 'data'                     (unlifted unit type)          ;-- new
+        | '[' ']'                                  (list constructor)
+        | '(' '->' ')'                             (function constructor)
+        | '(' ',' {','} ')'                        (tupling constructors)
 
 Syntax for class content and class simplified content:
 
 .. code:: abnf
 
     topdecl := 'type' simpletype '=' type
-        | 'data'     [context '=>'] simpletype ['=' constrs] [deriving]
-        | 'newtype'  [context '=>'] simpletype '=' newconstr [deriving]
+        | 'data'     [context '=>']  simpletype  ['=' constrs] [deriving]
+        | 'newtype'  [context '=>']  simpletype  '=' newconstr [deriving]
         | 'class'    [scontext '=>'] tycls tyvar ['where' cdecls]
         | 'instance' [scontext '=>'] qtycls inst ['where' idecls]
         | ……
@@ -270,7 +282,7 @@ for ``BangPatterns``, ``AsPattern``, ``StrictPattern``,  ``Irrefutable Patterns`
     let ~(a,b,) data = expr in e0 a b
 
     -- Data declaration	vs function declaration
-	(a1, b1,) data `op` (a2, b2,) data = expr
+    (a1, b1,) data `op` (a2, b2,) data = expr
 
 Tuple Section
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Comma Tuples**

This is an attempt to allow redundant commas (leading and trailing commas) in alternative syntax of tuple-like structures:

- tuples
- unboxed tuples
- constraint tuples
- class context

[Rendered](https://github.com/VitWW/ghc-proposals/blob/comma-qualified-structures/proposals/0000-comma_qualified_structures.rst)