### PR TITLE
Built-in HasField Solver Support for Polytype Fields under OverloadedRecordDot

### DIFF
--- a/proposals/0000-overload-record-dot-constraints.rst
+++ b/proposals/0000-overload-record-dot-constraints.rst
@@ -1,5 +1,5 @@
-Native Typechecker Fallback for OverloadedRecordDot on Constrained Fields
-=========================================================================
+Built-in HasField Solver Support for Polytype Fields under OverloadedRecordDot
+==============================================================================
 
 .. author:: Gautier DI FOLCO
 .. date-accepted::
@@ -10,7 +10,7 @@ Native Typechecker Fallback for OverloadedRecordDot on Constrained Fields
 .. sectnum::
 .. contents::
 
-We propose modifying the desugaring of ``OverloadedRecordDot`` so that, when the record type is concretely known and the field has a polymorphic type (involving ``forall`` or typeclass constraints), the typechecker uses the native record selector directly instead of going through ``HasField``. This resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_ without any changes to the constraint solver.
+We propose modifying the built-in ``HasField`` constraint solver so that, when the record type is concretely known and the field has a polymorphic type (involving ``forall`` or typeclass constraints), the solver constructs proper evidence by decomposing the selector type and emitting the field's constraints as separate subgoals. This resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_ without any changes to the renamer or desugaring.
 
 Motivation
 ==========
@@ -89,43 +89,77 @@ The ``HasField`` class is defined as:
 
 The functional dependency ``x r -> a`` says that the result type ``a`` is uniquely determined by the field name and the record type. For a constrained field like ``HasCallStack => String -> Int``, the type checker would need to unify ``a`` with a polytype, but the constraint solver is not designed to do this. It therefore reports ``No instance for HasField``.
 
-This is an inherent limitation of the ``HasField`` design: the functional dependency ties the result type to a single monomorphic type, which cannot accommodate the implicit quantification introduced by constraints or explicit ``forall``\ s.
+More precisely, the built-in ``HasField`` solver (``matchHasField`` in ``GHC.Tc.Instance.Class``) locates the record selector and creates an equality constraint between the selector's type and ``r -> a``. For a constrained field, the selector has a type like ``R -> (HasCallStack => String -> Int)``, which in GHC Core is ``R -> HasCallStack -> String -> Int`` (a three-argument function). But the expected type from the ``HasField`` constraint is ``R -> String -> Int`` (a two-argument function). The equality ``R -> HasCallStack -> String -> Int ~ R -> String -> Int`` fails because the types have different arities.
+
+For ``forall``-quantified fields, the situation is different: the check ``hasNoForallsTy`` detects the ``ForAllTy`` in the selector type and the solver falls back to looking for user-defined instances, of which there are none.
+
+In both cases, the native record selector works correctly, but the solver cannot bridge the gap between the selector's polytype and the monomorphic ``a`` expected by ``HasField``.
 
 Goal
 ----
 
-Dot syntax should work on all fields of a record whose type is concretely known, regardless of whether the field type is monomorphic or polymorphic. When the record type is known, the compiler has all the information needed to resolve the field without going through ``HasField``.
+Dot syntax should work on all fields of a record whose type is concretely known, regardless of whether the field type is monomorphic or polymorphic. The fix should be localized to the built-in ``HasField`` solver, with no changes to the renamer, desugaring, or the ``HasField`` class itself.
 
 Proposed Change Specification
 =============================
 
-Desugaring rules
-----------------
+We modify the built-in ``HasField`` solver (``matchHasField`` in ``GHC.Tc.Instance.Class``). The renamer continues to desugar ``e.fld`` to ``getField @"fld" e`` as before. The change is entirely in how the solver constructs evidence when it finds a polytype field selector.
 
-We modify the desugaring of field selection expressions ``e.fld`` when ``OverloadedRecordDot`` is enabled. The new behaviour is:
+Phase 1: Constraint-only fields
+-------------------------------
 
-1. **Native fallback.** If, at the point where ``e.fld`` is desugared, the type of ``e`` is a **concretely known record type** ``T p1 ... pn`` (i.e., ``T`` is a data type constructor, not a type variable or type family), and ``fld`` is a field of ``T`` whose type is a **polytype** (its top-level structure contains a ``forall`` or a constraint arrow ``=>``), then ``e.fld`` desugars to the native record selector: ``fld e``.
+When the solver locates a record selector whose result type has constraint arrows (``=>``) not present in the expected type ``r -> a``, instead of emitting a single equality between the full selector type and ``r -> a`` (which fails due to arity mismatch):
 
