### PR TITLE
ghc-internals -> ghc-internal

### DIFF
--- a/principles.rst
+++ b/principles.rst
@@ -365,8 +365,8 @@ In this context the term "API" should be taken to include types, semantics, and 
 Consider building one of P's dependencies, say D, with GHC(X+1):
 
 * D may work unchanged with GHC(X+1).
-* D may depend on (say) ``ghc-internals``, and require some small change to accomodate the change to ``ghc-internals``, but one that does not require changing D's API; so D will have a minor version bump.
-* D may depend on (say) ``ghc-internals``, those changes may force a change to D's API; so D will have a major version bump.
+* D may depend on (say) ``ghc-internal``, and require some small change to accomodate the change to ``ghc-internal``, but one that does not require changing D's API; so D will have a minor version bump.
+* D may depend on (say) ``ghc-internal``, those changes may force a change to D's API; so D will have a major version bump.
 
 In all three cases, **provided the bits of D's API that P uses are unchanged**, compiling P with GHC(X+1) should work.
 


### PR DESCRIPTION
I just noticed this probable typo.