-2. **Standard path.** In all other cases (the field type is a monotype, or the type of ``e`` is not concretely known), ``e.fld`` desugars to ``getField @"fld" e`` as before.
+1. **Decompose** the instantiated selector type into the record-accepting prefix (``r ->``), the constraint arguments, and the body type.
+
+2. **Emit** each constraint argument as a separate wanted constraint.
+
+3. **Emit** an equality between the body type and ``a``.
+
+4. **Build evidence** by eta-expansion: ``\r -> sel r ?dict1 ... ?dictN``, where each ``?dictN`` is the evidence for the corresponding constraint wanted.
+
+For example, given ``HasField "myFunc" R (String -> Int)`` where the selector is ``myFunc :: R -> (HasCallStack => String -> Int)``:
+
+- Decompose: record arg ``R``, constraint ``HasCallStack``, body ``String -> Int``
+- Emit wanted: ``HasCallStack``
+- Emit equality: ``String -> Int ~ String -> Int`` (trivially solved)
+- Evidence: ``\r -> myFunc r ?hasCallStack`` of type ``R -> String -> Int``
+
+Phase 2: ``forall``-quantified fields (stretch goal)
+----------------------------------------------------
+
+When the selector's result type contains a ``forall``, the solver additionally:
+
+1. **Instantiates** the ``forall``-bound type variables with the types determined by the expected result type ``a`` (e.g., if ``a = Int -> String`` and the field is ``forall x. Show x => x -> String``, instantiate ``x := Int``).
+
+2. **Emits** the resulting constraints as wanteds (e.g., ``Show Int``).
+
+3. **Builds evidence** by type application of the selector to the instantiated types, with dictionary arguments filled by the constraint evidence.
+
+Standard path (unchanged)
+-------------------------
+
+When the field type is a monotype, the solver behaves exactly as it does today: it emits a single equality ``sel_ty ~ (r -> a)`` and builds evidence by casting the selector. No change.
 
 We define:
 
-- A **concretely known record type** is a type whose outermost constructor is a data type or newtype constructor applied to its arguments (not a type variable, type family application, or ``forall``-quantified type).
+- A **concretely known record type** is a type whose outermost constructor is a data type or newtype constructor applied to its arguments (not a type variable, type family application, or ``forall``-quantified type). This is already checked by ``lookupHasFieldLabel`` via ``tcSplitTyConApp_maybe``.
 - A **polytype** is a type whose top-level structure is ``forall a. tau`` or ``Ctx => tau``, as opposed to a monomorphic ``tau``.
-- A field selector ``fld`` is considered available if the record type has a field with that name in scope (i.e., it would be a valid native record selector application).
+- A field selector ``fld`` is considered available if the record type has a field with that name in scope (i.e., it would be a valid native record selector application). This is already checked by ``lookupHasFieldLabel``.
 
 What changes, what stays the same
 ---------------------------------
 
-- **No changes** to the ``HasField`` class, its instances, or the constraint solver.
-- **No changes** to the behaviour of ``OverloadedRecordDot`` when the field is monomorphic: ``e.fld`` still goes through ``HasField``.
-- **No changes** when the record type is not concretely known (e.g., ``e`` is polymorphic): ``e.fld`` still goes through ``HasField``.
-- **The only change** is that when the record type is known and the field is polymorphic, the compiler uses the native selector instead of ``HasField``.
+- **No changes** to the renamer or desugaring: ``e.fld`` still desugars to ``getField @"fld" e`` in all cases.
+- **No changes** to the ``HasField`` class, its instances, or its functional dependency.
+- **No changes** to the behaviour of ``OverloadedRecordDot`` when the field is monomorphic: the solver uses the same equality-based evidence as before.
+- **No changes** when the record type is not concretely known (e.g., ``e`` is polymorphic): the solver cannot locate a selector and falls back to user instances as before.
+- **The only change** is in the built-in solver's evidence construction: when the record type is concretely known and the field is a polytype, the solver decomposes the selector type and builds eta-expanded evidence with separate constraint subgoals, instead of emitting a doomed equality or falling back.
 
 Proposed Library Change Specification
 -------------------------------------
 
-No changes to library interfaces, ``base``, or ``ghc-experimental`` are required. This is purely a desugaring change within the compiler's typechecker.
+No changes to library interfaces, ``base``, or ``ghc-experimental`` are required. This is purely a change within the compiler's built-in ``HasField`` solver.
 
 Examples
 ========
@@ -144,7 +178,7 @@ HasCallStack-constrained field
 
 **Before:** Compile error: ``No instance for (HasField "myFunc" R (String -> Int))``.
 
-**After:** The typechecker sees that ``r :: R`` is concretely known, and ``myFunc`` has type ``HasCallStack => String -> Int``, which is a polytype. It desugars ``r.myFunc`` to ``myFunc r``, which compiles successfully. The ``HasCallStack`` constraint is propagated to the call site as usual.
+**After:** The solver finds selector ``myFunc :: R -> (HasCallStack => String -> Int)``. It decomposes the type: record arg ``R``, constraint ``HasCallStack``, body ``String -> Int``. It emits ``HasCallStack`` as a wanted, checks ``String -> Int ~ String -> Int`` (trivial), and builds evidence ``\r -> myFunc r ?hasCallStack``. The ``HasCallStack`` constraint is propagated to the call site as usual.
 
 forall-constrained field
 ------------------------
@@ -160,7 +194,7 @@ forall-constrained field
 
 **Before:** Compile error: ``No instance for (HasField "showable" S (Int -> String))``.
 
-**After:** The typechecker sees that ``s :: S`` is concretely known, and ``showable`` has a polytype. It desugars ``s.showable`` to ``showable s``, and the ``Show Int`` dictionary is passed at the call site.
+**After (Phase 2):** The solver finds selector ``showable :: S -> (forall a. Show a => a -> String)``. It instantiates ``a := Int`` from the expected result type ``Int -> String``, emits ``Show Int`` as a wanted, and builds evidence with the instantiated selector. The ``Show Int`` dictionary is resolved at the call site.
 
 Eq-constrained field with a type parameter
 ------------------------------------------
@@ -176,7 +210,7 @@ Eq-constrained field with a type parameter
 
 **Before:** Compile error.
 
-**After:** ``t :: T a`` is concretely known (the outermost constructor is ``T``), and ``eqField`` is a polytype. Desugars to ``eqField t x``. The ``Eq a`` constraint is propagated from the record selector to the call site.
+**After:** ``t :: T a`` is concretely known (the outermost constructor is ``T``), and ``eqField`` has a constrained type. The solver finds selector ``eqField :: T a -> (Eq a => a -> Bool)``, decomposes it, emits ``Eq a`` as a wanted, and builds eta-expanded evidence. The ``Eq a`` constraint is propagated from the record selector to the call site.
 
 Monomorphic field: unchanged behaviour
 --------------------------------------
@@ -190,7 +224,7 @@ Monomorphic field: unchanged behaviour
    useU :: U -> String
    useU u = u.name
 
-**Before and after:** ``name`` is a monotype, so this goes through ``HasField`` as before. No change in behaviour.
+**Before and after:** ``name`` is a monotype, so the solver uses the same equality-based evidence as today. No change in behaviour.
 
 Polymorphic record variable: unchanged behaviour
 ------------------------------------------------
@@ -202,21 +236,23 @@ Polymorphic record variable: unchanged behaviour
    genericAccess :: (HasField "name" r String) => r -> String
    genericAccess r = r.name
 
-**Before and after:** The type of ``r`` is not concretely known (it is a type variable), so this goes through ``HasField`` as before. No change in behaviour.
+**Before and after:** The type of ``r`` is not concretely known (it is a type variable), so the solver cannot locate a selector and falls back to the user-provided ``HasField`` constraint. No change in behaviour.
 
 Effect and Interactions
 =======================
 
-This change resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. It interacts seamlessly with existing ``OverloadedRecordDot`` usages because the native fallback only triggers in cases where the compiler currently throws an error. When the field is monomorphic or the record type is not concretely known, behaviour is identical to the status quo.
+This change resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. It interacts seamlessly with existing ``OverloadedRecordDot`` usages because the solver change only affects cases where the compiler currently throws an error. When the field is monomorphic or the record type is not concretely known, behaviour is identical to the status quo. All field access continues to go through ``HasField`` uniformly -- the change is in how evidence is constructed, not in whether ``HasField`` is used.
 
 It aligns with the user's mental model that dot syntax should be a transparent shorthand for record selection.
 
 Costs and Drawbacks
 ===================
 
-The development cost involves modifying the typechecker to inspect the record type and field type before emitting a ``HasField`` constraint. There are no significant maintenance costs.
+The development cost involves modifying the built-in ``HasField`` solver in ``GHC.Tc.Instance.Class`` to decompose the selector type, emit constraint subgoals, and build eta-expanded evidence. There are no significant maintenance costs.
 
-A minor drawback is a slight internal divergence in how ``OverloadedRecordDot`` operates (native selector vs. ``HasField`` resolution depending on the field type), but this divergence is entirely invisible to the user and improves the learnability of the language by removing an edge-case error.
+A minor drawback is that the evidence construction in ``matchHasField`` becomes more complex, as it must now handle the decomposition of polytype selector types rather than relying on a single equality constraint.
+
+Phase 2 (``forall``-quantified fields) introduces additional complexity: the solver must instantiate ``forall``-bound variables with types determined from the expected result, which touches on impredicative territory. This is why Phase 2 is designated as a stretch goal.
 
 Backward Compatibility
 ======================
@@ -230,7 +266,14 @@ It strictly expands the set of valid programs. Programs that previously failed t
 - Only the previously-errored case (concretely-known record type + polytype field) changes.
 
 Alternatives
-============
+=============
+
+Renamer-Level Native Selector Fallback
+---------------------------------------
+
+An earlier version of this proposal suggested modifying the desugaring of ``e.fld`` so that, when the record type is concretely known and the field is a polytype, ``e.fld`` desugars to the native record selector ``fld e`` instead of ``getField @"fld" e``.
+
+This approach has a fundamental problem: the desugaring of ``OverloadedRecordDot`` happens in the **renamer** (``GHC.Rename.Expr``), where no type information is available. Determining whether the type of ``e`` is "concretely known" and whether the field is a "polytype" requires type information that only exists in the typechecker. Ad-hoc type guessing in the renamer was previously attempted for ``DuplicateRecordFields`` and proved fragile (see `proposal 0366 <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0366-no-ambiguous-field-access.rst>`_).
 
 Associated Type Family Redesign
 -------------------------------
@@ -248,9 +291,17 @@ Integrate the built-in ``HasField`` solver directly with Quick Look impredicativ
 Unresolved Questions
 ====================
 
-None yet.
+- For Phase 2 (``forall``-quantified fields), what is the precise strategy for instantiating ``forall``-bound variables from the expected result type? Should this use Quick Look impredicativity, or a simpler targeted instantiation within ``matchHasField`` only?
 
 Implementation Plan
 ===================
+
+The change is localized to ``matchHasField`` in ``compiler/GHC/Tc/Instance/Class.hs``. The existing ``lookupHasFieldLabel`` function already performs the "concretely known record type" check and returns the selector name, so the modification is in the evidence construction after the lookup succeeds:
+
+1. After ``tcInstType`` produces the instantiated selector type ``sel_ty``, check whether ``sel_ty`` has invisible (constraint) arguments beyond what ``r -> a`` expects.
+2. If so, decompose ``sel_ty`` into its constraint prefix and body, emit the constraints as wanteds, and build eta-expanded evidence.
+3. If not (monomorphic field), proceed with the existing equality-based evidence.
+
+Phase 2 would add ``forall``-instantiation logic in the same function.
 
 If accepted, I can rework `#14391 <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14391>`_.

--- a/proposals/0000-overload-record-dot-constraints.rst
+++ b/proposals/0000-overload-record-dot-constraints.rst
@@ -10,71 +10,224 @@ Native Typechecker Fallback for OverloadedRecordDot on Constrained Fields
 .. sectnum::
 .. contents::
 
-We propose modifying the typechecker to selectively fall back to native record selectors when using ``OverloadedRecordDot`` on fields with higher-rank types or typeclass constraints. This allows developers to use record dot syntax on all fields without requiring changes to the constraint solver.
+We propose modifying the desugaring of ``OverloadedRecordDot`` so that, when the record type is concretely known and the field has a polymorphic type (involving ``forall`` or typeclass constraints), the typechecker uses the native record selector directly instead of going through ``HasField``. This resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_ without any changes to the constraint solver.
 
 Motivation
 ==========
 
-Currently, ``OverloadedRecordDot`` is broken when records have a constraint, which is tracked as GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. Whenever a user tries to reference a function with a constraint using ``OverloadedRecordDot`` syntax, they encounter a compiler error.
+The problem
+-----------
 
-The root of this issue lies in the design of the ``HasField`` class, which is defined with a functional dependency ``x r -> a``. When dot-syntax is used, it desugars into a ``HasField`` constraint. However, bidirectional type inference requires that instantiations of ``forall``-bound variables be determined while traversing the term, prior to the constraint solver being invoked. Consequently, ``HasField`` constraints involving fields with higher-rank types or typeclass constraints cannot be solved automatically.
+With ``OverloadedRecordDot``, ``r.field`` desugars to ``getField @"field" r``, which invokes the ``HasField`` typeclass. This works well for monomorphic fields:
 
-Because of this limitation, users are forced to abandon dot-syntax and revert to traditional record accessors when working with constrained fields.
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   data R = R { myFunc :: String -> Int }
+
+   myUsage :: R -> Int
+   myUsage r = r.myFunc "42"      -- OK: desugars to getField @"myFunc" r "42"
+
+But adding a constraint to the field causes a compile error:
+
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   data R = R { myFunc :: HasCallStack => String -> Int }
+
+   myUsage :: R -> Int
+   myUsage r = r.myFunc "42"
+
+This produces:
+
+::
+
+   error:
+       • No instance for (GHC.Records.HasField "myFunc" R (String -> Int))
+           arising from selecting the field 'myFunc'
+       • In the expression: r.myFunc
+         In the expression: r.myFunc "42"
+         In an equation for 'myUsage': myUsage r = r.myFunc "42"
+
+The same failure occurs with any constrained field type:
+
+.. code:: haskell
+
+   data S = S { showable :: forall a. Show a => a -> String }
+
+   useS :: S -> String
+   useS s = s.showable 42       -- ERROR: HasField cannot be solved
+
+.. code:: haskell
+
+   data T a = T { eqField :: Eq a => a -> Bool }
+
+   useT :: T a -> a -> Bool
+   useT t x = t.eqField x       -- ERROR: HasField cannot be solved
+
+In every case, the **native** record selector works perfectly:
+
+.. code:: haskell
+
+   myUsage r = myFunc r "42"     -- OK
+   useS s     = showable s       -- OK
+   useT t x   = eqField t x      -- OK
+
+Yet the user is forced to abandon dot syntax and write these by hand.
+
+Why does ``HasField`` fail?
+---------------------------
+
+The ``HasField`` class is defined as:
+
+.. code:: haskell
+
+   class HasField (x :: Symbol) r a | x r -> a where
+     getField :: r -> a
+
+The functional dependency ``x r -> a`` says that the result type ``a`` is uniquely determined by the field name and the record type. For a constrained field like ``HasCallStack => String -> Int``, the type checker would need to unify ``a`` with a polytype, but the constraint solver is not designed to do this. It therefore reports ``No instance for HasField``.
+
+This is an inherent limitation of the ``HasField`` design: the functional dependency ties the result type to a single monomorphic type, which cannot accommodate the implicit quantification introduced by constraints or explicit ``forall``\ s.
+
+Goal
+----
+
+Dot syntax should work on all fields of a record whose type is concretely known, regardless of whether the field type is monomorphic or polymorphic. When the record type is known, the compiler has all the information needed to resolve the field without going through ``HasField``.
 
 Proposed Change Specification
 =============================
 
-We propose a modification to the desugaring behavior of ``OverloadedRecordDot`` within the typechecker. Instead of uniformly emitting a ``HasField`` constraint for every dot-syntax access, the typechecker will first inspect the inferred type of the record.
+Desugaring rules
+----------------
 
-The behavior is specified as follows:
+We modify the desugaring of field selection expressions ``e.fld`` when ``OverloadedRecordDot`` is enabled. The new behaviour is:
 
-1. If the concrete type of the record is known during typechecking, and the accessed field is a polytype (e.g., it contains a typeclass constraint or a higher-rank ``forall``), the typechecker will directly desugar the expression to a native record selector application.
-2. If the field is a monotype, or the record type is opaque/virtual, the typechecker will emit the standard ``HasField`` constraint.
+1. **Native fallback.** If, at the point where ``e.fld`` is desugared, the type of ``e`` is a **concretely known record type** ``T p1 ... pn`` (i.e., ``T`` is a data type constructor, not a type variable or type family), and ``fld`` is a field of ``T`` whose type is a **polytype** (its top-level structure contains a ``forall`` or a constraint arrow ``=>``), then ``e.fld`` desugars to the native record selector: ``fld e``.
 
-This completely bypasses the functional dependency limitation by preventing the constraint solver from ever seeing the polytype. It requires no changes to the constraint solver itself or the ``GHC.Records`` module.
+2. **Standard path.** In all other cases (the field type is a monotype, or the type of ``e`` is not concretely known), ``e.fld`` desugars to ``getField @"fld" e`` as before.
+
+We define:
+
+- A **concretely known record type** is a type whose outermost constructor is a data type or newtype constructor applied to its arguments (not a type variable, type family application, or ``forall``-quantified type).
+- A **polytype** is a type whose top-level structure is ``forall a. tau`` or ``Ctx => tau``, as opposed to a monomorphic ``tau``.
+- A field selector ``fld`` is considered available if the record type has a field with that name in scope (i.e., it would be a valid native record selector application).
+
+What changes, what stays the same
+---------------------------------
+
+- **No changes** to the ``HasField`` class, its instances, or the constraint solver.
+- **No changes** to the behaviour of ``OverloadedRecordDot`` when the field is monomorphic: ``e.fld`` still goes through ``HasField``.
+- **No changes** when the record type is not concretely known (e.g., ``e`` is polymorphic): ``e.fld`` still goes through ``HasField``.
+- **The only change** is that when the record type is known and the field is polymorphic, the compiler uses the native selector instead of ``HasField``.
 
 Proposed Library Change Specification
-=====================================
+-------------------------------------
 
-No changes to library interfaces, ``base``, or ``ghc-experimental`` are required. This is purely a syntactic desugaring change within the compiler's typechecker.
+No changes to library interfaces, ``base``, or ``ghc-experimental`` are required. This is purely a desugaring change within the compiler's typechecker.
 
 Examples
 ========
 
-Given the following data type containing a constrained field:
+HasCallStack-constrained field
+------------------------------
 
-::
+.. code:: haskell
 
-  data MyRecord a = MyRecord
-    { myField :: Eq a => a -> Int
-    }
+   {-# LANGUAGE OverloadedRecordDot #-}
 
-Under the status quo, the following expression fails to compile because the constraint solver refuses to unify the polytype with the ``HasField`` functional dependency:
+   data R = R { myFunc :: HasCallStack => String -> Int }
 
-::
+   myUsage :: R -> Int
+   myUsage r = r.myFunc "42"
 
-  useRecord :: MyRecord a -> a -> Int
-  useRecord rec val = rec.myField val
+**Before:** Compile error: ``No instance for (HasField "myFunc" R (String -> Int))``.
 
-Under this proposal, the typechecker observes that ``rec`` has a known type ``MyRecord a`` and that ``myField`` is a polytype. It then desugars ``rec.myField`` directly to the native selector ``myField rec``, allowing the code to compile successfully.
+**After:** The typechecker sees that ``r :: R`` is concretely known, and ``myFunc`` has type ``HasCallStack => String -> Int``, which is a polytype. It desugars ``r.myFunc`` to ``myFunc r``, which compiles successfully. The ``HasCallStack`` constraint is propagated to the call site as usual.
+
+forall-constrained field
+------------------------
+
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   data S = S { showable :: forall a. Show a => a -> String }
+
+   useS :: S -> String
+   useS s = s.showable 42
+
+**Before:** Compile error: ``No instance for (HasField "showable" S (Int -> String))``.
+
+**After:** The typechecker sees that ``s :: S`` is concretely known, and ``showable`` has a polytype. It desugars ``s.showable`` to ``showable s``, and the ``Show Int`` dictionary is passed at the call site.
+
+Eq-constrained field with a type parameter
+------------------------------------------
+
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   data T a = T { eqField :: Eq a => a -> Bool }
+
+   useT :: T a -> a -> Bool
+   useT t x = t.eqField x
+
+**Before:** Compile error.
+
+**After:** ``t :: T a`` is concretely known (the outermost constructor is ``T``), and ``eqField`` is a polytype. Desugars to ``eqField t x``. The ``Eq a`` constraint is propagated from the record selector to the call site.
+
+Monomorphic field: unchanged behaviour
+--------------------------------------
+
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   data U = U { name :: String }
+
+   useU :: U -> String
+   useU u = u.name
+
+**Before and after:** ``name`` is a monotype, so this goes through ``HasField`` as before. No change in behaviour.
+
+Polymorphic record variable: unchanged behaviour
+------------------------------------------------
+
+.. code:: haskell
+
+   {-# LANGUAGE OverloadedRecordDot #-}
+
+   genericAccess :: (HasField "name" r String) => r -> String
+   genericAccess r = r.name
+
+**Before and after:** The type of ``r`` is not concretely known (it is a type variable), so this goes through ``HasField`` as before. No change in behaviour.
 
 Effect and Interactions
 =======================
 
-This change resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. It interacts seamlessly with existing ``OverloadedRecordDot`` usages because it only intervenes in cases where the compiler currently throws an error. It aligns with the user's mental model that dot-syntax should be an exact syntactic equivalent to native record selection.
+This change resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. It interacts seamlessly with existing ``OverloadedRecordDot`` usages because the native fallback only triggers in cases where the compiler currently throws an error. When the field is monomorphic or the record type is not concretely known, behaviour is identical to the status quo.
+
+It aligns with the user's mental model that dot syntax should be a transparent shorthand for record selection.
 
 Costs and Drawbacks
 ===================
 
-The development cost involves modifying the typechecker to peek at the record type before emitting a ``HasField`` constraint. There are no significant maintenance costs.
-A minor drawback is a slight divergence in how ``OverloadedRecordDot`` operates internally (native application vs. typeclass resolution), but this divergence is entirely invisible to the user and drastically improves the learnability of the language by removing an edge-case error.
+The development cost involves modifying the typechecker to inspect the record type and field type before emitting a ``HasField`` constraint. There are no significant maintenance costs.
+
+A minor drawback is a slight internal divergence in how ``OverloadedRecordDot`` operates (native selector vs. ``HasField`` resolution depending on the field type), but this divergence is entirely invisible to the user and improves the learnability of the language by removing an edge-case error.
 
 Backward Compatibility
 ======================
 
 This proposal evaluates to **0. No breakage** on the impact scale.
 
-It strictly expands the set of valid programs. Programs that previously failed to compile due to the higher-rank field limitation will now compile. No existing valid code will change behavior or stop working.
+It strictly expands the set of valid programs. Programs that previously failed to compile due to the constrained-field limitation will now compile. No existing valid code will change behaviour or stop working. In particular:
+
+- Monomorphic field access continues to use ``HasField``.
+- Polymorphic record variables continue to use ``HasField``.
+- Only the previously-errored case (concretely-known record type + polytype field) changes.
 
 Alternatives
 ============

--- a/proposals/0000-overload-record-dot-constraints.rst
+++ b/proposals/0000-overload-record-dot-constraints.rst
@@ -1,0 +1,103 @@
+Native Typechecker Fallback for OverloadedRecordDot on Constrained Fields
+=========================================================================
+
+.. author:: Gautier DI FOLCO
+.. date-accepted::
+.. ticket-url::
+.. implemented::
+.. highlight:: haskell
+.. header:: This proposal is `discussed at this pull request <https://github.com/ghc-proposals/ghc-proposals/pull/761>`_.
+.. sectnum::
+.. contents::
+
+We propose modifying the typechecker to selectively fall back to native record selectors when using ``OverloadedRecordDot`` on fields with higher-rank types or typeclass constraints. This allows developers to use record dot syntax on all fields without requiring changes to the constraint solver.
+
+Motivation
+==========
+
+Currently, ``OverloadedRecordDot`` is broken when records have a constraint, which is tracked as GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. Whenever a user tries to reference a function with a constraint using ``OverloadedRecordDot`` syntax, they encounter a compiler error.
+
+The root of this issue lies in the design of the ``HasField`` class, which is defined with a functional dependency ``x r -> a``. When dot-syntax is used, it desugars into a ``HasField`` constraint. However, bidirectional type inference requires that instantiations of ``forall``-bound variables be determined while traversing the term, prior to the constraint solver being invoked. Consequently, ``HasField`` constraints involving fields with higher-rank types or typeclass constraints cannot be solved automatically.
+
+Because of this limitation, users are forced to abandon dot-syntax and revert to traditional record accessors when working with constrained fields.
+
+Proposed Change Specification
+=============================
+
+We propose a modification to the desugaring behavior of ``OverloadedRecordDot`` within the typechecker. Instead of uniformly emitting a ``HasField`` constraint for every dot-syntax access, the typechecker will first inspect the inferred type of the record.
+
+The behavior is specified as follows:
+
+1. If the concrete type of the record is known during typechecking, and the accessed field is a polytype (e.g., it contains a typeclass constraint or a higher-rank ``forall``), the typechecker will directly desugar the expression to a native record selector application.
+2. If the field is a monotype, or the record type is opaque/virtual, the typechecker will emit the standard ``HasField`` constraint.
+
+This completely bypasses the functional dependency limitation by preventing the constraint solver from ever seeing the polytype. It requires no changes to the constraint solver itself or the ``GHC.Records`` module.
+
+Proposed Library Change Specification
+=====================================
+
+No changes to library interfaces, ``base``, or ``ghc-experimental`` are required. This is purely a syntactic desugaring change within the compiler's typechecker.
+
+Examples
+========
+
+Given the following data type containing a constrained field:
+
+::
+
+  data MyRecord a = MyRecord
+    { myField :: Eq a => a -> Int
+    }
+
+Under the status quo, the following expression fails to compile because the constraint solver refuses to unify the polytype with the ``HasField`` functional dependency:
+
+::
+
+  useRecord :: MyRecord a -> a -> Int
+  useRecord rec val = rec.myField val
+
+Under this proposal, the typechecker observes that ``rec`` has a known type ``MyRecord a`` and that ``myField`` is a polytype. It then desugars ``rec.myField`` directly to the native selector ``myField rec``, allowing the code to compile successfully.
+
+Effect and Interactions
+=======================
+
+This change resolves GHC Issue `#22267 <https://gitlab.haskell.org/ghc/ghc/-/issues/22267>`_. It interacts seamlessly with existing ``OverloadedRecordDot`` usages because it only intervenes in cases where the compiler currently throws an error. It aligns with the user's mental model that dot-syntax should be an exact syntactic equivalent to native record selection.
+
+Costs and Drawbacks
+===================
+
+The development cost involves modifying the typechecker to peek at the record type before emitting a ``HasField`` constraint. There are no significant maintenance costs.
+A minor drawback is a slight divergence in how ``OverloadedRecordDot`` operates internally (native application vs. typeclass resolution), but this divergence is entirely invisible to the user and drastically improves the learnability of the language by removing an edge-case error.
+
+Backward Compatibility
+======================
+
+This proposal evaluates to **0. No breakage** on the impact scale.
+
+It strictly expands the set of valid programs. Programs that previously failed to compile due to the higher-rank field limitation will now compile. No existing valid code will change behavior or stop working.
+
+Alternatives
+============
+
+Associated Type Family Redesign
+-------------------------------
+
+Instead of using a functional dependency, it is also possible to express the relationship between the record type and the field type using a type family, such as ``type FieldType x r :: Type``.
+
+* This type family approach ends up with unsolved constraints and equalities, which can complicate type inference.
+* Supporting representation polymorphism with the type family approach would introduce extra complexity, because we would need another type family to determine the ``RuntimeRep`` of the field.
+
+Impredicativity-Aware Constraint Solving
+----------------------------------------
+
+Integrate the built-in ``HasField`` solver directly with Quick Look impredicativity. This would permit the unifier to bind a type variable to a polytype strictly when the equality arises from the ``HasField`` functional dependency. This is mathematically complex and risks disrupting the stability of the constraint solver.
+
+Unresolved Questions
+====================
+
+None yet.
+
+Implementation Plan
+===================
+
+If accepted, I can rework `#14391 <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14391>`_.


### PR DESCRIPTION
The proposal tries to extend `OverloadedRecordDot` [#22267](https://gitlab.haskell.org/ghc/ghc/-/issues/22267)

[Rendered](https://github.com/blackheaven/ghc-proposals/blob/overloaded-record-dot/proposals/0000-overload-record-dot-constraints.rst)